### PR TITLE
Restore Unity validation for same-repository PRs

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -237,12 +237,12 @@ jobs:
     needs:
       - matrix-config
       - runner-preflight
-    # Licensed Unity never executes unmerged pull-request code. The aggregate
-    # required check accepts this intentional skip while protected pushes,
-    # schedules from the default branch, and controlled dispatches remain eligible.
+    # Same-repository pull requests run licensed validation behind approval from
+    # the protected unity-license environment. Fork pull requests remain static-only.
     if: >-
       ${{
-        github.event_name != 'pull_request' &&
+        (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository) &&
         (github.event_name != 'push' || github.ref_protected) &&
         needs.matrix-config.outputs.ci-owned-docs-only != 'true'
       }}
@@ -492,21 +492,48 @@ jobs:
     # Exactly always() -- NEVER a falsifiable job-level if. A skipped required
     # check counts as passing and the latest run on a SHA wins, so a guard that
     # can be false on a pull_request could launder a red/pending gate into a
-    # false green. The per-job skips (fork / docs-only / missing secrets) are
-    # tolerated via allowed-skips below, preserving the exact "skipped leg
-    # counts as success" semantics the 11 individual required contexts had.
+    # false green. The step below validates the only two intentional skip shapes:
+    # fork PRs skip both licensed jobs, while CI-owned docs-only PRs run preflight
+    # but skip the Unity matrix. Every other run must execute Unity successfully.
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Verify all Unity CI jobs succeeded (or skipped to success)
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}
-          # runner-preflight can skip on forks, and the whole unity-tests matrix
-          # skips on the docs-only / fork / no-secrets shapes; those skips must
-          # pass the gate exactly as the individual required contexts did.
-          # matrix-config has no intentional skip path because it produces the
-          # matrix and skip-policy outputs. A real failure or cancellation still
-          # fails.
-          allowed-skips: runner-preflight, unity-tests
+      - name: Verify Unity CI result shape
+        env:
+          MATRIX_CONFIG_RESULT: ${{ needs.matrix-config.result }}
+          RUNNER_PREFLIGHT_RESULT: ${{ needs.runner-preflight.result }}
+          UNITY_TESTS_RESULT: ${{ needs.unity-tests.result }}
+          FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          DOCS_ONLY: ${{ needs.matrix-config.outputs.ci-owned-docs-only }}
+        run: |
+          set -euo pipefail
+          failed=0
+
+          assert_result() {
+            local variable="$1"
+            local expected="$2"
+            local actual="$3"
+            echo "${variable}=${actual} (expected ${expected})"
+            if [ "${actual}" != "${expected}" ]; then
+              failed=1
+            fi
+          }
+
+          if [ "${MATRIX_CONFIG_RESULT}" != "success" ]; then
+            echo "MATRIX_CONFIG_RESULT=${MATRIX_CONFIG_RESULT} (expected success)"
+            failed=1
+          fi
+
+          if [ "${FORK_PR}" = "true" ]; then
+            assert_result RUNNER_PREFLIGHT_RESULT skipped "${RUNNER_PREFLIGHT_RESULT}"
+            assert_result UNITY_TESTS_RESULT skipped "${UNITY_TESTS_RESULT}"
+          elif [ "${DOCS_ONLY}" = "true" ]; then
+            assert_result RUNNER_PREFLIGHT_RESULT success "${RUNNER_PREFLIGHT_RESULT}"
+            assert_result UNITY_TESTS_RESULT skipped "${UNITY_TESTS_RESULT}"
+          else
+            assert_result RUNNER_PREFLIGHT_RESULT success "${RUNNER_PREFLIGHT_RESULT}"
+            assert_result UNITY_TESTS_RESULT success "${UNITY_TESTS_RESULT}"
+          fi
+
+          exit "${failed}"

--- a/package.json
+++ b/package.json
@@ -79,11 +79,12 @@
     "fix:csharp-underscores": "node scripts/fix-csharp-underscore-methods.js",
     "validate:asmdef-references": "node scripts/validate-asmdef-references.js",
     "validate:unity-versions": "node scripts/validate-unity-versions.js",
+    "validate:unity-pr-policy": "python3 scripts/validate-unity-pr-policy.py",
     "validate:js-loc-budget": "node scripts/validate-js-loc-budget.js",
     "validate:unity-license-classifiers": "python3 .github/actions/return-unity-license/classify_unity_account_health.py --self-test && pwsh -NoProfile -File .github/actions/return-unity-license/Classify-UnityLicenseReturn.ps1 -SelfTest",
     "validate:npm-meta": "node scripts/validate-npm-meta.js",
     "validate:docs:strict": "python3 -m venv .artifacts/docs-venv && .artifacts/docs-venv/bin/python -m pip install -r requirements-docs.txt && .artifacts/docs-venv/bin/mkdocs build --strict --site-dir _site",
-    "validate:all": "npm run validate:asmdef-references && npm run validate:unity-versions && npm run validate:js-loc-budget && npm run validate:unity-license-classifiers && npm run check:banner && npm run validate:npm-meta && npm run check:analyzers && npm run check:llms-txt && npm run check:skills-index && npm run check:issue-template-versions"
+    "validate:all": "npm run validate:asmdef-references && npm run validate:unity-versions && npm run validate:unity-pr-policy && npm run validate:js-loc-budget && npm run validate:unity-license-classifiers && npm run check:banner && npm run validate:npm-meta && npm run check:analyzers && npm run check:llms-txt && npm run check:skills-index && npm run check:issue-template-versions"
   },
   "devDependencies": {
     "cspell": "10.0.1",

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -2,6 +2,7 @@
 
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
+const childProcess = require("node:child_process");
 const fs = require("node:fs");
 const path = require("node:path");
 
@@ -93,6 +94,18 @@ function getStepBlock(jobBlock, stepName) {
 
   const next = jobBlock.indexOf("\n      - name:", start + marker.length);
   return jobBlock.slice(start, next === -1 ? jobBlock.length : next);
+}
+
+function getRunScript(stepBlock) {
+  const marker = "        run: |\n";
+  const start = stepBlock.indexOf(marker);
+  assert.notEqual(start, -1, "step must include a multiline run script");
+  return stepBlock
+    .slice(start + marker.length)
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("          ") || line.length === 0)
+    .map((line) => line.slice(10))
+    .join("\n");
 }
 
 function extractShellPatternVariable(source, variableName) {
@@ -332,7 +345,7 @@ test("Unity return proof classifications remain fail closed and non-masking", ()
   assert.match(source, /resource-health[\s\S]*resource-reason/); assert.match(actionSource, /resource-health=healthy[\s\S]*?resource-reason=\$healthyReason[\s\S]*?function Resolve-PythonApplication/); assert.match(actionSource, /function Resolve-PythonApplication[\s\S]*?Get-Command \$Name[^\n]*-All[\s\S]*?Test-Path[\s\S]*?--version[\s\S]*?LASTEXITCODE -eq 0/); assert.match(actionSource, /Resolve-PythonApplication -Name python3\b/); assert.match(actionSource, /Resolve-PythonApplication -Name python\b/); assert.doesNotMatch(actionSource, /run:\s*python3(?:\s|$)|run:\s*\|[^\n]*\n\s*python3(?:\s|$)/m);
 });
 // prettier-ignore
-test("licensed workflows pin external actions and reject pull-request licensing", () => {
+test("licensed workflows pin external actions and guard pull-request licensing", () => {
   const files = [...new Set(UNITY_LOCK_WINDOWS.map(([file]) => file))];
   for (const file of files) {
     const source = fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8");
@@ -349,8 +362,85 @@ test("licensed workflows pin external actions and reject pull-request licensing"
   for (const [file, jobId] of UNITY_LOCK_WINDOWS.filter(([file]) => ["perf-numbers.yml", "unity-tests.yml"].includes(file))) {
     const source = fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8");
     if (file === "perf-numbers.yml") assert.doesNotMatch(source, /\n  pull_request:|comment-perf-doc/, file);
-    else assert.match(getJobBlock(source, jobId, file), /github\.event_name != 'pull_request'/, `${file}:${jobId}`);
+    else {
+      const job = getJobBlock(source, jobId, file);
+      assert.match(
+        job,
+        /github\.event_name != 'pull_request' \|\|\s*github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
+        `${file}:${jobId} must admit same-repository PRs and reject forks`
+      );
+      assert.doesNotMatch(
+        job,
+        /github\.event_name != 'pull_request' &&/,
+        `${file}:${jobId} must not reject every pull request`
+      );
+    }
   }
+});
+
+test("Unity CI aggregate fails closed for unexpected licensed-job skips", () => {
+  const source = fs.readFileSync(path.join(WORKFLOW_DIR, "unity-tests.yml"), "utf8");
+  const gate = getJobBlock(source, "unity-ci-success", "unity-tests.yml");
+
+  assert.match(gate, /\n    if: \$\{\{ always\(\) \}\}\n/);
+  assert.doesNotMatch(gate, /re-actors\/alls-green|allowed-skips/);
+  for (const variable of [
+    "MATRIX_CONFIG_RESULT",
+    "RUNNER_PREFLIGHT_RESULT",
+    "UNITY_TESTS_RESULT",
+    "FORK_PR",
+    "DOCS_ONLY"
+  ]) {
+    assert.match(gate, new RegExp(`\\n          ${variable}:`), `${variable} must be explicit`);
+  }
+  assert.match(gate, /if \[ "\$\{MATRIX_CONFIG_RESULT\}" != "success" \]; then/);
+  assert.match(
+    gate,
+    /if \[ "\$\{FORK_PR\}" = "true" \]; then[\s\S]*assert_result RUNNER_PREFLIGHT_RESULT skipped[\s\S]*assert_result UNITY_TESTS_RESULT skipped/
+  );
+  assert.match(
+    gate,
+    /elif \[ "\$\{DOCS_ONLY\}" = "true" \]; then[\s\S]*assert_result RUNNER_PREFLIGHT_RESULT success[\s\S]*assert_result UNITY_TESTS_RESULT skipped/
+  );
+  assert.match(
+    gate,
+    /else[\s\S]*assert_result RUNNER_PREFLIGHT_RESULT success[\s\S]*assert_result UNITY_TESTS_RESULT success/
+  );
+
+  // The repository's Linux CI executes the production Bash truth table. The
+  // legacy Windows bash.exe launcher depends on WSL service availability and
+  // is not a reliable local test runtime.
+  if (process.platform === "win32") return;
+
+  const script = getRunScript(getStepBlock(gate, "Verify Unity CI result shape"));
+  const cases = [
+    ["same-repository PR", "success", "success", "success", "false", "false", 0],
+    ["fork PR", "success", "skipped", "skipped", "true", "false", 0],
+    ["CI-owned docs-only PR", "success", "success", "skipped", "false", "true", 0],
+    ["same-repository PR skipped Unity", "success", "success", "skipped", "false", "false", 1],
+    ["fork unexpectedly ran Unity", "success", "skipped", "success", "true", "false", 1],
+    ["matrix config failed", "failure", "success", "success", "false", "false", 1]
+  ];
+  const invocation = ["set +e"];
+  const actualRef = "$" + "{actual}";
+  for (const [name, matrix, preflight, unity, fork, docsOnly, expectedExit] of cases) {
+    invocation.push(
+      "(",
+      `export MATRIX_CONFIG_RESULT=${matrix}`,
+      `export RUNNER_PREFLIGHT_RESULT=${preflight}`,
+      `export UNITY_TESTS_RESULT=${unity}`,
+      `export FORK_PR=${fork}`,
+      `export DOCS_ONLY=${docsOnly}`,
+      script,
+      ")",
+      "actual=$?",
+      `if [ "${actualRef}" -ne ${expectedExit} ]; then echo '${name}: expected ${expectedExit}, got '"${actualRef}" >&2; exit 99; fi`
+    );
+  }
+  invocation.push("exit 0");
+  const combined = invocation.join("\n");
+  const result = childProcess.spawnSync("bash", ["-c", combined], { encoding: "utf8" });
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 });
 
 test("release workflows pin App write scopes and denied-push diagnostics", () => {

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -2,7 +2,6 @@
 
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const childProcess = require("node:child_process");
 const fs = require("node:fs");
 const path = require("node:path");
 
@@ -94,18 +93,6 @@ function getStepBlock(jobBlock, stepName) {
 
   const next = jobBlock.indexOf("\n      - name:", start + marker.length);
   return jobBlock.slice(start, next === -1 ? jobBlock.length : next);
-}
-
-function getRunScript(stepBlock) {
-  const marker = "        run: |\n";
-  const start = stepBlock.indexOf(marker);
-  assert.notEqual(start, -1, "step must include a multiline run script");
-  return stepBlock
-    .slice(start + marker.length)
-    .split(/\r?\n/)
-    .filter((line) => line.startsWith("          ") || line.length === 0)
-    .map((line) => line.slice(10))
-    .join("\n");
 }
 
 function extractShellPatternVariable(source, variableName) {
@@ -345,7 +332,7 @@ test("Unity return proof classifications remain fail closed and non-masking", ()
   assert.match(source, /resource-health[\s\S]*resource-reason/); assert.match(actionSource, /resource-health=healthy[\s\S]*?resource-reason=\$healthyReason[\s\S]*?function Resolve-PythonApplication/); assert.match(actionSource, /function Resolve-PythonApplication[\s\S]*?Get-Command \$Name[^\n]*-All[\s\S]*?Test-Path[\s\S]*?--version[\s\S]*?LASTEXITCODE -eq 0/); assert.match(actionSource, /Resolve-PythonApplication -Name python3\b/); assert.match(actionSource, /Resolve-PythonApplication -Name python\b/); assert.doesNotMatch(actionSource, /run:\s*python3(?:\s|$)|run:\s*\|[^\n]*\n\s*python3(?:\s|$)/m);
 });
 // prettier-ignore
-test("licensed workflows pin external actions and guard pull-request licensing", () => {
+test("licensed workflows pin external actions and reject pull-request licensing", () => {
   const files = [...new Set(UNITY_LOCK_WINDOWS.map(([file]) => file))];
   for (const file of files) {
     const source = fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8");
@@ -362,85 +349,8 @@ test("licensed workflows pin external actions and guard pull-request licensing",
   for (const [file, jobId] of UNITY_LOCK_WINDOWS.filter(([file]) => ["perf-numbers.yml", "unity-tests.yml"].includes(file))) {
     const source = fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8");
     if (file === "perf-numbers.yml") assert.doesNotMatch(source, /\n  pull_request:|comment-perf-doc/, file);
-    else {
-      const job = getJobBlock(source, jobId, file);
-      assert.match(
-        job,
-        /github\.event_name != 'pull_request' \|\|\s*github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
-        `${file}:${jobId} must admit same-repository PRs and reject forks`
-      );
-      assert.doesNotMatch(
-        job,
-        /github\.event_name != 'pull_request' &&/,
-        `${file}:${jobId} must not reject every pull request`
-      );
-    }
+    else assert.match(getJobBlock(source, jobId, file), /github\.event_name != 'pull_request'/, `${file}:${jobId}`);
   }
-});
-
-test("Unity CI aggregate fails closed for unexpected licensed-job skips", () => {
-  const source = fs.readFileSync(path.join(WORKFLOW_DIR, "unity-tests.yml"), "utf8");
-  const gate = getJobBlock(source, "unity-ci-success", "unity-tests.yml");
-
-  assert.match(gate, /\n    if: \$\{\{ always\(\) \}\}\n/);
-  assert.doesNotMatch(gate, /re-actors\/alls-green|allowed-skips/);
-  for (const variable of [
-    "MATRIX_CONFIG_RESULT",
-    "RUNNER_PREFLIGHT_RESULT",
-    "UNITY_TESTS_RESULT",
-    "FORK_PR",
-    "DOCS_ONLY"
-  ]) {
-    assert.match(gate, new RegExp(`\\n          ${variable}:`), `${variable} must be explicit`);
-  }
-  assert.match(gate, /if \[ "\$\{MATRIX_CONFIG_RESULT\}" != "success" \]; then/);
-  assert.match(
-    gate,
-    /if \[ "\$\{FORK_PR\}" = "true" \]; then[\s\S]*assert_result RUNNER_PREFLIGHT_RESULT skipped[\s\S]*assert_result UNITY_TESTS_RESULT skipped/
-  );
-  assert.match(
-    gate,
-    /elif \[ "\$\{DOCS_ONLY\}" = "true" \]; then[\s\S]*assert_result RUNNER_PREFLIGHT_RESULT success[\s\S]*assert_result UNITY_TESTS_RESULT skipped/
-  );
-  assert.match(
-    gate,
-    /else[\s\S]*assert_result RUNNER_PREFLIGHT_RESULT success[\s\S]*assert_result UNITY_TESTS_RESULT success/
-  );
-
-  // The repository's Linux CI executes the production Bash truth table. The
-  // legacy Windows bash.exe launcher depends on WSL service availability and
-  // is not a reliable local test runtime.
-  if (process.platform === "win32") return;
-
-  const script = getRunScript(getStepBlock(gate, "Verify Unity CI result shape"));
-  const cases = [
-    ["same-repository PR", "success", "success", "success", "false", "false", 0],
-    ["fork PR", "success", "skipped", "skipped", "true", "false", 0],
-    ["CI-owned docs-only PR", "success", "success", "skipped", "false", "true", 0],
-    ["same-repository PR skipped Unity", "success", "success", "skipped", "false", "false", 1],
-    ["fork unexpectedly ran Unity", "success", "skipped", "success", "true", "false", 1],
-    ["matrix config failed", "failure", "success", "success", "false", "false", 1]
-  ];
-  const invocation = ["set +e"];
-  const actualRef = "$" + "{actual}";
-  for (const [name, matrix, preflight, unity, fork, docsOnly, expectedExit] of cases) {
-    invocation.push(
-      "(",
-      `export MATRIX_CONFIG_RESULT=${matrix}`,
-      `export RUNNER_PREFLIGHT_RESULT=${preflight}`,
-      `export UNITY_TESTS_RESULT=${unity}`,
-      `export FORK_PR=${fork}`,
-      `export DOCS_ONLY=${docsOnly}`,
-      script,
-      ")",
-      "actual=$?",
-      `if [ "${actualRef}" -ne ${expectedExit} ]; then echo '${name}: expected ${expectedExit}, got '"${actualRef}" >&2; exit 99; fi`
-    );
-  }
-  invocation.push("exit 0");
-  const combined = invocation.join("\n");
-  const result = childProcess.spawnSync("bash", ["-c", combined], { encoding: "utf8" });
-  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 });
 
 test("release workflows pin App write scopes and denied-push diagnostics", () => {

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -10,6 +10,13 @@ from pathlib import Path
 
 
 WORKFLOW = Path(".github/workflows/unity-tests.yml")
+SAME_REPOSITORY_PR_GUARD = re.compile(
+    r"github\.event_name\s*!=\s*'pull_request'\s*\|\|\s*"
+    r"github\.event\.pull_request\.head\.repo\.full_name\s*==\s*github\.repository"
+)
+BLANKET_PR_REJECTION = re.compile(
+    r"github\.event_name\s*!=\s*'pull_request'\s*&&"
+)
 
 
 def require(condition: bool, message: str) -> None:
@@ -59,17 +66,27 @@ def validate() -> None:
         run_script(parser_fixture) == "echo first\necho second",
         "run parser must stop at the next step key",
     )
+    require(
+        SAME_REPOSITORY_PR_GUARD.search(
+            "github.event_name!='pull_request'||"
+            "github.event.pull_request.head.repo.full_name==github.repository"
+        )
+        is not None,
+        "same-repository guard parser must accept compact operators",
+    )
+    require(
+        BLANKET_PR_REJECTION.search("github.event_name!='pull_request'&&(") is not None,
+        "blanket rejection parser must detect compact operators",
+    )
 
     source = WORKFLOW.read_text(encoding="utf-8")
     licensed = job_block(source, "unity-tests")
-    normalized = " ".join(licensed.split())
-    guard = (
-        "github.event_name != 'pull_request' || "
-        "github.event.pull_request.head.repo.full_name == github.repository"
-    )
-    require(guard in normalized, "Unity job must admit same-repository PRs and reject forks")
     require(
-        "github.event_name != 'pull_request' &&" not in normalized,
+        SAME_REPOSITORY_PR_GUARD.search(licensed) is not None,
+        "Unity job must admit same-repository PRs and reject forks",
+    )
+    require(
+        BLANKET_PR_REJECTION.search(licensed) is None,
         "Unity job must not reject every pull request",
     )
     require("environment: unity-license" in licensed, "Unity job must use the protected environment")

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -39,12 +39,27 @@ def run_script(step: str) -> str:
     marker = "        run: |\n"
     start = step.find(marker)
     require(start >= 0, "aggregate step must contain a multiline run script")
-    lines = step[start + len(marker) :].splitlines()
-    require(all(not line or line.startswith("          ") for line in lines), "invalid run indentation")
-    return "\n".join(line[10:] if line else "" for line in lines)
+    lines = []
+    for line in step[start + len(marker) :].splitlines():
+        if line and not line.startswith("          "):
+            break
+        lines.append(line[10:] if line else "")
+    require(bool(lines), "aggregate run script must not be empty")
+    return "\n".join(lines)
 
 
 def validate() -> None:
+    parser_fixture = """      - name: Fixture
+        run: |
+          echo first
+          echo second
+        shell: bash
+"""
+    require(
+        run_script(parser_fixture) == "echo first\necho second",
+        "run parser must stop at the next step key",
+    )
+
     source = WORKFLOW.read_text(encoding="utf-8")
     licensed = job_block(source, "unity-tests")
     normalized = " ".join(licensed.split())
@@ -82,13 +97,16 @@ def validate() -> None:
     )
     if os.name != "nt":
         for name, matrix, preflight, unity, fork, docs_only, expected in cases:
-            environment = os.environ | {
-                "MATRIX_CONFIG_RESULT": matrix,
-                "RUNNER_PREFLIGHT_RESULT": preflight,
-                "UNITY_TESTS_RESULT": unity,
-                "FORK_PR": fork,
-                "DOCS_ONLY": docs_only,
-            }
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "MATRIX_CONFIG_RESULT": matrix,
+                    "RUNNER_PREFLIGHT_RESULT": preflight,
+                    "UNITY_TESTS_RESULT": unity,
+                    "FORK_PR": fork,
+                    "DOCS_ONLY": docs_only,
+                }
+            )
             result = subprocess.run(
                 ["bash", "-c", script],
                 env=environment,

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Validate trusted-PR Unity admission and the aggregate skip truth table."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/unity-tests.yml")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def job_block(source: str, job_id: str) -> str:
+    match = re.search(rf"^  {re.escape(job_id)}:\n", source, re.MULTILINE)
+    require(match is not None, f"missing job: {job_id}")
+    assert match is not None
+    rest = source[match.end() :]
+    next_job = re.search(r"^  [A-Za-z0-9_-]+:\n", rest, re.MULTILINE)
+    end = match.end() + (next_job.start() if next_job else len(rest))
+    return source[match.start() : end]
+
+
+def step_block(job: str, name: str) -> str:
+    marker = f"      - name: {name}\n"
+    start = job.find(marker)
+    require(start >= 0, f"missing step: {name}")
+    following = job.find("\n      - name:", start + len(marker))
+    return job[start : following if following >= 0 else len(job)]
+
+
+def run_script(step: str) -> str:
+    marker = "        run: |\n"
+    start = step.find(marker)
+    require(start >= 0, "aggregate step must contain a multiline run script")
+    lines = step[start + len(marker) :].splitlines()
+    require(all(not line or line.startswith("          ") for line in lines), "invalid run indentation")
+    return "\n".join(line[10:] if line else "" for line in lines)
+
+
+def validate() -> None:
+    source = WORKFLOW.read_text(encoding="utf-8")
+    licensed = job_block(source, "unity-tests")
+    normalized = " ".join(licensed.split())
+    guard = (
+        "github.event_name != 'pull_request' || "
+        "github.event.pull_request.head.repo.full_name == github.repository"
+    )
+    require(guard in normalized, "Unity job must admit same-repository PRs and reject forks")
+    require(
+        "github.event_name != 'pull_request' &&" not in normalized,
+        "Unity job must not reject every pull request",
+    )
+    require("environment: unity-license" in licensed, "Unity job must use the protected environment")
+
+    gate = job_block(source, "unity-ci-success")
+    require("if: ${{ always() }}" in gate, "aggregate must always report")
+    require("re-actors/alls-green" not in gate and "allowed-skips" not in gate, "skips must be typed")
+    for variable in (
+        "MATRIX_CONFIG_RESULT",
+        "RUNNER_PREFLIGHT_RESULT",
+        "UNITY_TESTS_RESULT",
+        "FORK_PR",
+        "DOCS_ONLY",
+    ):
+        require(re.search(rf"^          {variable}:", gate, re.MULTILINE) is not None, f"missing {variable}")
+
+    script = run_script(step_block(gate, "Verify Unity CI result shape"))
+    cases = (
+        ("same-repository PR", "success", "success", "success", "false", "false", 0),
+        ("fork PR", "success", "skipped", "skipped", "true", "false", 0),
+        ("CI-owned docs-only PR", "success", "success", "skipped", "false", "true", 0),
+        ("same-repository PR skipped Unity", "success", "success", "skipped", "false", "false", 1),
+        ("fork unexpectedly ran Unity", "success", "skipped", "success", "true", "false", 1),
+        ("matrix config failed", "failure", "success", "success", "false", "false", 1),
+    )
+    if os.name != "nt":
+        for name, matrix, preflight, unity, fork, docs_only, expected in cases:
+            environment = os.environ | {
+                "MATRIX_CONFIG_RESULT": matrix,
+                "RUNNER_PREFLIGHT_RESULT": preflight,
+                "UNITY_TESTS_RESULT": unity,
+                "FORK_PR": fork,
+                "DOCS_ONLY": docs_only,
+            }
+            result = subprocess.run(
+                ["bash", "-c", script],
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            require(
+                result.returncode == expected,
+                f"{name}: expected {expected}, got {result.returncode}\n{result.stdout}\n{result.stderr}",
+            )
+
+    print("Unity pull-request policy validation passed.")
+
+
+if __name__ == "__main__":
+    validate()


### PR DESCRIPTION
## Summary
- run protected Unity validation for same-repository pull requests while keeping fork PRs static-only
- replace unconditional allowed-skips with a fail-closed aggregate truth table
- add red/green policy and runtime truth-table coverage

## Environment cutover
- unity-license now allows all branches
- required reviewer wallstop and admin-bypass behavior are preserved

## Verification
- focused aggregate policy tests pass (14/14)
- actionlint, Prettier, Unity-version validation, and diff checks pass
- full local script suite: 245 pass; 3 unrelated Windows-host limitations (symlink privilege, unavailable WSL service, PowerShell display wrapping) remain for Linux CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes branch-protection CI semantics and runs licensed Unity against PR code; misconfiguration could false-green merges or expose license use on untrusted refs.
> 
> **Overview**
> **Same-repository pull requests** can run the licensed Unity matrix again (behind the `unity-license` environment); **fork PRs** stay static-only, matching the updated `runner-preflight` / `unity-tests` guards.
> 
> The **Unity CI Success** aggregate no longer uses `re-actors/alls-green` with blanket `allowed-skips`. A custom **Verify Unity CI result shape** step enforces a fixed outcome table: fork PRs must skip preflight and Unity; docs-only PRs must succeed preflight and skip Unity; all other eligible runs must succeed both. Unexpected skips (e.g. Unity skipped on a same-repo code PR) fail the gate.
> 
> Adds **`scripts/validate-unity-pr-policy.py`** and wires **`validate:unity-pr-policy`** into **`validate:all`** so workflow guards and the aggregate script stay aligned, including runtime checks of the bash truth table on non-Windows hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ef641ed7a41cf0bbd39b441e4b285099324438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->