### PR TITLE
feat(editor): adopt design-system empty-state structure in diagnostics windows

### DIFF
--- a/Editor/DxMessagingEditorTheme.cs
+++ b/Editor/DxMessagingEditorTheme.cs
@@ -145,14 +145,17 @@ namespace DxMessaging.Editor
                 container.Add(titleLabel);
             }
 
-            Label bodyLabel = new(body);
-            if (!string.IsNullOrEmpty(bodyName))
+            if (!string.IsNullOrEmpty(body))
             {
-                bodyLabel.name = bodyName;
+                Label bodyLabel = new(body);
+                if (!string.IsNullOrEmpty(bodyName))
+                {
+                    bodyLabel.name = bodyName;
+                }
+                bodyLabel.AddToClassList(EmptyBodyClassName);
+                bodyLabel.style.whiteSpace = WhiteSpace.Normal;
+                container.Add(bodyLabel);
             }
-            bodyLabel.AddToClassList(EmptyBodyClassName);
-            bodyLabel.style.whiteSpace = WhiteSpace.Normal;
-            container.Add(bodyLabel);
 
             return container;
         }

--- a/Editor/DxMessagingEditorTheme.cs
+++ b/Editor/DxMessagingEditorTheme.cs
@@ -134,10 +134,10 @@ namespace DxMessaging.Editor
             VisualElement container = new();
             container.AddToClassList(EmptyClassName);
 
-            if (!string.IsNullOrEmpty(title))
+            if (!string.IsNullOrWhiteSpace(title))
             {
                 Label titleLabel = new(title);
-                if (!string.IsNullOrEmpty(titleName))
+                if (!string.IsNullOrWhiteSpace(titleName))
                 {
                     titleLabel.name = titleName;
                 }
@@ -145,10 +145,10 @@ namespace DxMessaging.Editor
                 container.Add(titleLabel);
             }
 
-            if (!string.IsNullOrEmpty(body))
+            if (!string.IsNullOrWhiteSpace(body))
             {
                 Label bodyLabel = new(body);
-                if (!string.IsNullOrEmpty(bodyName))
+                if (!string.IsNullOrWhiteSpace(bodyName))
                 {
                     bodyLabel.name = bodyName;
                 }

--- a/Editor/DxMessagingEditorTheme.cs
+++ b/Editor/DxMessagingEditorTheme.cs
@@ -25,6 +25,8 @@ namespace DxMessaging.Editor
         internal const string SearchClassName = "dx-search";
         internal const string CardClassName = "dx-card";
         internal const string CardLabelClassName = "dx-card__label";
+        internal const string EmptyClassName = "dx-empty";
+        internal const string EmptyTitleClassName = "dx-empty__title";
         internal const string EmptyBodyClassName = "dx-empty__body";
         internal const string ButtonAccentClassName = "dx-btn-accent";
         internal const string ButtonGhostClassName = "dx-btn-ghost";
@@ -114,6 +116,45 @@ namespace DxMessaging.Editor
                     element.AddToClassList(TypeBadgeBroadcastClassName);
                     break;
             }
+        }
+
+        /// <summary>
+        /// Builds a themed empty-state block: a centered <c>.dx-empty</c> container holding an
+        /// optional bold <c>.dx-empty__title</c> headline and a muted, wrapping
+        /// <c>.dx-empty__body</c> detail label. Callers may name the title/body labels so tests
+        /// and callbacks can query them.
+        /// </summary>
+        internal static VisualElement CreateEmptyState(
+            string title,
+            string body,
+            string bodyName = null,
+            string titleName = null
+        )
+        {
+            VisualElement container = new();
+            container.AddToClassList(EmptyClassName);
+
+            if (!string.IsNullOrEmpty(title))
+            {
+                Label titleLabel = new(title);
+                if (!string.IsNullOrEmpty(titleName))
+                {
+                    titleLabel.name = titleName;
+                }
+                titleLabel.AddToClassList(EmptyTitleClassName);
+                container.Add(titleLabel);
+            }
+
+            Label bodyLabel = new(body);
+            if (!string.IsNullOrEmpty(bodyName))
+            {
+                bodyLabel.name = bodyName;
+            }
+            bodyLabel.AddToClassList(EmptyBodyClassName);
+            bodyLabel.style.whiteSpace = WhiteSpace.Normal;
+            container.Add(bodyLabel);
+
+            return container;
         }
 
         private static StyleSheet LoadStyleSheet(string path)

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -26,6 +26,7 @@ namespace DxMessaging.Editor.Windows
         internal const string ExportButtonName = "dxmessaging-flow-graph-export";
         internal const string ContentName = "dxmessaging-flow-graph-content";
         internal const string EmptyStateLabelName = "dxmessaging-flow-graph-empty";
+        internal const string EmptyStateTitleLabelName = "dxmessaging-flow-graph-empty-title";
         internal const string RouteMapName = "dxmessaging-flow-graph-route-map";
         internal const string RouteMapRouteClassName = "dxmessaging-flow-graph-route-map-route";
         internal const string RouteMapMessageLabelName = "dxmessaging-flow-graph-route-map-message";
@@ -552,17 +553,22 @@ namespace DxMessaging.Editor.Windows
 
             if (!hasGraphItems && !hasWarnings)
             {
-                string emptyText =
+                bool noRegistrations =
                     snapshot.ComponentNodes.Count == 0
                     && snapshot.MessageNodes.Count == 0
                     && snapshot.Edges.Count == 0
                     && snapshot.TracePaths.Count == 0
-                    && snapshot.Warnings.Count == 0
-                        ? "No MessagingComponent registrations are loaded in open scenes."
-                        : "No graph items match the current filter.";
-                Label empty = new(emptyText) { name = EmptyStateLabelName };
-                empty.AddToClassList(DxMessagingEditorTheme.EmptyBodyClassName);
-                empty.style.whiteSpace = WhiteSpace.Normal;
+                    && snapshot.Warnings.Count == 0;
+                string emptyTitle = noRegistrations ? "No registrations" : "No matches";
+                string emptyText = noRegistrations
+                    ? "No MessagingComponent registrations are loaded in open scenes."
+                    : "No graph items match the current filter.";
+                VisualElement empty = DxMessagingEditorTheme.CreateEmptyState(
+                    emptyTitle,
+                    emptyText,
+                    bodyName: EmptyStateLabelName,
+                    titleName: EmptyStateTitleLabelName
+                );
                 content.Add(empty);
             }
             else if (hasGraphItems)

--- a/Editor/Windows/DxMessagingMessageMonitorWindow.cs
+++ b/Editor/Windows/DxMessagingMessageMonitorWindow.cs
@@ -38,6 +38,7 @@ namespace DxMessaging.Editor.Windows
         internal const string ContentContainerName = "dxmessaging-monitor-content";
         internal const string MessageSectionName = "dxmessaging-monitor-message-section";
         internal const string EmptyStateLabelName = "dxmessaging-monitor-empty";
+        internal const string EmptyStateTitleLabelName = "dxmessaging-monitor-empty-title";
         internal const string MessageTypeLabelName = "dxmessaging-monitor-message-type";
         internal const string RouteKindLabelName = "dxmessaging-monitor-route-kind";
         internal const string ContextLabelName = "dxmessaging-monitor-context";
@@ -291,7 +292,7 @@ namespace DxMessaging.Editor.Windows
             if (!snapshot.Available)
             {
                 root.Add(content);
-                AddEmptyState(content, snapshot.UnavailableReason);
+                AddEmptyState(content, "Monitor unavailable", snapshot.UnavailableReason);
                 content.Add(CreateComponentPanel(componentEntries));
                 return;
             }
@@ -491,7 +492,8 @@ namespace DxMessaging.Editor.Windows
             {
                 AddEmptyState(
                     messageSection,
-                    "Diagnostics are Off. Enable diagnostics to collect message history."
+                    "Diagnostics are Off",
+                    "Enable diagnostics to collect message history."
                 );
                 return;
             }
@@ -500,6 +502,7 @@ namespace DxMessaging.Editor.Windows
             {
                 AddEmptyState(
                     messageSection,
+                    "No messages yet",
                     "Diagnostics are On. No messages have been recorded yet."
                 );
                 return;
@@ -507,7 +510,11 @@ namespace DxMessaging.Editor.Windows
 
             if (filteredEntries.Count == 0)
             {
-                AddEmptyState(messageSection, "No messages match the current filter.");
+                AddEmptyState(
+                    messageSection,
+                    "No matches",
+                    "No messages match the current filter."
+                );
                 return;
             }
 
@@ -1374,11 +1381,14 @@ namespace DxMessaging.Editor.Windows
             return string.Join("/", segments);
         }
 
-        private static void AddEmptyState(VisualElement root, string text)
+        private static void AddEmptyState(VisualElement root, string title, string body)
         {
-            Label empty = new(text) { name = EmptyStateLabelName };
-            empty.AddToClassList(DxMessagingEditorTheme.EmptyBodyClassName);
-            empty.style.whiteSpace = WhiteSpace.Normal;
+            VisualElement empty = DxMessagingEditorTheme.CreateEmptyState(
+                title,
+                body,
+                bodyName: EmptyStateLabelName,
+                titleName: EmptyStateTitleLabelName
+            );
             empty.style.marginTop = 8;
             root.Add(empty);
         }

--- a/Tests/Editor/DxMessagingEditorThemeTests.cs
+++ b/Tests/Editor/DxMessagingEditorThemeTests.cs
@@ -107,11 +107,13 @@ namespace DxMessaging.Tests.Editor
             Assert.That(body.style.whiteSpace.value, Is.EqualTo(WhiteSpace.Normal));
         }
 
-        [Test]
-        public void CreateEmptyStateOmitsTitleWhenBlank()
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void CreateEmptyStateOmitsTitleWhenBlank(string blankTitle)
         {
             VisualElement empty = DxMessagingEditorTheme.CreateEmptyState(
-                title: null,
+                blankTitle,
                 body: "Body only.",
                 bodyName: "body-name"
             );
@@ -124,12 +126,14 @@ namespace DxMessaging.Tests.Editor
             Assert.That(empty.Q<Label>("body-name"), Is.Not.Null);
         }
 
-        [Test]
-        public void CreateEmptyStateOmitsBodyWhenBlank()
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void CreateEmptyStateOmitsBodyWhenBlank(string blankBody)
         {
             VisualElement empty = DxMessagingEditorTheme.CreateEmptyState(
                 "Title only",
-                body: null,
+                blankBody,
                 titleName: "title-name"
             );
 

--- a/Tests/Editor/DxMessagingEditorThemeTests.cs
+++ b/Tests/Editor/DxMessagingEditorThemeTests.cs
@@ -81,6 +81,50 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
+        public void CreateEmptyStateBuildsContainerWithTitleAndBody()
+        {
+            VisualElement empty = DxMessagingEditorTheme.CreateEmptyState(
+                "No data",
+                "Nothing to show yet.",
+                bodyName: "body-name",
+                titleName: "title-name"
+            );
+
+            Assert.That(empty.ClassListContains(DxMessagingEditorTheme.EmptyClassName), Is.True);
+
+            Label title = empty.Q<Label>("title-name");
+            Assert.That(title, Is.Not.Null);
+            Assert.That(title.text, Is.EqualTo("No data"));
+            Assert.That(
+                title.ClassListContains(DxMessagingEditorTheme.EmptyTitleClassName),
+                Is.True
+            );
+
+            Label body = empty.Q<Label>("body-name");
+            Assert.That(body, Is.Not.Null);
+            Assert.That(body.text, Is.EqualTo("Nothing to show yet."));
+            Assert.That(body.ClassListContains(DxMessagingEditorTheme.EmptyBodyClassName), Is.True);
+            Assert.That(body.style.whiteSpace.value, Is.EqualTo(WhiteSpace.Normal));
+        }
+
+        [Test]
+        public void CreateEmptyStateOmitsTitleWhenBlank()
+        {
+            VisualElement empty = DxMessagingEditorTheme.CreateEmptyState(
+                title: null,
+                body: "Body only.",
+                bodyName: "body-name"
+            );
+
+            Assert.That(empty.ClassListContains(DxMessagingEditorTheme.EmptyClassName), Is.True);
+            Assert.That(
+                empty.Query<Label>(className: DxMessagingEditorTheme.EmptyTitleClassName).ToList(),
+                Is.Empty
+            );
+            Assert.That(empty.Q<Label>("body-name"), Is.Not.Null);
+        }
+
+        [Test]
         public void ApplyCompleteBorderSetsUniformOnePixelBorder()
         {
             VisualElement element = new();

--- a/Tests/Editor/DxMessagingEditorThemeTests.cs
+++ b/Tests/Editor/DxMessagingEditorThemeTests.cs
@@ -125,6 +125,23 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
+        public void CreateEmptyStateOmitsBodyWhenBlank()
+        {
+            VisualElement empty = DxMessagingEditorTheme.CreateEmptyState(
+                "Title only",
+                body: null,
+                titleName: "title-name"
+            );
+
+            Assert.That(empty.ClassListContains(DxMessagingEditorTheme.EmptyClassName), Is.True);
+            Assert.That(empty.Q<Label>("title-name"), Is.Not.Null);
+            Assert.That(
+                empty.Query<Label>(className: DxMessagingEditorTheme.EmptyBodyClassName).ToList(),
+                Is.Empty
+            );
+        }
+
+        [Test]
         public void ApplyCompleteBorderSetsUniformOnePixelBorder()
         {
             VisualElement element = new();

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -6474,9 +6474,19 @@ namespace DxMessaging.Tests.Editor
 
             DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot);
 
+            Label emptyBody = root.Q<Label>(DxMessagingFlowGraphWindow.EmptyStateLabelName);
+            Assert.That(emptyBody.text, Does.Contain("No MessagingComponent registrations"));
             Assert.That(
-                root.Q<Label>(DxMessagingFlowGraphWindow.EmptyStateLabelName).text,
-                Does.Contain("No MessagingComponent registrations")
+                emptyBody.ClassListContains(DxMessagingEditorTheme.EmptyBodyClassName),
+                Is.True
+            );
+            Assert.That(
+                emptyBody.parent.ClassListContains(DxMessagingEditorTheme.EmptyClassName),
+                Is.True
+            );
+            Assert.That(
+                root.Q<Label>(DxMessagingFlowGraphWindow.EmptyStateTitleLabelName).text,
+                Is.EqualTo("No registrations")
             );
             Assert.That(
                 root.Query<VisualElement>(className: DxMessagingFlowGraphWindow.EdgeRowClassName)

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -6254,10 +6254,12 @@ namespace DxMessaging.Tests.Editor
                     .ToList(),
                 Is.Empty
             );
-            Assert.That(
-                root.Q<Label>(DxMessagingFlowGraphWindow.EmptyStateLabelName).text,
-                Does.Contain("No graph items match")
-            );
+            Label emptyBody = root.Q<Label>(DxMessagingFlowGraphWindow.EmptyStateLabelName);
+            Assert.That(emptyBody, Is.Not.Null);
+            Assert.That(emptyBody.text, Does.Contain("No graph items match"));
+            Label emptyTitle = root.Q<Label>(DxMessagingFlowGraphWindow.EmptyStateTitleLabelName);
+            Assert.That(emptyTitle, Is.Not.Null);
+            Assert.That(emptyTitle.text, Is.EqualTo("No matches"));
             Assert.That(
                 root.Q<Button>(DxMessagingFlowGraphWindow.ExportButtonName).enabledSelf,
                 Is.False
@@ -6475,6 +6477,7 @@ namespace DxMessaging.Tests.Editor
             DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot);
 
             Label emptyBody = root.Q<Label>(DxMessagingFlowGraphWindow.EmptyStateLabelName);
+            Assert.That(emptyBody, Is.Not.Null);
             Assert.That(emptyBody.text, Does.Contain("No MessagingComponent registrations"));
             Assert.That(
                 emptyBody.ClassListContains(DxMessagingEditorTheme.EmptyBodyClassName),
@@ -6484,10 +6487,9 @@ namespace DxMessaging.Tests.Editor
                 emptyBody.parent.ClassListContains(DxMessagingEditorTheme.EmptyClassName),
                 Is.True
             );
-            Assert.That(
-                root.Q<Label>(DxMessagingFlowGraphWindow.EmptyStateTitleLabelName).text,
-                Is.EqualTo("No registrations")
-            );
+            Label emptyTitle = root.Q<Label>(DxMessagingFlowGraphWindow.EmptyStateTitleLabelName);
+            Assert.That(emptyTitle, Is.Not.Null);
+            Assert.That(emptyTitle.text, Is.EqualTo("No registrations"));
             Assert.That(
                 root.Query<VisualElement>(className: DxMessagingFlowGraphWindow.EdgeRowClassName)
                     .ToList(),

--- a/Tests/Editor/DxMessagingMessageMonitorWindowTests.cs
+++ b/Tests/Editor/DxMessagingMessageMonitorWindowTests.cs
@@ -165,6 +165,7 @@ namespace DxMessaging.Tests.Editor
                 Is.Empty
             );
             Label emptyBody = root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateLabelName);
+            Assert.That(emptyBody, Is.Not.Null);
             Assert.That(emptyBody.text, Does.Contain("Enable"));
             Assert.That(
                 emptyBody.ClassListContains(DxMessagingEditorTheme.EmptyBodyClassName),
@@ -189,6 +190,56 @@ namespace DxMessaging.Tests.Editor
             Assert.That(
                 DxMessagingMessageMonitorWindow.CreateExportText(snapshot, snapshot.Entries),
                 Does.Contain("\"entryCount\": 0")
+            );
+        }
+
+        // The snapshot is built inside the test body (not passed as a parameter) because
+        // MessageMonitorSnapshot is internal, and a public [Test] method may not expose an
+        // internal parameter type (CS0051).
+        [TestCase("unavailable", "Monitor unavailable", "active global bus")]
+        [TestCase("diagnostics-off", "Diagnostics are Off", "Enable diagnostics")]
+        [TestCase("no-messages-yet", "No messages yet", "recorded")]
+        public void BuildMonitorUiEmptyStateHasExpectedTitleAndBody(
+            string state,
+            string expectedTitle,
+            string expectedBodySubstring
+        )
+        {
+            MessageMonitorSnapshot snapshot = state switch
+            {
+                "unavailable" => MessageMonitorSnapshot.Unavailable(
+                    "The active global bus is not the default DxMessaging MessageBus."
+                ),
+                "diagnostics-off" => new MessageMonitorSnapshot(
+                    diagnosticsEnabled: false,
+                    capacity: 8,
+                    entries: Array.Empty<MessageMonitorEntry>()
+                ),
+                _ => new MessageMonitorSnapshot(
+                    diagnosticsEnabled: true,
+                    capacity: 8,
+                    entries: Array.Empty<MessageMonitorEntry>()
+                ),
+            };
+            VisualElement root = new();
+
+            DxMessagingMessageMonitorWindow.BuildMonitorUi(root, snapshot);
+
+            Label title = root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateTitleLabelName);
+            Assert.That(title, Is.Not.Null);
+            Assert.That(title.text, Is.EqualTo(expectedTitle));
+            Assert.That(
+                title.ClassListContains(DxMessagingEditorTheme.EmptyTitleClassName),
+                Is.True
+            );
+
+            Label body = root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateLabelName);
+            Assert.That(body, Is.Not.Null);
+            Assert.That(body.text, Does.Contain(expectedBodySubstring));
+            Assert.That(body.ClassListContains(DxMessagingEditorTheme.EmptyBodyClassName), Is.True);
+            Assert.That(
+                body.parent.ClassListContains(DxMessagingEditorTheme.EmptyClassName),
+                Is.True
             );
         }
 
@@ -1259,6 +1310,10 @@ namespace DxMessaging.Tests.Editor
                 root.Query<VisualElement>(className: DxMessagingMessageMonitorWindow.RowClassName)
                     .ToList(),
                 Is.Empty
+            );
+            Assert.That(
+                root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateTitleLabelName).text,
+                Is.EqualTo("No matches")
             );
             Assert.That(
                 root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateLabelName).text,

--- a/Tests/Editor/DxMessagingMessageMonitorWindowTests.cs
+++ b/Tests/Editor/DxMessagingMessageMonitorWindowTests.cs
@@ -164,9 +164,23 @@ namespace DxMessaging.Tests.Editor
                     .ToList(),
                 Is.Empty
             );
+            Label emptyBody = root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateLabelName);
+            Assert.That(emptyBody.text, Does.Contain("Enable"));
             Assert.That(
-                root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateLabelName).text,
-                Does.Contain("Enable")
+                emptyBody.ClassListContains(DxMessagingEditorTheme.EmptyBodyClassName),
+                Is.True
+            );
+            Assert.That(
+                emptyBody.parent.ClassListContains(DxMessagingEditorTheme.EmptyClassName),
+                Is.True
+            );
+            Label emptyTitle = root.Q<Label>(
+                DxMessagingMessageMonitorWindow.EmptyStateTitleLabelName
+            );
+            Assert.That(emptyTitle, Is.Not.Null);
+            Assert.That(
+                emptyTitle.ClassListContains(DxMessagingEditorTheme.EmptyTitleClassName),
+                Is.True
             );
             Assert.That(
                 root.Q<Button>(DxMessagingMessageMonitorWindow.ExportButtonName).enabledSelf,
@@ -1668,8 +1682,12 @@ namespace DxMessaging.Tests.Editor
             DxMessagingMessageMonitorWindow.BuildMonitorUi(root, snapshot, new[] { component });
 
             Assert.That(
+                root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateTitleLabelName).text,
+                Is.EqualTo("Diagnostics are Off")
+            );
+            Assert.That(
                 root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateLabelName).text,
-                Does.Contain("Diagnostics are Off")
+                Does.Contain("Enable diagnostics")
             );
             Assert.That(
                 root.Query<VisualElement>(

--- a/Tests/Editor/DxMessagingMessageMonitorWindowTests.cs
+++ b/Tests/Editor/DxMessagingMessageMonitorWindowTests.cs
@@ -1311,14 +1311,14 @@ namespace DxMessaging.Tests.Editor
                     .ToList(),
                 Is.Empty
             );
-            Assert.That(
-                root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateTitleLabelName).text,
-                Is.EqualTo("No matches")
+            Label emptyTitle = root.Q<Label>(
+                DxMessagingMessageMonitorWindow.EmptyStateTitleLabelName
             );
-            Assert.That(
-                root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateLabelName).text,
-                Does.Contain("No messages match")
-            );
+            Assert.That(emptyTitle, Is.Not.Null);
+            Assert.That(emptyTitle.text, Is.EqualTo("No matches"));
+            Label emptyBody = root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateLabelName);
+            Assert.That(emptyBody, Is.Not.Null);
+            Assert.That(emptyBody.text, Does.Contain("No messages match"));
             Assert.That(
                 root.Q<VisualElement>(DxMessagingMessageMonitorWindow.DetailsPaneName),
                 Is.Null
@@ -1736,14 +1736,14 @@ namespace DxMessaging.Tests.Editor
 
             DxMessagingMessageMonitorWindow.BuildMonitorUi(root, snapshot, new[] { component });
 
-            Assert.That(
-                root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateTitleLabelName).text,
-                Is.EqualTo("Diagnostics are Off")
+            Label emptyTitle = root.Q<Label>(
+                DxMessagingMessageMonitorWindow.EmptyStateTitleLabelName
             );
-            Assert.That(
-                root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateLabelName).text,
-                Does.Contain("Enable diagnostics")
-            );
+            Assert.That(emptyTitle, Is.Not.Null);
+            Assert.That(emptyTitle.text, Is.EqualTo("Diagnostics are Off"));
+            Label emptyBody = root.Q<Label>(DxMessagingMessageMonitorWindow.EmptyStateLabelName);
+            Assert.That(emptyBody, Is.Not.Null);
+            Assert.That(emptyBody.text, Does.Contain("Enable diagnostics"));
             Assert.That(
                 root.Query<VisualElement>(
                         className: DxMessagingMessageMonitorWindow.ComponentRowClassName


### PR DESCRIPTION
## What

Adopt the design system's **empty-state structure** (`.dx-empty` container + `.dx-empty__title` headline + `.dx-empty__body` detail) in the Message Monitor and Flow Graph diagnostics windows.

Both windows previously rendered their primary "no data / disabled" empty states as a single bare `.dx-empty__body` label — leaving the `.dx-empty` and `.dx-empty__title` classes defined in `DxMessagingTheme.uss` but referenced by no C# (stylesheet ⟷ implementation drift, category **D1** in the editor-tooling plan).

## How

- **New shared helper** `DxMessagingEditorTheme.CreateEmptyState(title, body, bodyName, titleName)` — the single source of truth for the empty-state visual tree: a centered `.dx-empty` container holding an optional bold `.dx-empty__title` and a muted, wrapping `.dx-empty__body`.
- **Message Monitor** — the four primary empty states (unavailable, diagnostics-off, no-messages-yet, no-filter-match) now route through the helper with a short title headline + explanatory body.
- **Flow Graph** — the primary graph empty state (no-registrations / no-filter-match) does the same.
- **Left body-only by design:** the small inline notes (Monitor component-panel note, Flow route-map note) stay single-label — they are contextual sub-notes, not full-panel empty states, so a centered headline would be noise.

The body labels keep their existing element names (`…-empty`), so existing queries/behavior are preserved; the title labels get new `…-empty-title` names.

## Tests

- `DxMessagingEditorThemeTests`: contract tests for the helper — full title+body structure, title-omitted-when-blank, and body-omitted-when-blank.
- `DxMessagingMessageMonitorWindowTests`: a data-driven `[TestCase]` test asserting the title + body for **every** snapshot-driven empty state (unavailable, diagnostics-off, and the previously-untested "No messages yet" zero-entries state), plus title assertions on the filter-empty path.
- `DxMessagingFlowGraphWindowTests`: structural assertions that the built empty state is a `.dx-empty` container carrying a `.dx-empty__title` + `.dx-empty__body`, with title assertions on both the no-registrations and filter-empty paths.
- Full EditMode assembly green: **438 passed / 0 failed** via the local Unity MCP `DxMcpTestRunner` loop (Unity 6000.4).

Two commits: the adoption, then an adversarial-review follow-up strengthening empty-state coverage.

## Scope / risk

Editor-only, presentation-only; no runtime cost, no public API change, compiles on the shipped 2021.3+ floor (only `VisualElement`/`Label`/`AddToClassList` used). `.dx-dot*`, `.dx-admonition__title`, `.dx-tip`/`.dx-danger`, and the columnar/subscription class groups are intentionally **not** touched here — they belong to their own follow-up feature PRs (live recorder, subscriptions section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only UI structure and copy split; no runtime or public API changes, and existing body label names are preserved for queries.
> 
> **Overview**
> Introduces **`DxMessagingEditorTheme.CreateEmptyState`** as the shared builder for the design-system empty UI: a **`.dx-empty`** wrapper with optional **`.dx-empty__title`** and **`.dx-empty__body`** labels (named for tests via optional `titleName` / `bodyName`).
> 
> **Message Monitor** and **Flow Graph** no longer use a lone **`.dx-empty__body`** label for main empty panels. They call the helper with short titles (e.g. *No matches*, *Diagnostics are Off*, *No registrations*) plus the existing explanatory copy. Body element names stay the same; new **`…-empty-title`** names were added for titles.
> 
> **Tests** cover the helper (full tree, omit title/body when blank) and window UI assertions for each monitor empty scenario and flow-graph empty paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f611f2fc75abd2eeb2b0de9eef66fb5cf3f8f42c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->