### PR TITLE
[codex] Harden release App ref pushes

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,7 +1,8 @@
 name: Release Prepare
 
 # Manual entry point of the release pipeline. Dispatched from the DEFAULT
-# branch, it computes the next version (bump or explicit), rewrites
+# branch, it first validates the GitHub App token needed to publish the
+# release PR, computes the next version (bump or explicit), rewrites
 # package.json, rotates CHANGELOG.md's Unreleased section under the new
 # version heading, syncs the banner SVG, re-runs the script tests and
 # validators against the bumped tree, and opens a `release/vX.Y.Z` pull
@@ -82,9 +83,23 @@ jobs:
             echo "::warning::AUTO_COMMIT_APP_* secrets are not set; dry-run continues but a real run would fail."
           fi
 
+      - name: Generate the auto-commit GitHub App token
+        id: app-token
+        if: ${{ !inputs.dry-run }}
+        # Request only the release-prepare scopes this workflow needs. If the App
+        # installation no longer grants them, fail here before spending time
+        # preparing a release tree that cannot be published.
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.AUTO_COMMIT_APP_ID }}
+          private-key: ${{ secrets.AUTO_COMMIT_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -178,16 +193,6 @@ jobs:
           echo "::endgroup::"
           echo "Dry run complete; nothing was pushed."
 
-      - name: Generate the auto-commit GitHub App token
-        id: app-token
-        if: ${{ !inputs.dry-run }}
-        # The action's v3 metadata requires app-id; keep this name aligned
-        # with actionlint instead of using legacy aliases.
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.AUTO_COMMIT_APP_ID }}
-          private-key: ${{ secrets.AUTO_COMMIT_APP_PRIVATE_KEY }}
-
       - name: Push the release branch and open the PR
         if: ${{ !inputs.dry-run }}
         env:
@@ -207,10 +212,35 @@ jobs:
           # omitted artifact is regenerated, passes validate:all, then is silently
           # dropped from the release commit.
           git add package.json CHANGELOG.md docs/images/DxMessaging-banner.svg llms.txt .github/ISSUE_TEMPLATE/bug_report.yml
+          if git diff --cached --quiet -- package.json CHANGELOG.md docs/images/DxMessaging-banner.svg llms.txt .github/ISSUE_TEMPLATE/bug_report.yml; then
+            echo "::error::Release preparation staged no changes; refusing to create an empty release commit."
+            exit 1
+          fi
           git commit -m "release: ${TAG}"
+
+          recovery_dir="artifacts/release-prepare"
+          mkdir -p "${recovery_dir}"
+          git format-patch -1 --stdout > "${recovery_dir}/release-${TAG}.patch"
+          git show --stat --oneline --decorate --no-renames HEAD > "${recovery_dir}/release-${TAG}.stat.txt"
+
           auth_header="$(printf 'x-access-token:%s' "${GH_PUSH_TOKEN}" | base64 | tr -d '\n')"
+          push_log="${RUNNER_TEMP}/release-push.log"
+          set +e
           git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
-            push origin "HEAD:refs/heads/${BRANCH}"
+            push origin "HEAD:refs/heads/${BRANCH}" 2>&1 | tee "${push_log}"
+          push_status=${PIPESTATUS[0]}
+          set -e
+          if [ "${push_status}" -ne 0 ]; then
+            echo "::group::release branch push failure"
+            cat "${push_log}" || true
+            echo "::endgroup::"
+            message="Failed to push ${BRANCH} with the auto-commit GitHub App token. "
+            message+="Confirm the App is installed on ${GITHUB_REPOSITORY}, has Contents: write, "
+            message+="and is allowed by any ruleset or branch rule that targets release branches. "
+            message+="A recovery patch was written to ${recovery_dir}/release-${TAG}.patch."
+            echo "::error::${message}"
+            exit "${push_status}"
+          fi
 
           # Excerpt the rotated changelog section for the PR body via the single
           # shared extractor (the same scripts/release module release.yml and
@@ -241,9 +271,31 @@ jobs:
             echo "1. The Unity Asset Store upload stays MANUAL: download the asset-store-submission artifact and follow docs/runbooks/asset-store-publishing.md."
           } > "${pr_body_file}"
 
-          GH_TOKEN="${GH_PUSH_TOKEN}" gh pr create \
+          pr_create_err="${RUNNER_TEMP}/release-pr-create.err"
+          set +e
+          pr_create_out="$(GH_TOKEN="${GH_PUSH_TOKEN}" gh pr create \
             --repo "${GITHUB_REPOSITORY}" \
             --base "${DEFAULT_BRANCH}" \
             --head "${BRANCH}" \
             --title "release: ${TAG}" \
-            --body-file "${pr_body_file}"
+            --body-file "${pr_body_file}" 2>"${pr_create_err}")"
+          pr_create_status=$?
+          set -e
+          if [ "${pr_create_status}" -ne 0 ]; then
+            compare_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${DEFAULT_BRANCH}...${BRANCH}"
+            message="Pushed ${BRANCH}, but PR creation failed. The release commit is preserved on the branch; "
+            message+="open the PR manually if needed: ${compare_url}. Confirm the App has Pull requests: write."
+            echo "::error::${message}"
+            echo "gh stdout: ${pr_create_out}"
+            cat "${pr_create_err}" || true
+            exit "${pr_create_status}"
+          fi
+          echo "${pr_create_out}"
+
+      - name: Upload failed release preparation patch
+        if: ${{ failure() && !inputs.dry-run }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-prepare-recovery-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/release-prepare/
+          if-no-files-found: ignore

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -135,6 +135,7 @@ jobs:
         with:
           app-id: ${{ secrets.AUTO_COMMIT_APP_ID }}
           private-key: ${{ secrets.AUTO_COMMIT_APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Create and push the annotated release tag
         if: >-
@@ -151,6 +152,23 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "${TAG}" -m "Release ${TAG}" "${GITHUB_SHA}"
           auth_header="$(printf 'x-access-token:%s' "${GH_PUSH_TOKEN}" | base64 | tr -d '\n')"
+          push_log="${RUNNER_TEMP}/release-tag-push.log"
+          set +e
           git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
-            push origin "refs/tags/${TAG}"
+            push origin "refs/tags/${TAG}" 2>&1 | tee "${push_log}"
+          push_status=${PIPESTATUS[0]}
+          set -e
+          if [ "${push_status}" -ne 0 ]; then
+            echo "::group::release tag push failure"
+            cat "${push_log}" || true
+            echo "::endgroup::"
+            message="Failed to push ${TAG} with the auto-commit GitHub App token. "
+            message+="Confirm the App is installed on ${GITHUB_REPOSITORY}, has Contents: write, "
+            message+="and is allowed by any ruleset that targets release tags. Manual fallback: "
+            message+="git fetch origin ${GITHUB_REF_NAME} && "
+            message+="git tag -a ${TAG} -m \"Release ${TAG}\" ${GITHUB_SHA} && "
+            message+="git push origin ${TAG}"
+            echo "::error::${message}"
+            exit "${push_status}"
+          fi
           echo "::notice::Pushed ${TAG} at ${GITHUB_SHA}; the tag-triggered Release workflow takes over from here."

--- a/docs/ops/npm-release-publishing.md
+++ b/docs/ops/npm-release-publishing.md
@@ -46,7 +46,9 @@ The normal path never creates the tag by hand:
 1. Dispatch `.github/workflows/release-prepare.yml` from the default branch
    (bump kind or explicit version). It opens a `release/vX.Y.Z` PR containing
    the version bump, the rotated changelog, the synced banner, and the
-   regenerated `llms.txt`.
+   regenerated `llms.txt`. The auto-commit GitHub App must have Contents write
+   and Pull requests write, and no matching rule may block its `release/*`
+   branch push.
 1. Squash-merge that PR with its default `release: vX.Y.Z` title.
 1. `.github/workflows/release-tag.yml` validates the merged commit and pushes
    the annotated tag `vX.Y.Z` with the auto-commit GitHub App token, which

--- a/docs/ops/npm-release-publishing.md
+++ b/docs/ops/npm-release-publishing.md
@@ -48,7 +48,7 @@ The normal path never creates the tag by hand:
    the version bump, the rotated changelog, the synced banner, and the
    regenerated `llms.txt`. The auto-commit GitHub App must have Contents write
    and Pull requests write, and no matching rule may block its `release/*`
-   branch push.
+   branch push or `v*` tag push.
 1. Squash-merge that PR with its default `release: vX.Y.Z` title.
 1. `.github/workflows/release-tag.yml` validates the merged commit and pushes
    the annotated tag `vX.Y.Z` with the auto-commit GitHub App token, which

--- a/docs/ops/release-operations.md
+++ b/docs/ops/release-operations.md
@@ -78,7 +78,11 @@ The release pipeline runs dispatch, PR, tag, publish:
    `npm run validate:all` against the bumped tree, and opens a
    `release/vX.Y.Z` pull request with the auto-commit GitHub App
    (`AUTO_COMMIT_APP_ID` / `AUTO_COMMIT_APP_PRIVATE_KEY`). The `dry-run`
-   input prints the prepared diff and stops without pushing.
+   input prints the prepared diff and stops without pushing. If the App token
+   cannot push the release branch, the failed run uploads a
+   `release-prepare-recovery-*` artifact containing a patch for the prepared
+   release commit; fix the App installation/permissions or matching branch
+   rules, then rerun the workflow.
 1. A maintainer reviews the release PR and squash-merges it, keeping the
    default `release: vX.Y.Z` title.
 1. `.github/workflows/release-tag.yml` sees the release commit on the default
@@ -86,7 +90,8 @@ The release pipeline runs dispatch, PR, tag, publish:
    `## [X.Y.Z]` changelog heading, tag absent) and pushes the annotated tag
    `vX.Y.Z` with the App token. When the App secrets are absent it prints the
    manual `git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z`
-   commands as a warning instead.
+   commands as a warning instead. If the App token exists but cannot write the
+   tag ref, the job fails with the same manual fallback commands.
 1. The tag fires `.github/workflows/release.yml`, which performs the gates
    below.
 

--- a/docs/runbooks/perf-numbers-auto-commit.md
+++ b/docs/runbooks/perf-numbers-auto-commit.md
@@ -33,6 +33,15 @@ built-in `GITHUB_TOKEN`. The built-in token cannot push to a protected branch:
 branch-protection bypass actor and GitHub blocks the push by design. A dedicated
 GitHub App that **is** allowed to bypass the protection does the push instead.
 
+The release pipeline uses the same App token: `release-prepare.yml` pushes the
+`release/vX.Y.Z` branch and opens the release pull request, then
+`release-tag.yml` pushes the annotated `vX.Y.Z` tag after that PR is merged. A
+denied release-branch push such as `Permission to ... denied to
+bot-auto-commit[bot]` means the App token can be minted but cannot write that
+ref. Check the App installation, **Contents: Read and write**, **Pull requests:
+Read and write**, and any branch or tag rulesets that target `release/*` or
+`v*`.
+
 App-token pushes **do** re-trigger workflows (only the built-in `GITHUB_TOKEN`
 suppresses that). Recursion is therefore broken at the trigger: the `push`
 trigger has `paths-ignore: [docs/architecture/performance.md]`, so the doc-only
@@ -106,6 +115,11 @@ that ruleset (not just the classic rule) is what blocks the push, add the App to
 its **Bypass list** as well -- both systems are enforced independently, so the
 pushing actor must satisfy every rule that targets the branch.
 
+Release branches and release tags are not the default branch, so the default
+branch bypass above is not enough if an organization or repository ruleset also
+targets `release/*` branches or `v*` tags. Either exclude those refs from the
+rule or add the App as a bypass actor/allowed pusher for that rule too.
+
 ### Step 4 -- store the credentials as Actions secrets
 
 Add these as repository (or organization) **Actions** secrets:
@@ -115,9 +129,11 @@ Add these as repository (or organization) **Actions** secrets:
    including the `-----BEGIN...` and `-----END...` lines.
 
 The workflow reads both via `actions/create-github-app-token`. The same App and
-secrets back every auto-commit workflow that pushes to the default branch -- both
-`perf-numbers.yml` and `update-llms-txt.yml` use them, so this one provisioning
-unblocks both at once.
+secrets back every auto-commit workflow that writes repository refs:
+`perf-numbers.yml`, `update-llms-txt.yml`,
+`update-issue-template-versions.yml`, `release-prepare.yml`, and
+`release-tag.yml`. This one provisioning unblocks the doc auto-commits and the
+release branch/tag handoff.
 
 ## Fallback pull request prerequisites
 

--- a/docs/runbooks/perf-numbers-auto-commit.md
+++ b/docs/runbooks/perf-numbers-auto-commit.md
@@ -36,11 +36,11 @@ GitHub App that **is** allowed to bypass the protection does the push instead.
 The release pipeline uses the same App token: `release-prepare.yml` pushes the
 `release/vX.Y.Z` branch and opens the release pull request, then
 `release-tag.yml` pushes the annotated `vX.Y.Z` tag after that PR is merged. A
-denied release-branch push such as `Permission to ... denied to
-bot-auto-commit[bot]` means the App token can be minted but cannot write that
-ref. Check the App installation, **Contents: Read and write**, **Pull requests:
-Read and write**, and any branch or tag rulesets that target `release/*` or
-`v*`.
+denied release-branch push that mentions `bot-auto-commit[bot]` and
+`Permission to ... denied` means the App token can be minted but cannot write
+that ref. Check the App installation, **Contents: Read and write**, **Pull
+requests: Read and write**, and any branch or tag rulesets that target
+`release/*` or `v*`.
 
 App-token pushes **do** re-trigger workflows (only the built-in `GITHUB_TOKEN`
 suppresses that). Recursion is therefore broken at the trigger: the `push`

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -257,13 +257,13 @@ test("standalone static-check workflows are not reintroduced", () => {
 test("release workflows pin App write scopes and denied-push diagnostics", () => {
   const prepare = fs.readFileSync(path.join(WORKFLOW_DIR, "release-prepare.yml"), "utf8");
   const tag = fs.readFileSync(path.join(WORKFLOW_DIR, "release-tag.yml"), "utf8");
-  assert.match(
-    prepare,
-    /- name: Generate the auto-commit GitHub App token[\s\S]*\n          permission-contents: write\n          permission-pull-requests: write\n[\s\S]*- name: Push the release branch and open the PR[\s\S]*\n          recovery_dir="artifacts\/release-prepare"\n[\s\S]*git format-patch -1 --stdout[\s\S]*release branch push failure[\s\S]*Confirm the App has Pull requests: write[\s\S]*- name: Upload failed release preparation patch[\s\S]*\n          path: artifacts\/release-prepare\/\n          if-no-files-found: ignore\n/
-  );
+  for (const [name, source, pattern] of [
+    ["prepare App scopes", prepare, /- name: Generate the auto-commit GitHub App token[\s\S]*\n          permission-contents: write\n          permission-pull-requests: write\n/],
+    ["prepare recovery patch", prepare, /- name: Push the release branch and open the PR[\s\S]*\n          recovery_dir="artifacts\/release-prepare"\n[\s\S]*git format-patch -1 --stdout/],
+    ["prepare diagnostics", prepare, /- name: Push the release branch and open the PR[\s\S]*release branch push failure[\s\S]*Confirm the App has Pull requests: write/],
+    ["prepare recovery upload", prepare, /- name: Upload failed release preparation patch[\s\S]*\n          path: artifacts\/release-prepare\/\n          if-no-files-found: ignore\n/],
+    ["tag App scope", tag, /- name: Generate the auto-commit GitHub App token[\s\S]*\n          permission-contents: write\n/],
+    ["tag diagnostics", tag, /- name: Create and push the annotated release tag[\s\S]*\n          push_status=\$\{PIPESTATUS\[0\]\}\n[\s\S]*release tag push failure[\s\S]*Manual fallback:/]
+  ]) assert.match(source, pattern, name);
   assert.doesNotMatch(prepare, /\.artifacts\/release-prepare/);
-  assert.match(
-    tag,
-    /- name: Generate the auto-commit GitHub App token[\s\S]*\n          permission-contents: write\n[\s\S]*- name: Create and push the annotated release tag[\s\S]*\n          push_status=\$\{PIPESTATUS\[0\]\}\n[\s\S]*release tag push failure[\s\S]*Manual fallback:/
-  );
 });

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -260,7 +260,7 @@ test("release workflows pin App write scopes and denied-push diagnostics", () =>
   for (const [name, source, pattern] of [
     ["prepare App scopes", prepare, /- name: Generate the auto-commit GitHub App token[\s\S]*\n          permission-contents: write\n          permission-pull-requests: write\n/],
     ["prepare recovery patch", prepare, /- name: Push the release branch and open the PR[\s\S]*\n          recovery_dir="artifacts\/release-prepare"\n[\s\S]*git format-patch -1 --stdout/],
-    ["prepare diagnostics", prepare, /- name: Push the release branch and open the PR[\s\S]*release branch push failure[\s\S]*Confirm the App has Pull requests: write/],
+    ["prepare diagnostics", prepare, /- name: Push the release branch and open the PR[\s\S]*release branch push failure[\s\S]*has Contents: write[\s\S]*ruleset or branch rule[\s\S]*recovery patch was written/],
     ["prepare recovery upload", prepare, /- name: Upload failed release preparation patch[\s\S]*\n          path: artifacts\/release-prepare\/\n          if-no-files-found: ignore\n/],
     ["tag App scope", tag, /- name: Generate the auto-commit GitHub App token[\s\S]*\n          permission-contents: write\n/],
     ["tag diagnostics", tag, /- name: Create and push the annotated release tag[\s\S]*\n          push_status=\$\{PIPESTATUS\[0\]\}\n[\s\S]*release tag push failure[\s\S]*Manual fallback:/]

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -122,11 +122,7 @@ test("static CI checks stay consolidated behind CI Success", () => {
   const ciSuccess = getJobBlock(source, "ci-success");
   assert.match(ciSuccess, /\n    name: CI Success\n/);
   assert.match(ciSuccess, /\n    if: \$\{\{ always\(\) \}\}\n/);
-  // Pin the fail-closed aggregator action identity to a versioned tag, not one
-  // exact version: re-actors/alls-green is what makes empty allowed-skips/failures
-  // gate every leg. The `@...vN` shape tolerates deliberate, dependabot-tracked
-  // version bumps (so the test never cries wolf) while still rejecting a floating
-  // @main/@master ref on the gate action.
+  // Pin the fail-closed aggregator action to a versioned tag, not @main/@master.
   assert.match(ciSuccess, /uses: re-actors\/alls-green@[\w./-]*v\d/);
   assert.match(ciSuccess, /allowed-skips: ""/);
   assert.match(ciSuccess, /allowed-failures: ""/);
@@ -256,4 +252,18 @@ test("standalone static-check workflows are not reintroduced", () => {
       `${workflow} is consolidated into ci.yml; do not restore it as a separate required gate`
     );
   }
+});
+
+test("release workflows pin App write scopes and denied-push diagnostics", () => {
+  const prepare = fs.readFileSync(path.join(WORKFLOW_DIR, "release-prepare.yml"), "utf8");
+  const tag = fs.readFileSync(path.join(WORKFLOW_DIR, "release-tag.yml"), "utf8");
+  assert.match(
+    prepare,
+    /permission-contents: write[\s\S]*permission-pull-requests: write[\s\S]*recovery_dir="artifacts\/release-prepare"[\s\S]*git format-patch -1 --stdout[\s\S]*release branch push failure[\s\S]*path: artifacts\/release-prepare\//
+  );
+  assert.doesNotMatch(prepare, /\.artifacts\/release-prepare/);
+  assert.match(
+    tag,
+    /permission-contents: write[\s\S]*push_status=\$\{PIPESTATUS\[0\]\}[\s\S]*release tag push failure[\s\S]*Manual fallback:/
+  );
 });

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -259,11 +259,11 @@ test("release workflows pin App write scopes and denied-push diagnostics", () =>
   const tag = fs.readFileSync(path.join(WORKFLOW_DIR, "release-tag.yml"), "utf8");
   assert.match(
     prepare,
-    /permission-contents: write[\s\S]*permission-pull-requests: write[\s\S]*recovery_dir="artifacts\/release-prepare"[\s\S]*git format-patch -1 --stdout[\s\S]*release branch push failure[\s\S]*path: artifacts\/release-prepare\//
+    /- name: Generate the auto-commit GitHub App token[\s\S]*\n          permission-contents: write\n          permission-pull-requests: write\n[\s\S]*- name: Push the release branch and open the PR[\s\S]*\n          recovery_dir="artifacts\/release-prepare"\n[\s\S]*git format-patch -1 --stdout[\s\S]*release branch push failure[\s\S]*Confirm the App has Pull requests: write[\s\S]*- name: Upload failed release preparation patch[\s\S]*\n          path: artifacts\/release-prepare\/\n          if-no-files-found: ignore\n/
   );
   assert.doesNotMatch(prepare, /\.artifacts\/release-prepare/);
   assert.match(
     tag,
-    /permission-contents: write[\s\S]*push_status=\$\{PIPESTATUS\[0\]\}[\s\S]*release tag push failure[\s\S]*Manual fallback:/
+    /- name: Generate the auto-commit GitHub App token[\s\S]*\n          permission-contents: write\n[\s\S]*- name: Create and push the annotated release tag[\s\S]*\n          push_status=\$\{PIPESTATUS\[0\]\}\n[\s\S]*release tag push failure[\s\S]*Manual fallback:/
   );
 });


### PR DESCRIPTION
## Summary

Root cause: the Release Prepare run could mint the auto-commit GitHub App token, but the token could not push the `release/vX.Y.Z` branch (`Permission to Ambiguous-Interactive/DxMessaging.git denied to bot-auto-commit[bot]`).

This PR hardens the release automation so the same class of failure is explicit and recoverable:

- requests Contents/Pull requests write scopes when minting the release-prepare App token
- captures release branch push failures with actionable diagnostics and a recovery patch artifact
- stores the recovery patch under a non-hidden artifact directory so `upload-artifact@v7` actually uploads it
- captures release PR creation failures after a successful branch push and prints the compare URL
- applies the same Contents write scope and denied-push diagnostics to the release-tag bridge
- adds a workflow contract test so denied-push diagnostics and non-hidden recovery artifacts do not regress
- updates the release/runbook docs to cover App installation, Contents/Pull requests permissions, release-branch rules, and release-tag rules

## Validation

- `node --test scripts/__tests__/ci-aggregate-workflow.test.js`
- `pre-commit run --hook-stage pre-push --files .github/workflows/release-prepare.yml .github/workflows/release-tag.yml scripts/__tests__/ci-aggregate-workflow.test.js`
- `pre-commit run --hook-stage pre-push --files docs/ops/npm-release-publishing.md docs/ops/release-operations.md docs/runbooks/perf-numbers-auto-commit.md`
- `npm test`
- `npm run validate:all`
- `npm run format:check`
- `npm run check:spelling`
- `actionlint`
- `npx markdownlint-cli2 docs/runbooks/perf-numbers-auto-commit.md docs/ops/release-operations.md docs/ops/npm-release-publishing.md`

Note: local `git push` needed `--no-verify` because this checkout's generated `.git/hooks/pre-push` has a Windows CRLF shebang; the actual pre-push hook stage was run explicitly and passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only release CI workflows and ops docs, but they gate publishing; misconfiguration could still block releases until App/rulesets are fixed, while recovery artifacts improve recoverability.
> 
> **Overview**
> **Hardens release automation** when the auto-commit GitHub App can mint a token but cannot write `release/*` branches or `v*` tags (the failure mode that produced `Permission ... denied to bot-auto-commit[bot]`).
> 
> In **`release-prepare.yml`**, App token creation runs **before** checkout and requests explicit **Contents** and **Pull requests** write scopes so bad installations fail early. Checkout uses that token for non–dry-run runs. The publish step refuses an empty staged release commit, writes a **recovery patch** under `artifacts/release-prepare/` (not a hidden path), surfaces **push** and **`gh pr create`** failures with actionable messages (including a compare URL when the branch pushed but the PR did not), and on failure uploads a **`release-prepare-recovery-*`** workflow artifact.
> 
> **`release-tag.yml`** gets the same **Contents: write** scope on token minting and similar **denied tag push** logging with manual `git tag` fallback text.
> 
> **Docs** (`release-operations`, `npm-release-publishing`, `perf-numbers-auto-commit`) now call out App permissions, `release/*` / `v*` rulesets, and recovery artifacts. A **workflow contract test** in `ci-aggregate-workflow.test.js` pins these behaviors so diagnostics and non-hidden recovery paths do not regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aafb6771e457ef70f9a77bd99d4941630cf734d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->