### PR TITLE
refresh(docs): rework README banner and simplify banner sync to version-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           set_output actionlint \
             "(^\.github/workflows/|^\.github/actionlint\.yaml$|^\.github/unity-versions\.json$|^scripts/validate-unity-versions\.js$)"
           set_output banner \
-            "(^docs/images/DxMessaging-banner\.svg$|^scripts/sync-banner-version\.js$|^package\.json$|^Tests/|^SourceGenerators/|^\.docs-tests/|$ci_workflow)"
+            "(^docs/images/DxMessaging-banner\.svg$|^scripts/sync-banner-version\.js$|^package\.json$|$ci_workflow)"
           set_output csharpier \
             "(\.cs$|^\.config/dotnet-tools\.json$|(^|/)\.csharpierrc[^/]*$|(^|/)\.csharpierignore$|(^|/)\.editorconfig$|$ci_workflow)"
           set_output docs \

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -44,7 +44,7 @@ This file is intentionally concise. It contains only critical, high-signal guida
 - Format markdown/JSON/YAML/asmdef: `npm run format` (check-only: `npm run format:check`)
 - Markdown lint: `npm run lint:markdown`
 - Spelling: `npm run check:spelling`
-- Sync banner SVG version/test-count: `npm run sync:banner` (check-only: `npm run check:banner`)
+- Sync banner SVG version: `npm run sync:banner` (check-only: `npm run check:banner`)
 - Regenerate llms.txt: `npm run update:llms-txt` (check-only: `npm run check:llms-txt`)
 - Regenerate the skills-index Lines column + counts: `npm run update:skills-index` (check-only: `npm run check:skills-index`, gated in `validate:all`)
 - Regenerate the bug-report version dropdown (`.github/ISSUE_TEMPLATE/bug_report.yml`, derived from `package.json` + `CHANGELOG.md` + git tags, append-only so a shallow checkout never drops history): `npm run update:issue-template-versions` (check-only: `npm run check:issue-template-versions`, gated in `validate:all`). Self-healing in three layers: `release-prepare.yml` regenerates + stages it in its version-sync step (so the release PR passes the gate); `update-issue-template-versions.yml` auto-commits it on any `package.json`/`CHANGELOG.md` push to the default branch + a weekly cron (the same App-token pattern as `update-llms-txt.yml`); and the `--check` gate blocks a stale hand-edit on PRs.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,19 +61,16 @@ repos:
         name: Sync banner version from package.json
         entry: node scripts/sync-banner-version.js
         language: system
-        # always_run (not a files: filter): pre-commit's changed-file list
-        # excludes deletions, so a files: pattern would never fire when a
-        # *Tests.cs file is deleted and the banner test count would go stale
-        # until CI's validate-banner workflow caught it. The script is fast
-        # and idempotent, so run it on every commit.
-        always_run: true
+        # The banner version is derived solely from package.json, so the hook
+        # only needs to run when package.json or the banner itself is staged.
+        files: (^package\.json$|^docs/images/DxMessaging-banner\.svg$)
         pass_filenames: false
         stages:
           - pre-commit
         description: >-
-          Sync package version and test count into the SVG banner. If it
-          rewrites the banner, pre-commit reports the modified file; restage
-          and commit again.
+          Sync the package version into the SVG banner. If it rewrites the
+          banner, pre-commit reports the modified file; restage and commit
+          again.
       - id: prettier
         name: Prettier (markdown, JSON, asmdef, asmref, YAML)
         entry: npx --no-install prettier --write
@@ -99,8 +96,7 @@ repos:
         # .llm/skills/*.md file is deleted, even though llms.txt enumerates
         # the skills directory and would go stale until CI's
         # validate-llms-txt workflow caught it. The --check run is fast and
-        # idempotent, so run it on every commit (same rationale as
-        # sync-banner-version above).
+        # idempotent, so run it on every commit.
         always_run: true
         stages:
           - pre-commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refreshed the README banner (`docs/images/DxMessaging-banner.svg`): added
+  vertical separation between the tagline and the badge row, replaced the badges
+  with **Simple**, **MIT**, and the synced version, and re-drew the right panel
+  as one bus spine dispatching three aligned, color-coded message dots along
+  routes to labeled **Untargeted**, **Targeted**, and **Broadcast** destinations.
+- Simplified banner sync (`scripts/sync-banner-version.js`) to track only the
+  package version; the auto-derived test-count badge and its file-walking logic
+  were removed, along with the now-unneeded test-source triggers in the CI banner
+  gate and the pre-commit hook.
+
 ### Added
 
 - Added a **Diagnostics Tooling Exerciser** sample scene that deterministically

--- a/docs/images/DxMessaging-banner.svg
+++ b/docs/images/DxMessaging-banner.svg
@@ -32,41 +32,46 @@
     <circle cx="44" cy="44" r="7" fill="#ffd48e"/>
   </g>
 
-  <g transform="translate(132 44)">
-    <text x="0" y="0" font-family="'JetBrains Mono', 'SF Mono', monospace" font-size="10" font-weight="700" letter-spacing="0" fill="#9aa3af">UNITY / C# / MIT</text>
-    <text x="0" y="46" font-family="'Space Grotesk', 'IBM Plex Sans', 'Segoe UI', sans-serif" font-size="44" font-weight="700" letter-spacing="0" fill="#e9eef4">DxMessaging</text>
-    <text x="0" y="78" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif" font-size="17" font-weight="700" letter-spacing="0" fill="#f4a836">Decoupled, simple systems.</text>
-    <text x="0" y="103" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif" font-size="13" font-weight="500" letter-spacing="0" fill="#9aa3af">Typed routes. Managed listeners. Editor visibility.</text>
+  <g transform="translate(132 40)">
+    <text x="0" y="0" font-family="'JetBrains Mono', 'SF Mono', monospace" font-size="10" font-weight="700" letter-spacing="0.5" fill="#9aa3af">UNITY &#183; C#</text>
+    <text x="0" y="44" font-family="'Space Grotesk', 'IBM Plex Sans', 'Segoe UI', sans-serif" font-size="44" font-weight="700" letter-spacing="0" fill="#e9eef4">DxMessaging</text>
+    <text x="0" y="76" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif" font-size="17" font-weight="700" letter-spacing="0" fill="#f4a836">Decoupled, simple systems.</text>
+    <text x="0" y="100" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif" font-size="13" font-weight="500" letter-spacing="0" fill="#9aa3af">Typed routes. Managed listeners. Editor visibility.</text>
   </g>
 
-  <g transform="translate(132 150)" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif" font-size="12" font-weight="800">
-    <rect x="0" y="0" width="108" height="28" rx="8" fill="#f4a836"/>
-    <text x="54" y="18" text-anchor="middle" fill="#0d1117">OpenUPM</text>
-    <rect x="120" y="0" width="112" height="28" rx="8" fill="none" stroke="#7fb88a" stroke-width="1.5"/>
-    <text data-sync="test-count" x="176" y="18" text-anchor="middle" fill="#7fb88a">1500+ Tests</text>
+  <g transform="translate(132 158)" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif" font-size="12" font-weight="800">
+    <rect x="0" y="0" width="84" height="28" rx="8" fill="#f4a836"/>
+    <text x="42" y="18" text-anchor="middle" fill="#0d1117">Simple</text>
+    <rect x="96" y="0" width="58" height="28" rx="8" fill="none" stroke="#4a5462" stroke-width="1.5"/>
+    <text x="125" y="18" text-anchor="middle" fill="#c9d1d9">MIT</text>
     <!-- Version text must contain vX.Y.Z for version sync. -->
-    <rect x="244" y="0" width="76" height="28" rx="8" fill="#0c1016" stroke="#232c38" stroke-width="1"/>
-    <text data-sync="version" x="282" y="18" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', monospace" font-size="11" font-weight="800" fill="#e9eef4">v3.2.0</text>
+    <rect x="166" y="0" width="76" height="28" rx="8" fill="#0c1016" stroke="#232c38" stroke-width="1"/>
+    <text data-sync="version" x="204" y="18" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', monospace" font-size="11" font-weight="800" fill="#e9eef4">v3.2.0</text>
   </g>
 
-  <g transform="translate(536 42)" filter="url(#dxBannerSoftShadow)">
-    <rect x="0" y="0" width="226" height="120" rx="8" fill="#0c1016" stroke="#232c38"/>
-    <text x="18" y="27" font-family="'JetBrains Mono', 'SF Mono', monospace" font-size="10" font-weight="800" letter-spacing="0" fill="#e9eef4">ONE BUS, THREE ROUTES</text>
-    <g transform="translate(14 47)">
-      <rect x="0" y="0" width="27" height="27" rx="6" fill="#111823" stroke="#232c38"/>
-      <text x="13.5" y="17.5" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', monospace" font-size="10" font-weight="800" fill="#7fa6d8">U</text>
-      <line x1="35" y1="13.5" x2="62" y2="13.5" stroke="#f4a836" stroke-width="2.4" stroke-linecap="round" opacity="0.82"/>
-      <rect x="69" y="3" width="21" height="21" rx="6" fill="#f4a836"/>
-      <line x1="98" y1="13.5" x2="126" y2="13.5" stroke="#f4a836" stroke-width="2.4" stroke-linecap="round" opacity="0.82"/>
-      <rect x="134" y="0" width="27" height="27" rx="6" fill="#111823" stroke="#232c38"/>
-      <text x="147.5" y="17.5" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', monospace" font-size="10" font-weight="800" fill="#ec4661">T</text>
-      <line x1="169" y1="13.5" x2="176" y2="13.5" stroke="#f4a836" stroke-width="2.4" stroke-linecap="round" opacity="0.82"/>
-      <rect x="184" y="0" width="27" height="27" rx="6" fill="#111823" stroke="#232c38"/>
-      <text x="197.5" y="17.5" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', monospace" font-size="10" font-weight="800" fill="#7fb88a">B</text>
-    </g>
-    <g transform="translate(18 88)" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif" font-size="10" font-weight="700">
-      <rect x="0" y="0" width="190" height="20" rx="6" fill="none" stroke="#232c38"/>
-      <text x="10" y="14" fill="#9aa3af">No direct scene references</text>
+  <g transform="translate(536 40)" filter="url(#dxBannerSoftShadow)">
+    <rect x="0" y="0" width="226" height="126" rx="8" fill="#0c1016" stroke="#232c38"/>
+    <text x="18" y="26" font-family="'JetBrains Mono', 'SF Mono', monospace" font-size="10" font-weight="800" letter-spacing="0.5" fill="#e9eef4">ONE BUS &#183; THREE ROUTES</text>
+    <rect x="18" y="44" width="5" height="68" rx="2.5" fill="url(#dxBannerAmber)"/>
+    <g font-family="'IBM Plex Sans', 'Segoe UI', sans-serif" font-size="12" font-weight="700">
+      <g>
+        <circle cx="32" cy="54" r="4.5" fill="#7fa6d8"/>
+        <line x1="40" y1="54" x2="118" y2="54" stroke="#7fa6d8" stroke-width="2" stroke-linecap="round" stroke-dasharray="2 4" opacity="0.75"/>
+        <polygon points="120,54 113,50.5 113,57.5" fill="#7fa6d8"/>
+        <text x="132" y="58" fill="#7fa6d8">Untargeted</text>
+      </g>
+      <g>
+        <circle cx="32" cy="78" r="4.5" fill="#ec4661"/>
+        <line x1="40" y1="78" x2="118" y2="78" stroke="#ec4661" stroke-width="2" stroke-linecap="round" stroke-dasharray="2 4" opacity="0.75"/>
+        <polygon points="120,78 113,74.5 113,81.5" fill="#ec4661"/>
+        <text x="132" y="82" fill="#ec4661">Targeted</text>
+      </g>
+      <g>
+        <circle cx="32" cy="102" r="4.5" fill="#7fb88a"/>
+        <line x1="40" y1="102" x2="118" y2="102" stroke="#7fb88a" stroke-width="2" stroke-linecap="round" stroke-dasharray="2 4" opacity="0.75"/>
+        <polygon points="120,102 113,98.5 113,105.5" fill="#7fb88a"/>
+        <text x="132" y="106" fill="#7fb88a">Broadcast</text>
+      </g>
     </g>
   </g>
 

--- a/scripts/__tests__/sync-banner-version.test.js
+++ b/scripts/__tests__/sync-banner-version.test.js
@@ -8,50 +8,12 @@ const path = require("node:path");
 
 const {
   VERSION_PATTERN,
-  TEST_COUNT_PATTERN,
   analyzeBanner,
-  stripSourceComments,
-  countTestMarkers,
-  roundTestCount,
   getVersionBadge,
   readPackageVersion,
   syncBanner,
   validateBanner
 } = require("../sync-banner-version.js");
-
-test("roundTestCount floors to the nearest hundred but never to zero", () => {
-  for (const [input, expected] of [
-    [1234, 1200],
-    [100, 100],
-    [199, 100],
-    [99, 99],
-    [0, 0]
-  ]) {
-    assert.equal(roundTestCount(input), expected);
-  }
-});
-
-test("stripSourceComments removes comments but keeps URLs", () => {
-  const source = 'int x = 1; // trailing\n/* block\ncomment */\nstring u = "https://a.b";';
-  const stripped = stripSourceComments(source);
-  assert.ok(!stripped.includes("trailing"));
-  assert.ok(!stripped.includes("comment"));
-  assert.ok(stripped.includes("https://a.b"));
-});
-
-test("countTestMarkers counts C# test attributes outside comments", () => {
-  const csharp = [
-    "[Test]",
-    "public void First() {}",
-    "// [Test] commented out",
-    "[UnityTest]",
-    "public IEnumerator Second() { yield break; }",
-    "[TestCase(1)]",
-    "public void Third(int x) {}"
-  ].join("\n");
-  assert.equal(countTestMarkers("Foo/BarTests.cs", csharp), 3);
-  assert.equal(countTestMarkers("Foo/bar.js", csharp), 0);
-});
 
 test("getVersionBadge output matches VERSION_PATTERN and embeds the version", () => {
   const badge = getVersionBadge("1.2.3");
@@ -59,19 +21,10 @@ test("getVersionBadge output matches VERSION_PATTERN and embeds the version", ()
   assert.ok(VERSION_PATTERN.test(badge));
 });
 
-test("TEST_COUNT_PATTERN matches the banner test-count text element", () => {
-  const svgText = '<text data-sync="test-count" x="176" y="18" fill="#22d3ee">500+ Tests</text>';
-  const match = svgText.match(TEST_COUNT_PATTERN);
-  assert.ok(match);
-  assert.equal(match[2], "500+ Tests");
-  assert.ok(!'<text x="176" y="18" fill="#22d3ee">500+ Tests</text>'.match(TEST_COUNT_PATTERN));
-});
-
-test("real README banner exposes sync anchors", () => {
+test("real README banner exposes the version sync anchor", () => {
   const repoRoot = path.resolve(__dirname, "..", "..");
   const result = analyzeBanner({ repoRoot });
   assert.equal(result.currentVersion, readPackageVersion(path.join(repoRoot, "package.json")));
-  assert.equal(result.currentTestCountLabel, result.testCountLabel);
   assert.ok(result.svgContent.includes("DxKit-family amber DxMessaging banner"));
   assert.ok(result.svgContent.includes("Decoupled, simple systems."));
   assert.ok(result.svgContent.includes("#f4a836"));
@@ -91,38 +44,20 @@ test("readPackageVersion returns semver and rejects invalid versions", (t) => {
   assert.throws(() => readPackageVersion(bad), /Invalid version format/);
 });
 
-test("syncBanner updates the SVG badge, never stages, and is idempotent", () => {
+test("syncBanner updates the SVG version badge, never stages, and is idempotent", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "banner-repo-"));
   try {
     fs.writeFileSync(path.join(repoRoot, "package.json"), '{"version":"9.9.9"}', "utf8");
-    const testsDir = path.join(repoRoot, "Tests");
-    fs.mkdirSync(testsDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(testsDir, "SampleTests.cs"),
-      "[Test]\npublic void One() {}\n[Test]\npublic void Two() {}\n",
-      "utf8"
-    );
-    const docsTestsDir = path.join(repoRoot, ".docs-tests");
-    fs.mkdirSync(docsTestsDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(docsTestsDir, "DocsSnippetCompilationTests.cs"),
-      "[Test]\npublic void DocsOne() {}\n",
-      "utf8"
-    );
     const svgPath = path.join(repoRoot, "docs", "images", "DxMessaging-banner.svg");
     fs.mkdirSync(path.dirname(svgPath), { recursive: true });
-    const svg = `<svg>${getVersionBadge("0.0.1")}\n<text data-sync="test-count">900+ Tests</text></svg>`;
-    fs.writeFileSync(svgPath, svg, "utf8");
+    fs.writeFileSync(svgPath, `<svg>${getVersionBadge("0.0.1")}</svg>`, "utf8");
 
     const first = syncBanner({ repoRoot });
     assert.equal(first.updated, true);
     assert.equal(first.version, "9.9.9");
-    assert.equal(first.testCount, 3);
-    assert.equal(first.testCountLabel, "3+ Tests");
 
     const updatedSvg = fs.readFileSync(svgPath, "utf8");
     assert.ok(updatedSvg.includes(">v9.9.9</text>"));
-    assert.ok(updatedSvg.includes("3+ Tests"));
 
     const second = syncBanner({ repoRoot });
     assert.equal(second.updated, false);
@@ -131,40 +66,22 @@ test("syncBanner updates the SVG badge, never stages, and is idempotent", () => 
   }
 });
 
-test("validateBanner requires the current rounded test-count label", () => {
+test("validateBanner flags a stale version badge and passes when current", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "banner-check-"));
   try {
     fs.writeFileSync(path.join(repoRoot, "package.json"), '{"version":"1.2.3"}', "utf8");
-    const testsDir = path.join(repoRoot, "Tests");
-    fs.mkdirSync(testsDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(testsDir, "SampleTests.cs"),
-      Array.from({ length: 123 }, (_, index) => `[Test]\npublic void T${index}() {}`).join("\n"),
-      "utf8"
-    );
     const svgPath = path.join(repoRoot, "docs", "images", "DxMessaging-banner.svg");
     fs.mkdirSync(path.dirname(svgPath), { recursive: true });
-    const writeSvg = (label) =>
-      fs.writeFileSync(
-        svgPath,
-        `<svg>${getVersionBadge("1.2.3")}<text data-sync="test-count">${label}</text></svg>`,
-        "utf8"
-      );
+    const writeSvg = (version) =>
+      fs.writeFileSync(svgPath, `<svg>${getVersionBadge(version)}</svg>`, "utf8");
 
-    for (const { label, ok, error } of [
-      { label: "100+ Tests", ok: true },
-      { label: "99+ Tests", ok: false, error: /expected 100\+ Tests.*is stale/ },
-      { label: "124+ Tests", ok: false, error: /expected 100\+ Tests.*overstates/ }
-    ]) {
-      writeSvg(label);
-      const result = validateBanner({ repoRoot });
-      assert.equal(result.ok, ok, label);
-      if (error) {
-        assert.match(result.errors.join("\n"), error);
-      } else {
-        assert.deepEqual(result.errors, []);
-      }
-    }
+    writeSvg("1.2.3");
+    assert.deepEqual(validateBanner({ repoRoot }).errors, []);
+
+    writeSvg("1.0.0");
+    const stale = validateBanner({ repoRoot });
+    assert.equal(stale.ok, false);
+    assert.match(stale.errors.join("\n"), /version badge is v1\.0\.0; expected v1\.2\.3/);
   } finally {
     fs.rmSync(repoRoot, { recursive: true, force: true });
   }

--- a/scripts/sync-banner-version.js
+++ b/scripts/sync-banner-version.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 /**
  * Cross-platform banner sync.
- * Keeps docs/images/DxMessaging-banner.svg aligned with package.json version
- * and the rounded C# test count (Tests/ + SourceGenerators/ + .docs-tests/).
+ * Keeps docs/images/DxMessaging-banner.svg aligned with package.json version.
  *
  * Usage:
  *   node scripts/sync-banner-version.js [--check]
@@ -16,66 +15,20 @@
 
 const fs = require("fs");
 const path = require("path");
-const { walkFiles } = require("./lib/repo-files");
 
 const VERSION_PATTERN =
   /(<text\b(?=[^>]*\bdata-sync="version")[^>]*>v)(\d+\.\d+\.\d+[^<]*)(<\/text>)/;
 const VERSION_VALUE_PATTERN =
   /<text\b(?=[^>]*\bdata-sync="version")[^>]*>v(\d+\.\d+\.\d+[^<]*)<\/text>/;
-const TEST_COUNT_PATTERN =
-  /(<text\b(?=[^>]*\bdata-sync="test-count")[^>]*>)(\d+\+ Tests)(<\/text>)/;
-const TEST_FILE_NAME_PATTERN = /(?:Test|Tests)\.cs$/;
-const TEST_ROOTS = ["Tests", "SourceGenerators", ".docs-tests"];
 
-function stripSourceComments(content) {
-  return content.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
-}
-
-function countTestMarkers(filePath, content) {
-  if (!filePath.endsWith(".cs")) {
-    return 0;
-  }
-  const source = stripSourceComments(content);
-  return (source.match(/\[(?:UnityTest|Test|TestCase|TestCaseSource|Theory|Fact)\b/g) ?? []).length;
-}
-
-function getRepositoryTestFiles(repoRoot) {
-  const results = [];
-  for (const relativeRoot of TEST_ROOTS) {
-    const absoluteRoot = path.join(repoRoot, relativeRoot);
-    if (!fs.existsSync(absoluteRoot)) {
-      continue;
-    }
-    results.push(
-      ...walkFiles(absoluteRoot, {
-        match: (fullPath, entry) => TEST_FILE_NAME_PATTERN.test(entry.name),
-        // Preserve the prior fail-hard behavior for unreadable directories.
-        onError: (error) => {
-          throw error;
-        }
-      })
-    );
-  }
-  return results;
-}
-
-function calculateRepositoryTestCount(repoRoot) {
-  return getRepositoryTestFiles(repoRoot).reduce(
-    (sum, filePath) => sum + countTestMarkers(filePath, fs.readFileSync(filePath, "utf8")),
-    0
-  );
-}
-
-function roundTestCount(testCount) {
-  const rounded = Math.floor(testCount / 100) * 100;
-  return rounded < 1 ? testCount : rounded;
-}
-
+// Self-contained version badge. Only syncBanner's in-place regex replace mutates
+// the shipped banner; this helper exists purely so tests can assert VERSION_PATTERN
+// against a standalone fragment, so it carries its own group transform.
 function getVersionBadge(version) {
   return `<!-- Version text must contain vX.Y.Z for version sync. -->
-  <g transform="translate(244, 0)">
-    <rect x="0" y="0" width="76" height="28" rx="8" fill="#14111e" stroke="#332c45" stroke-width="1"/>
-    <text data-sync="version" x="38" y="18" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', monospace" font-size="11" font-weight="800" fill="#f5f3fb">v${version}</text>
+  <g transform="translate(166 0)" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif">
+    <rect x="0" y="0" width="76" height="28" rx="8" fill="#0c1016" stroke="#232c38" stroke-width="1"/>
+    <text data-sync="version" x="38" y="18" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', monospace" font-size="11" font-weight="800" fill="#e9eef4">v${version}</text>
   </g>`;
 }
 
@@ -93,35 +46,18 @@ function readPackageVersion(packageJsonPath) {
 function syncBanner(options = {}) {
   const analysis = analyzeBanner(options);
 
-  if (
-    analysis.currentVersion === analysis.version &&
-    analysis.currentTestCountLabel === analysis.testCountLabel
-  ) {
-    return {
-      updated: false,
-      version: analysis.version,
-      testCount: analysis.testCount,
-      testCountLabel: analysis.testCountLabel
-    };
+  if (analysis.currentVersion === analysis.version) {
+    return { updated: false, version: analysis.version };
   }
 
-  let updatedSvg = analysis.svgContent.replace(
+  const updatedSvg = analysis.svgContent.replace(
     VERSION_PATTERN,
     (_whole, prefix, _oldVersion, suffix) => `${prefix}${analysis.version}${suffix}`
-  );
-  updatedSvg = updatedSvg.replace(
-    TEST_COUNT_PATTERN,
-    (_whole, prefix, _oldLabel, suffix) => `${prefix}${analysis.testCountLabel}${suffix}`
   );
 
   fs.writeFileSync(analysis.svgPath, updatedSvg, "utf8");
 
-  return {
-    updated: true,
-    version: analysis.version,
-    testCount: analysis.testCount,
-    testCountLabel: analysis.testCountLabel
-  };
+  return { updated: true, version: analysis.version };
 }
 
 function analyzeBanner(options = {}) {
@@ -138,33 +74,21 @@ function analyzeBanner(options = {}) {
   }
 
   const version = readPackageVersion(packageJsonPath);
-  const testCount = calculateRepositoryTestCount(repoRoot);
-  const testCountLabel = `${roundTestCount(testCount)}+ Tests`;
 
   const svgContent = fs.readFileSync(svgPath, "utf8");
   if (!VERSION_PATTERN.test(svgContent)) {
     throw new Error(`Could not find version pattern in: ${svgPath}`);
   }
-  if (!TEST_COUNT_PATTERN.test(svgContent)) {
-    throw new Error(`Could not find test-count pattern in: ${svgPath}`);
-  }
 
   const currentVersionMatch = svgContent.match(VERSION_VALUE_PATTERN);
-  const currentTestCountMatch = svgContent.match(TEST_COUNT_PATTERN);
   const currentVersion = currentVersionMatch?.[1];
-  const currentTestCountLabel = currentTestCountMatch?.[2];
-  const currentTestCount = Number.parseInt(currentTestCountLabel, 10);
 
   return {
-    currentTestCount,
-    currentTestCountLabel,
     currentVersion,
     packageJsonPath,
     repoRoot,
     svgContent,
     svgPath,
-    testCount,
-    testCountLabel,
     version
   };
 }
@@ -176,14 +100,6 @@ function validateBanner(options = {}) {
   if (analysis.currentVersion !== analysis.version) {
     errors.push(
       `${analysis.svgPath}: version badge is v${analysis.currentVersion}; expected v${analysis.version}.`
-    );
-  }
-
-  if (analysis.currentTestCountLabel !== analysis.testCountLabel) {
-    const reason =
-      analysis.currentTestCount > analysis.testCount ? "overstates the marker count" : "is stale";
-    errors.push(
-      `${analysis.svgPath}: test-count badge is ${analysis.currentTestCountLabel}; expected ${analysis.testCountLabel} from ${analysis.testCount} test markers (${reason}).`
     );
   }
 
@@ -202,21 +118,16 @@ function main() {
         process.exit(1);
       }
       console.log(`Banner version is current: v${result.version}`);
-      console.log(
-        `Banner test count is current: ${result.testCountLabel} (${result.testCount} markers).`
-      );
       return;
     }
 
     const result = syncBanner();
     if (!result.updated) {
       console.log(`Banner already has correct version: v${result.version}`);
-      console.log(`Banner already has correct test count: ${result.testCountLabel}`);
       return;
     }
 
     console.log(`Updated banner version to: v${result.version}`);
-    console.log(`Updated banner test count to: ${result.testCountLabel}`);
   } catch (error) {
     console.error(`Failed to ${checkMode ? "validate" : "sync"} banner: ${error.message}`);
     process.exit(1);
@@ -227,11 +138,7 @@ function main() {
 // (scripts/__tests__/sync-banner-version.test.js).
 module.exports = {
   VERSION_PATTERN,
-  TEST_COUNT_PATTERN,
   analyzeBanner,
-  stripSourceComments,
-  countTestMarkers,
-  roundTestCount,
   getVersionBadge,
   readPackageVersion,
   syncBanner,


### PR DESCRIPTION
## What & why

Refreshes the README banner (`docs/images/DxMessaging-banner.svg`) per direct
product direction, and simplifies the banner-sync tooling that the change makes
redundant.

### Banner

- **Breathing room** — opened an ~18px vertical gap between the tagline block and
  the badge row (was ~3px; the crowding the direction called out).
- **Badges = Simple / MIT / version** — filled-amber `Simple` (brand ethos),
  neutral-outlined `MIT` (license), dark mono synced version pill. Replaces the
  old `OpenUPM` + auto-synced `N+ Tests` badges. Eyebrow trimmed to `UNITY · C#`
  so it no longer duplicates the MIT badge.
- **Right panel re-concept** — "ONE BUS · THREE ROUTES": a single amber **bus
  spine** dispatches three vertically-aligned, color-coded **message dots** along
  dashed routes (inline-polygon arrowheads) to labeled **Untargeted** (blue),
  **Targeted** (red), and **Broadcast** (green) destinations, matching the editor
  route-kind palette. Replaces the previous ambiguous `U / [amber] / T / B` row
  with uneven connector lengths.

### Sync tooling

Dropping the `N+ Tests` badge removed its entire auto-sync machinery:

- `scripts/sync-banner-version.js` is now **version-only** (removed the test-file
  walking, marker counting, comment stripping, and rounding). `getVersionBadge`
  is now a self-contained test fixture.
- `scripts/__tests__/sync-banner-version.test.js` rewritten for the version-only
  surface.
- CI banner change-filter (`.github/workflows/ci.yml`) no longer keys on
  `Tests/` / `SourceGenerators/` / `.docs-tests/`.
- `sync-banner-version` pre-commit hook switched from `always_run` to a
  `files:` filter on `package.json` + the banner.
- `.llm/context.md`, `CHANGELOG.md` updated.

## Verification

- `npm test` → **241 pass / 0 fail**
- `npm run check:banner` → green (`v3.2.0`)
- `cspell` (banner) → 0 issues; `markdownlint` (changed md) → 0 errors
- Banner rendered headless at 2× — no overflow/collision in the 800×200 canvas;
  badge gap and route alignment confirmed.

## Rendered banner

The banner renders self-contained (own dark background); it displays identically
in GitHub light/dark themes. No `<script>`, external refs, or `<marker>` elements
(GitHub-sanitization safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and tooling only; no runtime or messaging behavior. Slightly narrower CI/pre-commit coverage for banner checks when only test files change.
> 
> **Overview**
> **README banner** (`docs/images/DxMessaging-banner.svg`) is redesigned: more space between tagline and badges; badges are **Simple**, **MIT**, and the synced version (replacing OpenUPM and auto **N+ Tests**); eyebrow is `UNITY · C#`; the right panel shows one bus spine with three color-coded routes to **Untargeted**, **Targeted**, and **Broadcast**.
> 
> **Banner sync** is **version-only**: `scripts/sync-banner-version.js` no longer walks test files or updates a test-count badge. CI’s `banner` change filter drops `Tests/`, `SourceGenerators/`, and `.docs-tests/`; the `sync-banner-version` pre-commit hook runs only when `package.json` or the banner SVG change (not `always_run`). Tests and docs (`CHANGELOG.md`, `.llm/context.md`) match the slimmer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1391ab1c721daa585e0a7958699eb25de5d8f97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->