### PR TITLE
Use build-lock App credentials and runner identity

### DIFF
--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -217,7 +217,7 @@ jobs:
             printf 'unity-versions=%s\n' "$(jq -c '[.all[-1]]' "${file}")"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Check for required Unity license secrets
+      - name: Check for required licensed workflow secrets
         id: check-secrets
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}

--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -223,13 +223,15 @@ jobs:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          ORG_BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           if [ -n "${UNITY_SERIAL:-}" ] && \
              [ -n "${UNITY_EMAIL:-}" ] && \
              [ -n "${UNITY_PASSWORD:-}" ] && \
-             [ -n "${ORG_BUILD_LOCK_TOKEN:-}" ]; then
+             [ -n "${BUILD_LOCK_APP_ID:-}" ] && \
+             [ -n "${BUILD_LOCK_APP_PRIVATE_KEY:-}" ]; then
             echo "has-secrets=true" >> "${GITHUB_OUTPUT}"
           else
             echo "has-secrets=false" >> "${GITHUB_OUTPUT}"
@@ -437,9 +439,11 @@ jobs:
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: perf-${{ matrix.unity-version }}-${{ matrix.test-mode }}
+          runner-id: ${{ runner.name }}
           timeout-minutes: "300"
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Run Unity Test Runner
         id: run_tests
@@ -494,8 +498,10 @@ jobs:
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: perf-${{ matrix.unity-version }}-${{ matrix.test-mode }}
+          runner-id: ${{ runner.name }}
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Capture exact standalone player size
         if: ${{ matrix.test-mode == 'standalone' && steps.run_tests.outcome == 'success' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,9 +334,11 @@ jobs:
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-editmode
+          runner-id: ${{ runner.name }}
           timeout-minutes: "300"
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Run Unity Test Runner
         id: run_tests
@@ -371,8 +373,10 @@ jobs:
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-editmode
+          runner-id: ${{ runner.name }}
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       # CANCELLATION + TIMEOUT DIAGNOSTIC: when Unity 2022 hangs in csc the
       # runner step times out (or the operator cancels), and the verify
@@ -503,9 +507,11 @@ jobs:
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-unitypackage
+          runner-id: ${{ runner.name }}
           timeout-minutes: "300"
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Export the .unitypackage
         timeout-minutes: 120
@@ -537,8 +543,10 @@ jobs:
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-unitypackage
+          runner-id: ${{ runner.name }}
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Dump Unity log tail on failure or cancellation
         if: ${{ failure() || cancelled() }}

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -270,9 +270,11 @@ jobs:
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
+          runner-id: ${{ runner.name }}
           timeout-minutes: "300"
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Run Unity Test Runner
         id: run_tests
@@ -312,8 +314,10 @@ jobs:
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
+          runner-id: ${{ runner.name }}
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       # CANCELLATION + TIMEOUT DIAGNOSTIC: when Unity 2022 hangs in csc the
       # runner step times out (or the operator cancels), and the verify

--- a/.github/workflows/unity-gameci-experiment.yml
+++ b/.github/workflows/unity-gameci-experiment.yml
@@ -172,9 +172,11 @@ jobs:
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: game-ci-experiment
+          runner-id: ${{ runner.name }}
           timeout-minutes: "300"
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Run GameCI normal project mode
         id: game_ci
@@ -222,8 +224,10 @@ jobs:
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: game-ci-experiment
+          runner-id: ${{ runner.name }}
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Dump Unity log tail on failure or cancellation
         if: ${{ failure() || cancelled() }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -128,13 +128,15 @@ jobs:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          ORG_BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           if [ -n "${UNITY_SERIAL:-}" ] && \
              [ -n "${UNITY_EMAIL:-}" ] && \
              [ -n "${UNITY_PASSWORD:-}" ] && \
-             [ -n "${ORG_BUILD_LOCK_TOKEN:-}" ]; then
+             [ -n "${BUILD_LOCK_APP_ID:-}" ] && \
+             [ -n "${BUILD_LOCK_APP_PRIVATE_KEY:-}" ]; then
             echo "has-secrets=true" >> "${GITHUB_OUTPUT}"
           else
             echo "has-secrets=false" >> "${GITHUB_OUTPUT}"
@@ -389,9 +391,11 @@ jobs:
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
+          runner-id: ${{ runner.name }}
           timeout-minutes: "300"
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Run Unity Test Runner
         id: run_tests
@@ -435,8 +439,10 @@ jobs:
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
+          runner-id: ${{ runner.name }}
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       # CANCELLATION + TIMEOUT DIAGNOSTIC: when Unity 2022 hangs in csc the
       # runner step times out (or the operator cancels), and the verify

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -122,7 +122,7 @@ jobs:
             echo "test-modes=${modes}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Check for required Unity license secrets
+      - name: Check for required Unity CI secrets
         id: check-secrets
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}

--- a/docs/ops/ambiguous-release-migration.md
+++ b/docs/ops/ambiguous-release-migration.md
@@ -104,6 +104,10 @@ organization lock.
     uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1
     with:
       lock-name: wallstop-organization-builds
+      runner-id: ${{ runner.name }}
+    env:
+      BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+      BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
   ```
 
   The matching release step uses `release-build-lock@v1` with `if:
@@ -181,6 +185,8 @@ tracked file or generated artifact.
 - [ ] Confirm Unity workflows can read the three required secret names:
       `UNITY_SERIAL`, `UNITY_EMAIL`, and `UNITY_PASSWORD` (the classic-serial
       activation path; the single CI activation path).
+- [ ] Confirm licensed Unity workflows can read `BUILD_LOCK_APP_ID` and
+      `BUILD_LOCK_APP_PRIVATE_KEY` for the central organization lock.
 - [ ] Confirm the retired `UNITY_LICENSING_SERVER` secret is removed from the
       workflows. The `validate-unity-license` action fails the run if it is still
       set. No local Unity license is needed: local verification runs on the host

--- a/docs/ops/ci-and-github-settings.md
+++ b/docs/ops/ci-and-github-settings.md
@@ -40,6 +40,10 @@ then acquire the central lock immediately before the licensed Unity section:
   uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1
   with:
     lock-name: wallstop-organization-builds
+    runner-id: ${{ runner.name }}
+  env:
+    BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+    BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 ```
 
 The matching release step uses `release-build-lock@v1` with `if:
@@ -222,6 +226,8 @@ Set secret names without documenting values:
 - `UNITY_SERIAL`
 - `UNITY_EMAIL`
 - `UNITY_PASSWORD`
+- `BUILD_LOCK_APP_ID`
+- `BUILD_LOCK_APP_PRIVATE_KEY`
 
 CI activates Unity with a classic serial: `UNITY_SERIAL` plus the account
 `UNITY_EMAIL` and `UNITY_PASSWORD` are the single CI activation path. A serial

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -253,6 +253,38 @@ test("standalone static-check workflows are not reintroduced", () => {
   }
 });
 
+test("copyable build-lock documentation follows the runner and App credential contract", () => {
+  for (const relativePath of [
+    "docs/ops/ci-and-github-settings.md",
+    "docs/ops/ambiguous-release-migration.md"
+  ]) {
+    const source = fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
+    const acquireExample =
+      /uses: Ambiguous-Interactive\/ambiguous-organization-build-lock\/\.github\/actions\/acquire-build-lock@v1[\s\S]*?```/.exec(
+        source
+      );
+
+    assert.ok(acquireExample, `${relativePath} must contain a copyable acquire example`);
+    assert.match(acquireExample[0], /runner-id: \$\{\{ runner\.name \}\}/, relativePath);
+    assert.match(
+      acquireExample[0],
+      /BUILD_LOCK_APP_ID: \$\{\{ secrets\.BUILD_LOCK_APP_ID \}\}/,
+      relativePath
+    );
+    assert.match(
+      acquireExample[0],
+      /BUILD_LOCK_APP_PRIVATE_KEY: \$\{\{ secrets\.BUILD_LOCK_APP_PRIVATE_KEY \}\}/,
+      relativePath
+    );
+    assert.match(source, /`BUILD_LOCK_APP_ID`/, `${relativePath} must list the App ID secret`);
+    assert.match(
+      source,
+      /`BUILD_LOCK_APP_PRIVATE_KEY`/,
+      `${relativePath} must list the App key secret`
+    );
+  }
+});
+
 test("release workflows pin App write scopes and denied-push diagnostics", () => {
   const prepare = fs.readFileSync(path.join(WORKFLOW_DIR, "release-prepare.yml"), "utf8");
   const tag = fs.readFileSync(path.join(WORKFLOW_DIR, "release-tag.yml"), "utf8");


### PR DESCRIPTION
## Summary

- pass `${{ runner.name }}` identically to every organization lock acquire/release pair
- authenticate lock actions with the dedicated GitHub App credentials
- replace PAT-based license preflight checks and remove all legacy build-lock token references

## Why

This is the compatible consumer rollout for runner-aware lock serialization and renewable GitHub App authentication. The central lock configuration remains inactive until all consumers are deployed and old runs drain.

## Validation

- `actionlint -shellcheck= -pyflakes=` on all five changed workflows
- `npm run format:check`
- `npm run validate:all` (repository checks passed until the analyzer payload check reported the host lacks pinned .NET SDK 9.0.314)
- `npm test` (241/243 passed; two unrelated Windows-host limitations: symlink privilege and Bash Windows-path conversion)
- structural audit: 6 acquire/release pairs, 12 matching runner IDs, no `BUILD_LOCK_TOKEN` or `ORG_BUILD_LOCK_TOKEN`

Licensed workflows remain disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all licensed Unity jobs acquire and release the shared org lock; missing or misconfigured App secrets will skip or fail Unity CI until org secrets are provisioned, but there is no application runtime impact.
> 
> **Overview**
> **Rolls out the consumer side of runner-aware organization Unity locking** by switching every `acquire-build-lock` / `release-build-lock` pair to GitHub App credentials (`BUILD_LOCK_APP_ID`, `BUILD_LOCK_APP_PRIVATE_KEY`) and passing **`runner-id: ${{ runner.name }}`** on both sides.
> 
> **Preflight secret gates** in `perf-numbers.yml` and `unity-tests.yml` now require the build-lock App secrets (not `ORG_BUILD_LOCK_TOKEN` / `BUILD_LOCK_TOKEN`), with step names aligned to “licensed workflow” / “Unity CI” wording.
> 
> **Docs** (`ci-and-github-settings.md`, `ambiguous-release-migration.md`) update copyable YAML and required-secret lists to match. A **new CI test** asserts those docs stay in sync with the contract.
> 
> **Workflows touched:** `perf-numbers.yml`, `release.yml`, `unity-benchmarks.yml`, `unity-gameci-experiment.yml`, `unity-tests.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b75a585af63015b71473c4d952a6d3afdcb5b4a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->