### PR TITLE
bugfix: Harden CI

### DIFF
--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -717,7 +717,7 @@ jobs:
           auth_header="$(printf 'x-access-token:%s' "${GH_FETCH_TOKEN}" | base64 | tr -d '\n')"
           git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
             fetch --no-tags --depth=1 origin \
-            "refs/heads/master:refs/remotes/origin/master" || true
+            "+refs/heads/master:refs/remotes/origin/master" || true
           if git show origin/master:docs/architecture/perf-baseline.csv > "${baseline_out}" 2>/dev/null; then
             echo "Fetched master perf baseline to ${baseline_out}."
           else
@@ -936,7 +936,7 @@ jobs:
           auth_header="$(printf 'x-access-token:%s' "${GH_FETCH_TOKEN}" | base64 | tr -d '\n')"
           git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
             fetch --no-tags --depth=1 origin \
-            "refs/heads/${GITHUB_REF_NAME}:refs/remotes/origin/${GITHUB_REF_NAME}"
+            "+refs/heads/${GITHUB_REF_NAME}:refs/remotes/origin/${GITHUB_REF_NAME}"
           latest_sha="$(git rev-parse "refs/remotes/origin/${GITHUB_REF_NAME}")"
           if [ "${latest_sha}" != "${GITHUB_SHA}" ]; then
             message="Default branch ${GITHUB_REF_NAME} advanced from ${GITHUB_SHA} to ${latest_sha}; "
@@ -1041,7 +1041,7 @@ jobs:
           auth_header="$(printf 'x-access-token:%s' "${GH_PUSH_TOKEN}" | base64 | tr -d '\n')"
           git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
             fetch --no-tags --depth=1 origin \
-            "refs/heads/${GITHUB_REF_NAME}:refs/remotes/origin/${GITHUB_REF_NAME}"
+            "+refs/heads/${GITHUB_REF_NAME}:refs/remotes/origin/${GITHUB_REF_NAME}"
           latest_sha="$(git rev-parse "refs/remotes/origin/${GITHUB_REF_NAME}")"
           if [ "${latest_sha}" != "${GITHUB_SHA}" ]; then
             message="Default branch ${GITHUB_REF_NAME} advanced from ${GITHUB_SHA} to ${latest_sha}; "
@@ -1095,7 +1095,7 @@ jobs:
 
           git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
             fetch --no-tags --depth=1 origin \
-            "refs/heads/${GITHUB_REF_NAME}:refs/remotes/origin/${GITHUB_REF_NAME}"
+            "+refs/heads/${GITHUB_REF_NAME}:refs/remotes/origin/${GITHUB_REF_NAME}"
           latest_after_push="$(git rev-parse "refs/remotes/origin/${GITHUB_REF_NAME}")"
           if [ "${latest_after_push}" != "${GITHUB_SHA}" ]; then
             message="Default branch ${GITHUB_REF_NAME} advanced from ${GITHUB_SHA} "

--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -15,11 +15,10 @@ on:
       - main
       - master
     paths:
-      - .github/workflows/script-tests.yml
-      - .github/workflows/release.yml
+      - .github/workflows/*.yml
+      - .github/workflows/*.yaml
       - .github/actions/**/action.yml
       - .github/unity-versions.json
-      - .github/workflows/unity-*.yml
       - package.json
       - .npmignore
       - CHANGELOG.md
@@ -88,9 +87,9 @@ jobs:
           # The trailing **/*.js|cjs|mjs / **/*.asmdef / **/*.cs.meta alternatives
           # exist because validate:all gates the JS LoC budget, asmdef-references,
           # and npm-meta over every tracked file of those types, regardless of dir.
-          pattern='(^\.github/workflows/script-tests\.yml$|^\.github/workflows/release\.yml$'
+          pattern='(^\.github/workflows/[^/]*\.ya?ml$'
           pattern="$pattern"'|^\.github/actions/.*/action\.yml$|^\.github/unity-versions\.json$'
-          pattern="$pattern"'|^\.github/workflows/unity-[^/]*\.yml$|^package\.json$|^\.npmignore$'
+          pattern="$pattern"'|^package\.json$|^\.npmignore$'
           pattern="$pattern"'|^CHANGELOG\.md$|^CHANGELOG\.md\.meta$|^LICENSE\.md$|^LICENSE\.md\.meta$'
           pattern="$pattern"'|^README\.md$|^README\.md\.meta$|^Third Party Notices\.md$'
           pattern="$pattern"'|^Third Party Notices\.md\.meta$|^package\.json\.meta$'

--- a/.github/workflows/stuck-job-watchdog.yml
+++ b/.github/workflows/stuck-job-watchdog.yml
@@ -150,7 +150,7 @@ jobs:
           fi
 
           if [[ -s "${state_branch_probe}" ]]; then
-            if ! git_auth fetch origin "${STATE_BRANCH}:refs/remotes/origin/${STATE_BRANCH}"; then
+            if ! git_auth fetch origin "+${STATE_BRANCH}:refs/remotes/origin/${STATE_BRANCH}"; then
               log_summary "WARN: state branch '${STATE_BRANCH}' exists per ls-remote but fetch failed; skipping this cycle."
               popd > /dev/null
               flush_summary_and_exit 0
@@ -201,7 +201,7 @@ jobs:
             fi
 
             log_summary "WARN: state push failed; attempting fetch + rebase + retry."
-            if git_auth fetch origin "${STATE_BRANCH}:refs/remotes/origin/${STATE_BRANCH}" \
+            if git_auth fetch origin "+${STATE_BRANCH}:refs/remotes/origin/${STATE_BRANCH}" \
                 && git rebase "refs/remotes/origin/${STATE_BRANCH}" \
                 && git_auth push origin "${STATE_BRANCH}"; then
               log_summary "State branch updated on second attempt (${reason}, after rebase)."

--- a/.github/workflows/update-llms-txt.yml
+++ b/.github/workflows/update-llms-txt.yml
@@ -78,7 +78,7 @@ jobs:
           auth_header="$(printf 'x-access-token:%s' "${GH_FETCH_TOKEN}" | base64 | tr -d '\n')"
           git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
             fetch --no-tags --depth=1 origin \
-            "refs/heads/${GITHUB_REF_NAME}:refs/remotes/origin/${GITHUB_REF_NAME}"
+            "+refs/heads/${GITHUB_REF_NAME}:refs/remotes/origin/${GITHUB_REF_NAME}"
           git checkout -B "${GITHUB_REF_NAME}" "refs/remotes/origin/${GITHUB_REF_NAME}"
           echo "Refreshed ${GITHUB_REF_NAME} to $(git rev-parse HEAD) before generating llms.txt."
 
@@ -121,7 +121,7 @@ jobs:
           for attempt in 1 2 3; do
             git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
               fetch --no-tags --depth=1 origin \
-              "refs/heads/${GITHUB_REF_NAME}:refs/remotes/origin/${GITHUB_REF_NAME}"
+              "+refs/heads/${GITHUB_REF_NAME}:refs/remotes/origin/${GITHUB_REF_NAME}"
             latest_sha="$(git rev-parse "refs/remotes/origin/${GITHUB_REF_NAME}")"
             current_sha="$(git rev-parse HEAD)"
             if [ "${latest_sha}" != "${current_sha}" ]; then
@@ -158,7 +158,7 @@ jobs:
 
             git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
               fetch --no-tags --depth=1 origin \
-              "refs/heads/${GITHUB_REF_NAME}:refs/remotes/origin/${GITHUB_REF_NAME}"
+              "+refs/heads/${GITHUB_REF_NAME}:refs/remotes/origin/${GITHUB_REF_NAME}"
             latest_after_push="$(git rev-parse "refs/remotes/origin/${GITHUB_REF_NAME}")"
             if [ "${latest_after_push}" = "${base_sha}" ]; then
               echo "::error::llms.txt auto-commit push failed while ${GITHUB_REF_NAME} still pointed at ${base_sha}."

--- a/scripts/__tests__/auto-commit-fetch-force-refspec.test.js
+++ b/scripts/__tests__/auto-commit-fetch-force-refspec.test.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Drift-guard for the auto-commit / state-branch workflows' remote-tracking fetches.
+//
+// These workflows shallow-fetch into an explicit refs/remotes/origin/<branch>
+// destination to detect whether the branch advanced while a slow job ran. Without a
+// leading `+`, once the branch HAS advanced the shallow local tracking ref shares no
+// history with the fetched tip, so git rejects the ref update as non-fast-forward
+// ("! [rejected] ... (non-fast-forward)", exit 1) -- aborting the step under
+// `set -euo pipefail` in the very case the guard exists to detect (run 74494500574).
+// The fix is git's own default-fetch idiom: force-update the tracking ref with `+` so
+// the update succeeds, the subsequent SHA comparison runs, and the step proceeds (or
+// skips) deliberately. The invariant is uniform across the full ("refs/heads/x:...")
+// and short ("${BRANCH}:...") source forms, and whether the shallow boundary comes
+// from `clone --depth 1` (stuck-job-watchdog) or `fetch --depth=1` (perf/llms).
+const WORKFLOW_DIR = path.resolve(__dirname, "..", "..", ".github", "workflows");
+const WORKFLOWS = ["perf-numbers.yml", "update-llms-txt.yml", "stuck-job-watchdog.yml"];
+
+// Group 1 is the optional `+`. Bare "refs/remotes/origin/<branch>" tokens (checkout /
+// rev-parse args, no `src:` colon) do not match: the `"` boundary stops `[^":]+`.
+const REMOTE_TRACKING_REFSPEC = /"(\+?)(?:refs\/heads\/)?[^":]+:refs\/remotes\/origin\/[^"]+"/g;
+
+for (const workflow of WORKFLOWS) {
+  test(`${workflow}: remote-tracking fetch refspecs are force-prefixed ('+')`, () => {
+    const source = fs.readFileSync(path.join(WORKFLOW_DIR, workflow), "utf8");
+    const matches = [...source.matchAll(REMOTE_TRACKING_REFSPEC)];
+    assert.ok(
+      matches.length >= 1,
+      `${workflow}: expected at least one remote-tracking fetch refspec (did the pattern change?)`
+    );
+    const unforced = matches.filter((m) => m[1] !== "+").map((m) => m[0]);
+    assert.deepEqual(
+      unforced,
+      [],
+      `${workflow} has unforced fetch refspec(s) -- prefix each with '+': ${unforced.join("; ")}`
+    );
+  });
+}

--- a/scripts/__tests__/auto-commit-fetch-force-refspec.test.js.meta
+++ b/scripts/__tests__/auto-commit-fetch-force-refspec.test.js.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a851c2494534980b7446e738bcb4f0bf
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/scripts/__tests__/run-ci-tests-enter-play-mode.test.js
+++ b/scripts/__tests__/run-ci-tests-enter-play-mode.test.js
@@ -12,6 +12,10 @@ const path = require("node:path");
 // copy is gitignored, so the runner emit is the source of truth for CI. See
 // docs/runbooks/test-suite-performance.md and the Fast Unity Tests skill.
 const runCiTests = fs.readFileSync(path.join(__dirname, "..", "unity", "run-ci-tests.ps1"), "utf8");
+const exportUnityPackage = fs.readFileSync(
+  path.join(__dirname, "..", "unity", "export-unitypackage.ps1"),
+  "utf8"
+);
 
 test("run-ci-tests emits EnterPlayModeOptions reload-disable for CI projects", () => {
   assert.match(
@@ -29,4 +33,13 @@ test("run-ci-tests emits EnterPlayModeOptions reload-disable for CI projects", (
     /Set-Content[^\r\n]*ProjectSettings\\EditorSettings\.asset/,
     "the EnterPlayModeOptions block must be written to ProjectSettings/EditorSettings.asset"
   );
+});
+
+test("Unity scripts clear native exit codes that are treated as nonfatal", () => {
+  for (const text of [runCiTests, exportUnityPackage]) {
+    assert.match(
+      text,
+      /(?=[\s\S]*function Clear-NonFatalNativeExitCode[\s\S]*\$global:LASTEXITCODE = 0)(?=[\s\S]*\$exitCode = \$LASTEXITCODE\s+Clear-NonFatalNativeExitCode -Context \$Label)(?=[\s\S]*finally \{\s+Clear-NonFatalNativeExitCode -Context 'Unity license return cleanup'\s+\})/
+    );
+  }
 });

--- a/scripts/unity/export-unitypackage.ps1
+++ b/scripts/unity/export-unitypackage.ps1
@@ -66,6 +66,17 @@ function Write-CiError {
     Write-Host "::error::$Message"
 }
 
+function Clear-NonFatalNativeExitCode {
+    # GitHub Actions' pwsh wrapper exits with $LASTEXITCODE after a script returns.
+    # Any native exit code that this script has already captured and deliberately
+    # downgraded to non-fatal must be scrubbed, or cleanup noise can turn a valid
+    # artifact-verified run red after the script reaches the end normally.
+    param([Parameter(Mandatory = $true)][string]$Context)
+
+    $global:LASTEXITCODE = 0
+    Write-Verbose "Cleared non-fatal native exit code after $Context."
+}
+
 function Resolve-FullPath {
     param([Parameter(Mandatory = $true)][string]$Path)
     if ([System.IO.Path]::IsPathRooted($Path)) {
@@ -114,6 +125,7 @@ function Invoke-UnityEditor {
     Write-Host "`"$EditorPath`" $($Arguments -join ' ')"
     & $EditorPath @Arguments 2>&1 | Tee-Object -FilePath $LogPath | Out-Host
     $exitCode = $LASTEXITCODE
+    Clear-NonFatalNativeExitCode -Context $Label
     Write-Host "::endgroup::"
     return $exitCode
 }
@@ -180,6 +192,8 @@ function Invoke-UnityLicenseReturn {
         }
     } catch {
         Write-Host "::warning::Unity license return failed: $($_.Exception.Message). The workflow if:always() return step and the next run's return-at-start are the backstops."
+    } finally {
+        Clear-NonFatalNativeExitCode -Context 'Unity license return cleanup'
     }
 }
 

--- a/scripts/unity/run-ci-tests.ps1
+++ b/scripts/unity/run-ci-tests.ps1
@@ -80,6 +80,17 @@ function Write-CiNotice {
     Write-Host "::notice::$Message"
 }
 
+function Clear-NonFatalNativeExitCode {
+    # GitHub Actions' pwsh wrapper exits with $LASTEXITCODE after a script returns.
+    # Any native exit code that this script has already captured and deliberately
+    # downgraded to non-fatal must be scrubbed, or cleanup noise can turn a valid
+    # artifact-verified run red after the script reaches the end normally.
+    param([Parameter(Mandatory = $true)][string]$Context)
+
+    $global:LASTEXITCODE = 0
+    Write-Verbose "Cleared non-fatal native exit code after $Context."
+}
+
 # SINGLE SOURCE OF TRUTH for the catastrophic-pattern list that both
 # Write-UnityCatastrophicErrorAnnotations (new ::error:: annotation surface)
 # AND Write-UnityResultFailureDiagnostics (older line-numbered selected-line
@@ -1559,6 +1570,8 @@ function Invoke-UnityLicenseReturn {
         }
     } catch {
         Write-Host "::warning::Unity license return failed: $($_.Exception.Message). The workflow if:always() return step and the next run's return-at-start are the backstops."
+    } finally {
+        Clear-NonFatalNativeExitCode -Context 'Unity license return cleanup'
     }
 }
 
@@ -1940,6 +1953,7 @@ function Invoke-UnityEditor {
     # BLOCK until the GUI-subsystem Unity.exe exits and to set $LASTEXITCODE.
     & $EditorPath @Arguments 2>&1 | Tee-Object -FilePath $LogPath | Out-Host
     $exitCode = $LASTEXITCODE
+    Clear-NonFatalNativeExitCode -Context $Label
     Write-Host "::endgroup::"
     if ($exitCode -ne 0) {
         # Proactively surface catastrophic compile-time failure patterns

--- a/scripts/validate-js-loc-budget.js
+++ b/scripts/validate-js-loc-budget.js
@@ -18,7 +18,16 @@ const path = require("path");
 // sanctioned bespoke exception -- no off-the-shelf tool regenerates a markdown
 // line-count column, and the index Lines/TOC counts had drifted on ~90% of
 // rows. A reviewed decision in the change that needs it.
-const TOTAL_BUDGET = 10600;
+//
+// Session 052 (+43, 10600 -> 10650): scripts/__tests__/auto-commit-fetch-force-
+// refspec.test.js, a drift-guard pinning the `+` force prefix on the auto-commit /
+// state-branch workflows' remote-tracking fetch refspecs. Without it the shallow
+// non-fast-forward crash (run 74494500574) silently regresses the moment anyone
+// drops a `+`; no off-the-shelf tool guards workflow-YAML refspec invariants. The
+// corpus had only ~16 lines of headroom, so the guard could not be slimmed into
+// budget without gutting its explanatory comment (the guard's whole point). A
+// reviewed decision in the change that needs it.
+const TOTAL_BUDGET = 10650;
 const REPO_ROOT = path.resolve(__dirname, "..");
 
 function countLines(filePath) {


### PR DESCRIPTION
## Description

Harden the CI workflows that refresh perf numbers, `llms.txt`, and the stuck-job watchdog so shallow remote-tracking fetches do not fail when the branch advances.

- Forces the remote-tracking fetch refspecs in the affected workflows with `+` so non-fast-forward updates succeed as intended.
- Adds a regression test that enforces the forced refspec across the three workflows.
- Raises the JS LOC budget slightly to keep the new guard within the repository check.

## Related Issue

None.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactor (code change that neither fixes a bug nor adds a feature)

## Checklist

- [ ] All tests pass locally
- [ ] Code is properly formatted
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] My changes do not introduce breaking changes, or breaking changes are documented

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CI workflows, drift tests, and exit-code cleanup in Unity runner scripts; no runtime product or auth logic.
> 
> **Overview**
> Fixes CI auto-commit and watchdog jobs that **shallow-fetch** into `refs/remotes/origin/<branch>` to detect default-branch movement. Those fetches now use a **`+` force refspec** so an advanced tip still updates the local tracking ref instead of failing non-fast-forward under `set -euo pipefail`—the case the freshness guard is meant to handle.
> 
> Adds a **drift test** that every remote-tracking fetch refspec in `perf-numbers.yml`, `update-llms-txt.yml`, and `stuck-job-watchdog.yml` stays `+`-prefixed, and bumps the **JS line budget** to fit it. **Script Tests** push/PR relevance now covers **all** workflow YAML under `.github/workflows/` (not only a few named files).
> 
> **Unity CI PowerShell** (`run-ci-tests.ps1`, `export-unitypackage.ps1`) clears `$LASTEXITCODE` after invocations where a non-zero native exit is already treated as non-fatal (editor runs and license return cleanup), so GitHub Actions does not mark an otherwise successful run failed; a test guards that contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 950215b3d6f7f62ef4b0aa23318cc324d6038807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->