### PR TITLE
chore: Bump CSharpier

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "CSharpier": {
-      "version": "1.2.6",
+      "version": "1.3.0",
       "commands": ["csharpier"]
     }
   }

--- a/SourceGenerators/Directory.Build.props
+++ b/SourceGenerators/Directory.Build.props
@@ -35,8 +35,7 @@
   <PropertyGroup>
     <SolutionDir Condition="'$(SolutionDir)' == ''">$(MSBuildThisFileDirectory)..\</SolutionDir>
     <ArtifactsRoot Condition="'$(ArtifactsRoot)' == ''"
-      >$(SolutionDir).artifacts/$(MSBuildProjectName)/</ArtifactsRoot
-    >
+      >$(SolutionDir).artifacts/$(MSBuildProjectName)/</ArtifactsRoot>
     <!-- Set BaseIntermediateOutputPath early so NuGet restore's obj/ (and
          project.assets.json) is written under .artifacts/, never in-tree. The
          trailing slash is required by the SDK's path-joining logic. -->
@@ -52,7 +51,6 @@
     <DebugSymbols>false</DebugSymbols>
     <CopyAnalyzerPayload Condition="'$(CopyAnalyzerPayload)' == ''">true</CopyAnalyzerPayload>
     <AnalyzerPayloadOutputDir Condition="'$(AnalyzerPayloadOutputDir)' == ''"
-      >$([System.IO.Path]::Combine('$(SolutionDir)', 'Editor', 'Analyzers'))</AnalyzerPayloadOutputDir
-    >
+      >$([System.IO.Path]::Combine('$(SolutionDir)', 'Editor', 'Analyzers'))</AnalyzerPayloadOutputDir>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Description

This PR is a tooling/formatting maintenance update.

User-facing highlights:
- Updates the CSharpier local tool version from 1.2.6 to 1.3.0.
- Applies corresponding formatting-only cleanup in SourceGenerators build props.
- No runtime behavior changes or public API changes are expected.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactor (code change that neither fixes a bug nor adds a feature)

## Checklist

- [ ] All tests pass locally
- [x] Code is properly formatted
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have updated the [CHANGELOG](CHANGELOG.md)
- [x] My changes do not introduce breaking changes, or breaking changes are documented

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and whitespace-only MSBuild formatting; no runtime, API, or build-path behavior changes.
> 
> **Overview**
> Bumps the repo-local **CSharpier** dotnet tool from `1.2.6` to `1.3.0` in `.config/dotnet-tools.json`, aligning CI and local `dotnet tool restore` with the newer formatter.
> 
> The only other diff is **formatting-only** in `SourceGenerators/Directory.Build.props`: MSBuild property closing tags are collapsed onto the same line as their values (no property or path changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b00f8ba88026f96b7059408ad8dae33d9170245c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->