### PR TITLE
fix(release): keep unitypackage export modules compatible

### DIFF
--- a/.unity-test-project/Packages/manifest.json
+++ b/.unity-test-project/Packages/manifest.json
@@ -16,10 +16,7 @@
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.unitywebrequest": "1.0.0",
     "com.unity.modules.unitywebrequestwww": "1.0.0",
-    "com.unity.modules.assetbundle": "1.0.0",
-    "com.unity.modules.accessibility": "1.0.0",
-    "com.unity.modules.adaptiveperformance": "1.0.0",
-    "com.unity.modules.vectorgraphics": "1.0.0"
+    "com.unity.modules.assetbundle": "1.0.0"
   },
   "scopedRegistries": [
     {

--- a/.unity-test-project/Packages/packages-lock.json
+++ b/.unity-test-project/Packages/packages-lock.json
@@ -139,29 +139,9 @@
       "source": "builtin",
       "dependencies": {}
     },
-    "com.unity.modules.accessibility": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.modules.adaptiveperformance": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.subsystems": "1.0.0"
-      }
-    },
     "com.unity.modules.hierarchycore": {
       "version": "1.0.0",
       "depth": 2,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.modules.imageconversion": {
-      "version": "1.0.0",
-      "depth": 1,
       "source": "builtin",
       "dependencies": {}
     },
@@ -189,14 +169,6 @@
       "source": "builtin",
       "dependencies": {}
     },
-    "com.unity.modules.subsystems": {
-      "version": "1.0.0",
-      "depth": 1,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.jsonserialize": "1.0.0"
-      }
-    },
     "com.unity.modules.ui": {
       "version": "1.0.0",
       "depth": 2,
@@ -213,16 +185,6 @@
         "com.unity.modules.jsonserialize": "1.0.0",
         "com.unity.modules.hierarchycore": "1.0.0",
         "com.unity.modules.physics": "1.0.0"
-      }
-    },
-    "com.unity.modules.vectorgraphics": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.uielements": "1.0.0",
-        "com.unity.modules.imageconversion": "1.0.0",
-        "com.unity.modules.imgui": "1.0.0"
       }
     }
   }

--- a/scripts/__tests__/export-unitypackage-stage.test.js
+++ b/scripts/__tests__/export-unitypackage-stage.test.js
@@ -306,6 +306,7 @@ test("export-unitypackage -StageOnly rejects destructive ProjectPath values befo
 // Single source of truth for the built-in module set the ephemeral export
 // project must enable; both export-unitypackage.ps1 and this guard read it.
 const MODULE_DATA_PATH = path.join(REPO_ROOT, "scripts", "unity", "unity-builtin-modules.json");
+const RELEASE_UNITY_2022_UNSUPPORTED_MODULES = ["com.unity.modules.accessibility"];
 
 test("export-unitypackage -StageOnly enables the built-in Unity modules", (t) => {
   if (!HAS_PWSH) {
@@ -321,22 +322,19 @@ test("export-unitypackage -StageOnly enables the built-in Unity modules", (t) =>
       fs.readFileSync(path.join(projectPath, "Packages", "manifest.json"), "utf8")
     );
     const deps = manifest.dependencies || {};
+    const hasDependency = (id) => Object.prototype.hasOwnProperty.call(deps, id);
 
-    // The proven v3.1.0 failure: EditorGUIUtility's base GUIUtility lives in
-    // UnityEngine.IMGUIModule, which an empty `dependencies: {}` never enables.
     assert.ok(
-      Object.prototype.hasOwnProperty.call(deps, "com.unity.modules.imgui"),
+      hasDependency("com.unity.modules.imgui"),
       "manifest must enable com.unity.modules.imgui (the module that broke v3.1.0)"
     );
 
-    // Every entry in the single-source data file must reach the manifest, so the
-    // export project compiles the payload exactly like a default Unity project.
     const required = JSON.parse(fs.readFileSync(MODULE_DATA_PATH, "utf8")).dependencies;
     for (const id of Object.keys(required)) {
-      assert.ok(
-        Object.prototype.hasOwnProperty.call(deps, id),
-        `manifest is missing required dependency ${id}`
-      );
+      assert.ok(hasDependency(id), `manifest is missing required dependency ${id}`);
+    }
+    for (const id of RELEASE_UNITY_2022_UNSUPPORTED_MODULES) {
+      assert.equal(hasDependency(id), false, `${id} is not resolvable by Unity 2022.3`);
     }
   } finally {
     fs.rmSync(stagingRoot, { recursive: true, force: true });

--- a/scripts/unity/export-unitypackage.ps1
+++ b/scripts/unity/export-unitypackage.ps1
@@ -725,11 +725,12 @@ foreach ($relativeFolder in $folderMetaRelativePaths) {
 # UnityEngine.IMGUIModule (and the rest), so the staged payload fails to compile
 # the instant it touches an IMGUI type (e.g. EditorGUIUtility, whose base class
 # GUIUtility lives there), Unity aborts batchmode, and ExportPackage never runs.
-# That is exactly what broke the v3.1.0 export. The canonical fresh-2022.3 module
-# set is the single source of truth in scripts/unity/unity-builtin-modules.json
-# (a default consumer project lists the full set; every entry ships inside the
-# editor, so no network is needed); the package's own UPM dependencies merge on
-# top. See .llm/skills/github-actions/release-asset-and-notes-invariants.md.
+# That is exactly what broke the v3.1.0 export. The release-editor-compatible
+# built-in package set is the single source of truth in
+# scripts/unity/unity-builtin-modules.json. Do not copy newer editor default
+# manifests wholesale; every listed package must resolve in the pinned release
+# editor without network access. The package's own UPM dependencies merge on top.
+# See .llm/skills/github-actions/release-asset-and-notes-invariants.md.
 New-Item -ItemType Directory -Force -Path (Join-Path $projectPath 'Packages') | Out-Null
 New-Item -ItemType Directory -Force -Path (Join-Path $projectPath 'ProjectSettings') | Out-Null
 New-Item -ItemType Directory -Force -Path ([System.IO.Path]::Combine($projectPath, 'Assets', 'Editor')) | Out-Null

--- a/scripts/unity/unity-builtin-modules.json
+++ b/scripts/unity/unity-builtin-modules.json
@@ -1,7 +1,6 @@
 {
-  "description": "Single source of truth for the Unity built-in module set the ephemeral .unitypackage export project must enable. This is the dependency set a fresh Unity 2022.3 project lists in Packages/manifest.json; an empty `dependencies: {}` enables NONE of these, which is what broke the v3.1.0 .unitypackage export (UnityEngine.IMGUIModule absent -> EditorGUIUtility/GUIUtility CS0012). Read by scripts/unity/export-unitypackage.ps1 (writes the manifest) and scripts/__tests__/export-unitypackage-stage.test.js (asserts the manifest). All built-in packages (modules + uGUI) ship inside the editor install, so listing them needs no network. See .llm/skills/github-actions/release-asset-and-notes-invariants.md.",
+  "description": "Single source of truth for the Unity built-in package set the ephemeral .unitypackage export project must enable. Keep this list compatible with the pinned release editor in .github/unity-versions.json; do not copy newer editor default manifests wholesale. An empty `dependencies: {}` enables NONE of these, which is what broke the v3.1.0 .unitypackage export (UnityEngine.IMGUIModule absent -> EditorGUIUtility/GUIUtility CS0012). Read by scripts/unity/export-unitypackage.ps1 (writes the manifest) and scripts/__tests__/export-unitypackage-stage.test.js (asserts the manifest). All listed packages ship inside the release editor install, so listing them needs no network. See .llm/skills/github-actions/release-asset-and-notes-invariants.md.",
   "dependencies": {
-    "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",


### PR DESCRIPTION
## Summary

- Fix the failed v3.2.0 Release workflow export job by removing `com.unity.modules.accessibility` from the release `.unitypackage` export manifest source; Unity 2022.3.45f1 cannot resolve that package.
- Update the committed local Unity test project manifest/lock to stop directly requesting the same too-new built-in module class (`accessibility`, `adaptiveperformance`, `vectorgraphics`) outside the `.github/comparison-packages.json` mirror.
- Add a StageOnly export guard so the generated release export manifest rejects `com.unity.modules.accessibility` for the pinned Unity 2022.3 release editor.

## Failure Root Cause

Release run `28423904274` failed in `Export .unitypackage` because Unity aborted package resolution with:

`Package [com.unity.modules.accessibility@1.0.0] cannot be found`

The package was copied into the export manifest data from a newer editor default module set, but release export runs on the pinned release editor `2022.3.45f1`.

## Validation

- `node --test scripts/__tests__/export-unitypackage-stage.test.js`
- `npm test`
- `npm run validate:js-loc-budget`
- `npm run validate:all`
- `npm run format:check`
- `npm run check:spelling`
- `pre-commit run --hook-stage pre-push --files .unity-test-project/Packages/manifest.json .unity-test-project/Packages/packages-lock.json scripts/__tests__/export-unitypackage-stage.test.js scripts/unity/export-unitypackage.ps1 scripts/unity/unity-builtin-modules.json`

Note: the local auxiliary worktree has an unstaged line-ending-only `.csproj` diff from checkout/install churn; it is not part of this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-pipeline and test-project manifest tuning only; no runtime product code or auth/data paths change.
> 
> **Overview**
> Fixes release **Export .unitypackage** failures where Unity **2022.3.45f1** could not resolve **`com.unity.modules.accessibility`** after that module was copied from a newer editor’s default manifest into **`scripts/unity/unity-builtin-modules.json`**.
> 
> **`com.unity.modules.accessibility`** is dropped from the canonical built-in list and the docs/comments now stress that the list must match the **pinned release editor**, not a wholesale copy of a newer default **`Packages/manifest.json`**. The local **`.unity-test-project`** manifest and lockfile stop directly requesting **`accessibility`**, **`adaptiveperformance`**, and **`vectorgraphics`**.
> 
> A **StageOnly** test asserts every required entry from **`unity-builtin-modules.json`** is present and that **`com.unity.modules.accessibility`** is **absent** on the release export manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bdd65c0b10c333d22662c0285ca961a3d16badb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->