### PR TITLE
chore(dependabot): prefer larger area-grouped Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,12 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
     assignees:
@@ -16,7 +21,12 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/SourceGenerators/WallstopStudios.DxMessaging.SourceGenerators"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      sourcegenerators-all:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
     assignees:
@@ -38,7 +48,12 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/SourceGenerators/WallstopStudios.DxMessaging.SourceGenerators.Tests"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      sourcegenerators-tests-all:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
     assignees:
@@ -56,7 +71,12 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      npm-all:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
     versioning-strategy: increase


### PR DESCRIPTION
### Motivation
- Reduce Dependabot noise by batching multiple version updates into broader, area-scoped PRs instead of opening many single-dependency PRs. 
- Align behavior with the requested grouped strategy while preserving existing compatibility constraints and ownership metadata.

### Description
- Changed update cadence from `daily` to `weekly` for all configured ecosystems in `.github/dependabot.yml`. 
- Added `open-pull-requests-limit: 2` to each update block to limit concurrent PRs while allowing larger batches. 
- Added `groups` entries (wildcard `patterns: ["*"]`) for each ecosystem/directory so Dependabot will group many updates into area-scoped PRs. 
- Preserved existing `labels`, `assignees`, `reviewers`, `versioning-strategy`, and the `ignore` rules for Roslyn packages, and committed the updated `.github/dependabot.yml` file.

### Testing
- Attempted to inspect the reference repo with `git clone https://github.com/Ambiguous-Interactive/signal-fish-cloud` to validate parity, but the network request failed with a 403 and therefore this check failed. 
- Ran a Python-based YAML rewrite path which attempted to use `PyYAML`, but the environment lacked the `yaml` module and that check failed. 
- Successfully validated the resulting YAML with `ruby -e 'require "yaml"; ...'`, asserting each `schedule.interval` is `weekly` and that `groups` are present, which passed. 
- Verified the file changes with `git diff` and created a commit via `git commit -m "chore(dependabot): group updates into larger weekly PRs"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca780410548331a78b8b3aeb0cbec8)