### PR TITLE
fix(ci): use org secrets and immutable action pins

### DIFF
--- a/.devcontainer/validate-caching.sh
+++ b/.devcontainer/validate-caching.sh
@@ -325,10 +325,10 @@ check_devcontainer_test_workflow() {
         check_fail "devcontainer-test workflow missing packages:write permission"
     fi
 
-    if grep -q "docker/login-action@v4" "$workflow_file"; then
-        check_pass "devcontainer-test workflow has current GHCR login step"
+    if grep -Eq '^[[:space:]]*uses:[[:space:]]+docker/login-action@[0-9a-f]{40}[[:space:]]+# v4[[:space:]]*$' "$workflow_file"; then
+        check_pass "devcontainer-test workflow has pinned current GHCR login step"
     else
-        check_fail "devcontainer-test workflow missing current GHCR login step"
+        check_fail "devcontainer-test workflow missing pinned current GHCR login step"
     fi
 
     if grep -q "eventFilterForPush: \"\"" "$workflow_file"; then
@@ -360,10 +360,10 @@ check_devcontainer_prebuild_workflow() {
         check_fail "devcontainer-prebuild workflow missing packages:write permission"
     fi
 
-    if grep -q "docker/login-action@v4" "$workflow_file"; then
-        check_pass "devcontainer-prebuild workflow has current GHCR login step"
+    if grep -Eq '^[[:space:]]*uses:[[:space:]]+docker/login-action@[0-9a-f]{40}[[:space:]]+# v4[[:space:]]*$' "$workflow_file"; then
+        check_pass "devcontainer-prebuild workflow has pinned current GHCR login step"
     else
-        check_fail "devcontainer-prebuild workflow missing current GHCR login step"
+        check_fail "devcontainer-prebuild workflow missing pinned current GHCR login step"
     fi
 
     if grep -q "push: never" "$workflow_file" && grep -q 'docker push "${IMAGE}"' "$workflow_file"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       yaml: ${{ steps.filter.outputs.yaml }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -204,7 +204,7 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.actionlint != 'false' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -214,11 +214,11 @@ jobs:
 
       - name: Run actionlint
         if: ${{ needs.changes.outputs.actionlint != 'false' }}
-        uses: rhysd/actionlint@v1.7.12
+        uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.actionlint != 'false' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
 
@@ -246,13 +246,13 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.markdown != 'false' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.markdown != 'false' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -291,7 +291,7 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.csharpier != 'false' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -303,7 +303,7 @@ jobs:
 
       - name: Setup .NET
         if: ${{ needs.changes.outputs.csharpier != 'false' }}
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: "8.0.x"
 
@@ -335,19 +335,19 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.dotnet != 'false' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Setup .NET
         if: ${{ needs.changes.outputs.dotnet != 'false' }}
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           global-json-file: SourceGenerators/global.json
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.dotnet != 'false' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
 
@@ -404,7 +404,7 @@ jobs:
 
       - name: Upload coverage report
         if: ${{ needs.changes.outputs.dotnet != 'false' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: generator-coverage
           path: artifacts/coverage
@@ -463,13 +463,13 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.json != 'false' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.json != 'false' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -508,13 +508,13 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.spellcheck != 'false' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.spellcheck != 'false' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -544,13 +544,13 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.banner != 'false' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.banner != 'false' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
 
@@ -578,14 +578,14 @@ jobs:
 
       - name: Checkout repository
         if: ${{ needs.changes.outputs.llms != 'false' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.llms != 'false' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -624,13 +624,13 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.yaml != 'false' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.yaml != 'false' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -651,7 +651,7 @@ jobs:
 
       - name: yamllint
         if: ${{ needs.changes.outputs.yaml != 'false' }}
-        uses: ibiqlik/action-yamllint@v3.1.1
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
         with:
           file_or_dir: .
           config_file: .yamllint.yaml
@@ -690,14 +690,14 @@ jobs:
 
       - name: Checkout repository
         if: ${{ needs.changes.outputs.scripts != 'false' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.scripts != 'false' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -705,7 +705,7 @@ jobs:
 
       - name: Setup .NET
         if: ${{ needs.changes.outputs.scripts != 'false' && matrix.os == 'ubuntu-latest' }}
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           global-json-file: SourceGenerators/global.json
 
@@ -749,7 +749,7 @@ jobs:
 
       - name: Checkout repository
         if: ${{ needs.changes.outputs.docs != 'false' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -783,7 +783,7 @@ jobs:
 
       - name: Setup Python
         if: ${{ needs.changes.outputs.docs != 'false' }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
           cache: "pip"
@@ -885,7 +885,7 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.docs_links != 'false' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -960,7 +960,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Verify all static CI jobs succeeded
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: ""

--- a/.github/workflows/csharpier-autofix.yml
+++ b/.github/workflows/csharpier-autofix.yml
@@ -39,13 +39,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: "8.0.x"
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: Commit formatting changes to PR branch (Dependabot only)
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'dependabot[bot]' }}
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           commit_message: "chore(format): apply CSharpier formatting"
           branch: ${{ github.head_ref }}
@@ -100,7 +100,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout fork PR HEAD
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -108,7 +108,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: "8.0.x"
 
@@ -174,7 +174,7 @@ jobs:
 
       - name: Open or update formatting PR in base repo
         if: steps.changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -200,7 +200,7 @@ jobs:
 
       - name: Comment link on original PR
         if: steps.changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,13 +43,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0 # Full history for git-revision-date-localized plugin
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
           cache: "pip"
@@ -122,7 +122,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: _site
 
@@ -138,4 +138,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/devcontainer-prebuild.yml
+++ b/.github/workflows/devcontainer-prebuild.yml
@@ -16,7 +16,7 @@
 #   - Manual dispatch.
 #
 # Critical: explicit push before verification
-#   devcontainers/ci@v0.3 performs registry pushes from its post action. A
+#   devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3 performs registry pushes from its post action. A
 #   follow-up step that tries to pull the image from GHCR runs before that post
 #   action, so it observes the previous registry state instead of the image that
 #   was just built. This workflow builds with push disabled, pushes explicitly,
@@ -55,7 +55,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           lfs: true
           persist-credentials: false
@@ -74,14 +74,14 @@ jobs:
           echo "repository_lowercase=${repo_lower}" >> "${GITHUB_OUTPUT}"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push devcontainer image
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3
         env:
           BUILDKIT_PROGRESS: plain
         with:

--- a/.github/workflows/devcontainer-test.yml
+++ b/.github/workflows/devcontainer-test.yml
@@ -22,7 +22,7 @@
 #   - Manual dispatch
 #
 # Critical: eventFilterForPush
-#   devcontainers/ci@v0.3 defaults `eventFilterForPush` to "push", which
+#   devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3 defaults `eventFilterForPush` to "push", which
 #   silently SKIPS pushing the image on `schedule` / `workflow_dispatch`
 #   events. Setting it to "" makes the `push` knob the single source of
 #   truth (combined with `refFilterForPush: refs/heads/master`). This gotcha
@@ -101,7 +101,7 @@ jobs:
           exit 1
 
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           lfs: true
           persist-credentials: false
@@ -120,14 +120,14 @@ jobs:
           echo "repository_lowercase=${repo_lower}" >> "${GITHUB_OUTPUT}"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pre-build devcontainer image
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3
         env:
           BUILDKIT_PROGRESS: plain
         with:
@@ -142,7 +142,7 @@ jobs:
           eventFilterForPush: ""
 
       - name: Run devcontainer smoke tests
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3
         with:
           imageName: ghcr.io/${{ steps.repo.outputs.repository_lowercase }}/devcontainer
           cacheFrom: ghcr.io/${{ steps.repo.outputs.repository_lowercase }}/devcontainer

--- a/.github/workflows/format-on-demand.yml
+++ b/.github/workflows/format-on-demand.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Resolve PR metadata and authorize request
         id: meta
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prNumber = context.payload.issue.number;
@@ -46,25 +46,25 @@ jobs:
           exit 1
       - name: Checkout PR branch (same-repo)
         if: ${{ steps.meta.outputs.same_repo == 'true' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ steps.meta.outputs.head_ref }}
           fetch-depth: 0
           persist-credentials: false
       - name: Checkout PR fork head
         if: ${{ steps.meta.outputs.same_repo != 'true' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           repository: ${{ steps.meta.outputs.head_repo }}
           ref: ${{ steps.meta.outputs.head_ref }}
           persist-credentials: false
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '8.0.x'
       - name: Restore .NET tools
@@ -120,7 +120,7 @@ jobs:
         run: git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
       - name: Commit changes to PR branch (same-repo)
         if: ${{ steps.meta.outputs.same_repo == 'true' && steps.changes.outputs.has_changes == 'true' }}
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           commit_message: "chore(format): apply requested formatting"
           branch: ${{ steps.meta.outputs.head_ref }}
@@ -163,7 +163,7 @@ jobs:
           git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" push upstream "$BRANCH" --force
       - name: Open/Update formatting PR (fork)
         if: ${{ steps.meta.outputs.same_repo != 'true' && steps.changes.outputs.has_changes == 'true' }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prNumber = Number(core.getInput('pr')) || Number('${{ steps.meta.outputs.pr }}');
@@ -183,7 +183,7 @@ jobs:
             }
       - name: Comment result on PR
         if: ${{ steps.changes.outputs.has_changes == 'true' }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prNumber = Number('${{ steps.meta.outputs.pr }}');
@@ -194,7 +194,7 @@ jobs:
             await github.rest.issues.createComment({ ...context.repo, issue_number: prNumber, body });
       - name: No-op comment (nothing to change)
         if: ${{ steps.changes.outputs.has_changes != 'true' }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prNumber = Number('${{ steps.meta.outputs.pr }}');
@@ -207,7 +207,7 @@ jobs:
     steps:
       - name: Resolve PR metadata
         id: meta
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prNumber = Number(core.getInput('pr_number'));
@@ -220,25 +220,25 @@ jobs:
             core.setOutput('same_repo', String(pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`));
       - name: Checkout PR branch (same-repo)
         if: ${{ steps.meta.outputs.same_repo == 'true' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ steps.meta.outputs.head_ref }}
           fetch-depth: 0
           persist-credentials: false
       - name: Checkout PR fork head
         if: ${{ steps.meta.outputs.same_repo != 'true' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           repository: ${{ steps.meta.outputs.head_repo }}
           ref: ${{ steps.meta.outputs.head_ref }}
           persist-credentials: false
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '8.0.x'
       - name: Restore .NET tools
@@ -294,7 +294,7 @@ jobs:
         run: git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
       - name: Commit changes to PR branch (same-repo)
         if: ${{ steps.meta.outputs.same_repo == 'true' && steps.changes.outputs.has_changes == 'true' }}
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           commit_message: "chore(format): apply requested formatting"
           branch: ${{ steps.meta.outputs.head_ref }}
@@ -337,7 +337,7 @@ jobs:
           git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" push upstream "$BRANCH" --force
       - name: Open/Update formatting PR (fork)
         if: ${{ steps.meta.outputs.same_repo != 'true' && steps.changes.outputs.has_changes == 'true' }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prNumber = Number('${{ steps.meta.outputs.pr }}');

--- a/.github/workflows/markdown-link-validity.yml
+++ b/.github/workflows/markdown-link-validity.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -44,7 +44,7 @@ jobs:
       # (below) so a one-off blip is never remembered as a result.
       - name: Restore lychee cache
         id: restore-cache
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
@@ -89,7 +89,7 @@ jobs:
 
       - name: Save lychee cache
         if: always()
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .lycheecache
           key: ${{ steps.restore-cache.outputs.cache-primary-key }}

--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -230,7 +230,6 @@ jobs:
     # Pinned to ELI-MACHINE via the `fast` label (the only self-hosted Windows
     # runner carrying it). Keep in sync with the preflight REQUIRED_LABELS.
     runs-on: [self-hosted, Windows, RAM-64GB, fast]
-    environment: unity-license
     timeout-minutes: 660
     strategy:
       fail-fast: false
@@ -299,7 +298,7 @@ jobs:
           key: Library-perf-${{ runner.os }}-${{ runner.arch }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}-${{ env.PACKAGE_HASH }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
 
@@ -379,7 +378,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: perf-${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -446,7 +445,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: perf-${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -617,7 +616,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.default-branch.outputs.fresh == 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
           cache: npm

--- a/.github/workflows/prettier-autofix.yml
+++ b/.github/workflows/prettier-autofix.yml
@@ -73,13 +73,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -126,7 +126,7 @@ jobs:
       - name: Commit formatting changes to PR branch (Dependabot only)
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'dependabot[bot]' }}
         id: auto-commit
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           commit_message: "chore(format): apply Prettier/markdownlint fixes"
           branch: ${{ github.head_ref }}
@@ -172,7 +172,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout fork PR HEAD
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -180,7 +180,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -255,7 +255,7 @@ jobs:
 
       - name: Open or update formatting PR in base repo
         if: steps.changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -280,7 +280,7 @@ jobs:
 
       - name: Comment link on original PR
         if: steps.changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         # The shared changelog extractor (scripts/release/release-notes.js) runs
         # under Node; pin it instead of the runner's ambient version.
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
 
@@ -79,7 +79,7 @@ jobs:
       # continue-on-error, so a second failure fails the job. continue-on-error on the first attempt
       # keeps its real result observable via steps.<id>.outcome while letting the retry proceed.
       - name: Run Release Drafter
-        uses: release-drafter/release-drafter@v7
+        uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7
         id: release_drafter
         continue-on-error: true
         with:
@@ -93,7 +93,7 @@ jobs:
 
       - name: Run Release Drafter (retry)
         if: steps.release_drafter.outcome == 'failure'
-        uses: release-drafter/release-drafter@v7
+        uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7
         id: release_drafter_retry
         with:
           config-name: release-drafter.yml
@@ -101,7 +101,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update release body with changelog
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           # Whichever attempt succeeded supplies the outputs; a failed attempt yields empty strings,
           # so the || falls through to the retry's outputs. If both attempts failed, the job already

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -89,7 +89,7 @@ jobs:
         # Request only the release-prepare scopes this workflow needs. If the App
         # installation no longer grants them, fail here before spending time
         # preparing a release tree that cannot be published.
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.AUTO_COMMIT_APP_ID }}
           private-key: ${{ secrets.AUTO_COMMIT_APP_PRIVATE_KEY }}
@@ -97,20 +97,20 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           token: ${{ steps.app-token.outputs.token || github.token }}
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
 
       - name: Setup .NET
         # validate:all runs check:analyzers, which builds the source
         # generators against the SDK pinned in SourceGenerators/global.json.
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           global-json-file: SourceGenerators/global.json
 
@@ -295,7 +295,7 @@ jobs:
 
       - name: Upload failed release preparation patch
         if: ${{ failure() && !inputs.dry-run }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-prepare-recovery-${{ github.run_id }}-${{ github.run_attempt }}
           path: artifacts/release-prepare/

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -131,7 +131,7 @@ jobs:
             steps.detect.outputs.proceed == 'true' &&
             steps.check-autocommit-app.outputs.has-app == 'true'
           }}
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.AUTO_COMMIT_APP_ID }}
           private-key: ${{ secrets.AUTO_COMMIT_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
 
@@ -245,7 +245,6 @@ jobs:
       - verify-tag
       - runner-preflight
     runs-on: [self-hosted, Windows, RAM-64GB]
-    environment: unity-license
     # Workflow-level permissions are `contents: read` (no checks: write), so
     # this job needs its own checks: write or game-ci's check-run creation
     # 403s and the release Unity gate silently stops failing on red tests.
@@ -278,7 +277,7 @@ jobs:
         uses: ./.github/actions/print-self-hosted-runner-diagnostics
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
 
@@ -331,7 +330,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-editmode
@@ -378,7 +377,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-editmode
@@ -444,7 +443,6 @@ jobs:
       - runner-preflight
       - unity-checks
     runs-on: [self-hosted, Windows, RAM-64GB]
-    environment: unity-license
     permissions:
       contents: read
     timeout-minutes: 660
@@ -471,7 +469,7 @@ jobs:
       - name: Setup Node.js
         # export-unitypackage.ps1 stages the payload with `npm pack`, so the
         # shipped bytes are identical to the npm/UPM artifact.
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
 
@@ -516,7 +514,7 @@ jobs:
           overwrite: true
 
       - name: Acquire organization Unity lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-unitypackage
@@ -561,7 +559,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-unitypackage
@@ -626,7 +624,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/runner-bootstrap.yml
+++ b/.github/workflows/runner-bootstrap.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Checkout
         # Shallow checkout: bootstrap only needs scripts/unity/* and a
         # composite action; no history depth required.
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         env:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/dxm-gitconfig
         with:
@@ -335,7 +335,7 @@ jobs:
 
           # F6: drop the GITHUB_ACTION_PATH `../../../` ascent. We are inside
           # a workflow (not a composite), so $GITHUB_WORKSPACE is reliably
-          # the repo root post-checkout (actions/checkout@v7 above guarantees
+          # the repo root post-checkout (actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7 above guarantees
           # the script is present at this path).
           $script = [System.IO.Path]::Combine($env:GITHUB_WORKSPACE, 'scripts', 'unity', 'maintain-windows-runner.ps1')
           if (-not (Test-Path -LiteralPath $script)) {
@@ -379,13 +379,13 @@ jobs:
           }
           if ($code -ne 0) { exit $code }
 
-      # F1: actions/upload-artifact@v7 -- matches the repo-wide pinned
+      # F1: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7 -- matches the repo-wide pinned
       # version used by release.yml/unity-tests.yml/unity-benchmarks.yml.
       # F19: if-no-files-found is `error` (not `warn`) so a missing transcript
       # is a HARD failure rather than a silent empty artifact upload.
       - name: Upload bootstrap transcript
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: runner-bootstrap-${{ inputs.runner-label }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: .artifacts/runner-bootstrap/**

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -27,7 +27,7 @@ jobs:
       should-deploy: ${{ steps.check.outputs.should-deploy }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 2
           persist-credentials: false
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           path: main
           persist-credentials: false
@@ -95,7 +95,7 @@ jobs:
             clone "https://github.com/${GITHUB_REPOSITORY}.wiki.git" wiki
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
 

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -154,7 +154,6 @@ jobs:
       - matrix-config
       - runner-preflight
     runs-on: [self-hosted, Windows, RAM-64GB]
-    environment: unity-license
     timeout-minutes: 660
     strategy:
       fail-fast: false
@@ -210,7 +209,7 @@ jobs:
           key: Library-bench-${{ runner.os }}-${{ runner.arch }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}-${{ env.PACKAGE_HASH }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
 
@@ -267,7 +266,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -319,7 +318,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}

--- a/.github/workflows/unity-gameci-experiment.yml
+++ b/.github/workflows/unity-gameci-experiment.yml
@@ -75,7 +75,6 @@ jobs:
     name: GameCI ${{ inputs.unity-version }} ${{ inputs.test-mode }}
     needs: runner-preflight
     runs-on: [self-hosted, Windows, RAM-64GB]
-    environment: unity-license
     timeout-minutes: 660
     continue-on-error: true
     steps:
@@ -99,7 +98,7 @@ jobs:
           matrix-note: "GameCI compatibility experiment (non-required)"
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
 
@@ -169,7 +168,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: game-ci-experiment
@@ -220,7 +219,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: game-ci-experiment

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -237,8 +237,8 @@ jobs:
     needs:
       - matrix-config
       - runner-preflight
-    # Same-repository pull requests run licensed validation behind approval from
-    # the protected unity-license environment. Fork pull requests remain static-only.
+    # Same-repository pull requests run licensed validation with organization
+    # secrets and no environment approval. Fork pull requests remain static-only.
     if: >-
       ${{
         (github.event_name != 'pull_request' ||
@@ -247,7 +247,6 @@ jobs:
         needs.matrix-config.outputs.ci-owned-docs-only != 'true'
       }}
     runs-on: [self-hosted, Windows, RAM-64GB]
-    environment: unity-license
     timeout-minutes: 660
     strategy:
       fail-fast: false
@@ -301,7 +300,7 @@ jobs:
           key: Library-${{ runner.os }}-${{ runner.arch }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}-${{ env.PACKAGE_HASH }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
 
@@ -364,7 +363,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -420,7 +419,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}

--- a/.github/workflows/update-issue-template-versions.yml
+++ b/.github/workflows/update-issue-template-versions.yml
@@ -66,13 +66,13 @@ jobs:
       - name: Generate auto-commit GitHub App token
         id: app-token
         if: steps.check-autocommit-app.outputs.has-app == 'true'
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.AUTO_COMMIT_APP_ID }}
           private-key: ${{ secrets.AUTO_COMMIT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           token: ${{ steps.app-token.outputs.token || github.token }}
           persist-credentials: false
@@ -91,7 +91,7 @@ jobs:
           echo "Refreshed ${GITHUB_REF_NAME} to $(git rev-parse HEAD) before regenerating the dropdown."
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
           cache: npm

--- a/.github/workflows/update-llms-txt.yml
+++ b/.github/workflows/update-llms-txt.yml
@@ -58,13 +58,13 @@ jobs:
       - name: Generate auto-commit GitHub App token
         id: app-token
         if: steps.check-autocommit-app.outputs.has-app == 'true'
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.AUTO_COMMIT_APP_ID }}
           private-key: ${{ secrets.AUTO_COMMIT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           token: ${{ steps.app-token.outputs.token || github.token }}
           persist-credentials: false
@@ -83,7 +83,7 @@ jobs:
           echo "Refreshed ${GITHUB_REF_NAME} to $(git rev-parse HEAD) before generating llms.txt."
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22.18.0"
           cache: npm

--- a/.llm/skills/index.md
+++ b/.llm/skills/index.md
@@ -225,7 +225,7 @@
 | [Unity Editor CLI Bootstrap](./unity/unity-editor-cli-bootstrap.md)         | [ok] 219   | [intermediate] | [stable] | [risk: none] | unity, cli           |
 | [Unity Editor Design System](./unity/editor-design-system.md)               | [ok] 145   | [basic]        | [stable] | [risk: low]  | unity, editor        |
 | [Unity License Bootstrap](./unity/unity-license-bootstrap.md)               | [ok] 194   | [basic]        | [stable] | [risk: none] | unity, license       |
-| [Unity License Return Guarantee](./unity/unity-license-return-guarantee.md) | [warn] 273 | [intermediate] | [stable] | [risk: none] | unity, serial        |
+| [Unity License Return Guarantee](./unity/unity-license-return-guarantee.md) | [warn] 271 | [intermediate] | [stable] | [risk: none] | unity, serial        |
 | [Unity MCP Test Loop](./unity/mcp-test-loop.md)                             | [ok] 207   | [intermediate] | [stable] | [risk: none] | unity, mcp           |
 | [Unity Perf Test Isolation](./unity/unity-perf-test-isolation.md)           | [ok] 208   | [intermediate] | [stable] | [risk: high] | unity, performance   |
 | [Unity Runner Host Prerequisites](./unity/unity-runner-host-prereqs.md)     | [ok] 251   | [intermediate] | [stable] | [risk: none] | unity, windows       |

--- a/.llm/skills/unity/unity-ci-matrix.md
+++ b/.llm/skills/unity/unity-ci-matrix.md
@@ -115,16 +115,16 @@ and returns the license on every exit path through four redundant layers
 inside the org-lock window, and the next run's return-at-start) -- see
 [unity-license-return-guarantee](./unity-license-return-guarantee.md).
 
-## Serialization + Timeout Invariant
+## Capacity + Timeout Invariant
 
-The Unity serial has only a small activation-seat pool (typically ~2 seats) shared across the whole org and no server-side reclaim, so Unity-licensed jobs are serialized to one-at-a-time in TWO complementary layers. Neither layer alone is sufficient.
+The Unity serial has two activation seats shared across the organization and no server-side reclaim. Two complementary controls keep that capacity safe and fair.
 
-**Two-layer serialization.** `strategy.max-parallel: 1` serializes the matrix cells WITHIN a single run, and the external `ambiguous-organization-build-lock` action serializes ACROSS runs, workflows, and repositories.
+**Matrix serialization and organization admission.** `strategy.max-parallel: 1` serializes matrix cells WITHIN a single run. The external `ambiguous-organization-build-lock` action admits at most two distinct runners ACROSS runs, workflows, and repositories while accounting for cooldowns, quarantines, and account incidents.
 
 - `max-parallel: 1` only: cannot prevent two separate runs (two pushes, `unity-tests` plus `unity-benchmarks`, or another org repo) from racing for the seat.
-- The lock only: leaves all 9 cells spawning at once, so 8 idle cells burn their job-timeout clocks waiting, race for the seat, and clutter logs. Since the lock already forces one-Unity-at-a-time, that parallelism buys ZERO throughput.
+- The lock only: leaves all 9 cells spawning at once, so idle cells burn their job-timeout clocks, one repository can occupy both seats, and logs become noisy without useful per-run throughput.
 
-With both layers, the within-run lock wait collapses to near-zero, so the cross-run lock poll budget can stay generous. This is `max-parallel: 1` ONLY -- it is NOT a native concurrency group. A native `concurrency.group: wallstop-organization-builds` is repository-scoped, serializes whole jobs, and is forbidden. Add `max-parallel: 1` under `strategy:` (sibling of `fail-fast`/`matrix`) on the matrix workflows only (`unity-tests.yml`, `unity-benchmarks.yml`); single-job workflows (`release.unity-checks`, the GameCI experiment) have no matrix and rely solely on the lock for across-run serialization.
+With both controls, a run consumes at most one seat while another repository can use the second. This is `max-parallel: 1` ONLY -- it is NOT a native concurrency group. A native `concurrency.group: wallstop-organization-builds` is repository-scoped, serializes whole jobs, and is forbidden. Add `max-parallel: 1` under `strategy:` (sibling of `fail-fast`/`matrix`) on the matrix workflows only (`unity-tests.yml`, `unity-benchmarks.yml`); single-job workflows (`release.unity-checks`, the GameCI experiment) rely on the lock for cross-run admission.
 
 **Timeout invariant.** GitHub counts the lock-wait against the job clock, so a job at the back of the serialized queue is killed before its lock wait can finish unless:
 

--- a/.llm/skills/unity/unity-license-return-guarantee.md
+++ b/.llm/skills/unity/unity-license-return-guarantee.md
@@ -95,12 +95,12 @@ two concurrent activation seats. There is no floating licensing server to expire
 a stale lease: once a run activates a seat and fails to return it, that seat
 stays consumed until something explicitly runs `-returnlicense`. The runners are
 persistent self-hosted Windows machines, so a force-killed run leaves its
-activation behind on that machine across runs. The org build lock
-(`wallstop-organization-builds`, `max-parallel: 1`) serializes every Unity job
-org-wide, so only one seat is needed at a time -- but the small seat pool means a
-single un-returned activation, plus one held by a concurrent machine, can
-exhaust the pool. The always-return guarantee below exists so no failure mode
-leaves an activation behind for longer than the next job's return-at-start.
+activation behind on that machine across runs. The schema-5 organization lock
+admits at most two distinct runners and reduces effective capacity for
+quarantines or an account incident. A single un-returned activation plus one
+clean concurrent activation can still exhaust the portal seats. The
+always-return guarantee below exists so no failure mode leaves an activation
+behind for longer than the next job's return-at-start.
 
 ## The Activation and Return Contract
 
@@ -177,12 +177,10 @@ This is the accepted cost of leaving the floating licensing server behind:
   return-at-start (layer 1) reclaims any seat the previous run on that machine
   leaked. So in normal operation a leaked seat is freed by the next job that
   lands on the same runner -- the seat is not lost forever.
-- **Accepted residual risk.** The one scenario the four layers do NOT fully cover
-  is BOTH machines leaking a seat simultaneously with zero seats free and no next
-  run able to activate to reach its own return-at-start. The maintainer
-  considered and DECLINED a scheduled reaper for this. The sanctioned mitigation
-  is operational: ask Unity to raise the activation seat count so a transient
-  double-leak cannot exhaust the pool.
+- **Accepted residual risk.** The scheduled lock reaper can quarantine a stale
+  holder and stop new admissions, but it cannot return an activation in Unity's
+  portal. If both machines leak, operators must reconcile the portal and perform
+  exact-incident recovery before capacity is restored.
 
 Do not oversell the guarantee: the four layers make a permanent leak very
 unlikely on persistent runners, but the small seat pool is a real constraint, not
@@ -205,18 +203,18 @@ Each failure mode is covered by at least one of the four return layers. With no
 server-side reclaim, the return-at-start of the next run is the final backstop on
 a persistent runner.
 
-| Failure mode                 | What happens                                     | Covered by                                                          |
-| ---------------------------- | ------------------------------------------------ | ------------------------------------------------------------------- |
-| Clean exit                   | Editor exits 0; script reaches `finally`.        | `try`/`finally` `Invoke-UnityLicenseReturn`.                        |
-| Editor throws / non-zero     | Editor exits non-zero; script reaches `finally`. | `try`/`finally` `Invoke-UnityLicenseReturn`.                        |
-| Step timeout / killed script | Script process is killed; no `finally` runs.     | `if: always()` `return-unity-license` step in the org-lock window.  |
-| Whole runner process killed  | No `finally` and no `if: always()` step run.     | Return-at-start of the NEXT run on the same persistent runner.      |
-| Prior run leaked a seat      | A seat is still activated from a previous run.   | Return-at-start (defensive `-returnlicense` before activating).     |
-| Both machines leak at once   | Zero seats free; a new run cannot activate.      | NOT fully covered -- raise the seat count (accepted residual risk). |
+| Failure mode                 | What happens                                     | Covered by                                                                            |
+| ---------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| Clean exit                   | Editor exits 0; script reaches `finally`.        | `try`/`finally` `Invoke-UnityLicenseReturn`.                                          |
+| Editor throws / non-zero     | Editor exits non-zero; script reaches `finally`. | `try`/`finally` `Invoke-UnityLicenseReturn`.                                          |
+| Step timeout / killed script | Script process is killed; no `finally` runs.     | `if: always()` `return-unity-license` step in the org-lock window.                    |
+| Whole runner process killed  | No `finally` and no `if: always()` step run.     | Return-at-start of the NEXT run on the same persistent runner.                        |
+| Prior run leaked a seat      | A seat is still activated from a previous run.   | Return-at-start (defensive `-returnlicense` before activating).                       |
+| Both machines leak at once   | Zero seats free; a new run cannot activate.      | Schema 5 blocks admission; operators clean the portal and recover the exact incident. |
 
 ## Contract Invariants (review these on every change)
 
-There is no automated validator for these anymore; keep them honest in review:
+Automated workflow contract tests cover these invariants; keep them honest in review too:
 
 1. `run-ci-tests.ps1` brackets activation with `Invoke-UnityLicenseActivate` /
    `Invoke-UnityLicenseReturn` (the return lives in a `finally`), and runs a

--- a/docs/ops/ambiguous-release-migration.md
+++ b/docs/ops/ambiguous-release-migration.md
@@ -81,9 +81,9 @@ Reference: [GitHub repository transfer documentation](https://docs.github.com/ar
 
 Unity workflows target self-hosted Windows runners by labels only. No
 dedicated runner group is provisioned; runners may live in the organization's
-default runner group. The Unity serial has only a small activation-seat pool
-(typically ~2 seats) with no server-side reclaim, so cross-repository
-serialization to one-Unity-at-a-time is provided by the central
+default runner group. The Unity serial has two activation seats and no
+server-side reclaim, so cross-repository admission, cooldowns, quarantines, and
+account incidents are managed by the central
 `Ambiguous-Interactive/ambiguous-organization-build-lock` actions. Native
 GitHub `concurrency` is repository-scoped and must not be used as the
 organization lock.
@@ -101,7 +101,7 @@ organization lock.
     uses: ./.github/actions/validate-unity-license
 
   - name: Acquire organization Unity lock
-    uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
+    uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
     with:
       lock-name: wallstop-organization-builds
       runner-id: ${{ runner.name }}
@@ -110,7 +110,7 @@ organization lock.
       BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
   ```
 
-  The matching release step uses `release-build-lock@v1` with `if:
+  The matching release step uses the same immutable lock commit with `if:
 always()`. Never use `wallstop-organization-builds` as a native GitHub
   `concurrency.group`; the native primitive is repository-scoped and would
   silently fail to serialize across repositories.
@@ -120,10 +120,9 @@ always()`. Never use `wallstop-organization-builds` as a native GitHub
   so missing GitHub secrets fail before blocking the shared Unity seat. IL2CPP
   is the `standalone` entry in the `unity-tests` `test-mode` matrix, not a
   separate job.
-- Publish `.ambiguous-organization-build-lock/` to
-  `Ambiguous-Interactive/ambiguous-organization-build-lock`, create the `v1`
-  tag, and enable private action access for this repository before the Unity
-  workflows are expected to pass.
+- Confirm the lock repository allows organization-owned consumers and the
+  shared writer App credentials are available through organization secrets
+  before the Unity workflows are expected to pass.
 - All Unity jobs declare the uniform `runs-on: [self-hosted, Windows,
 RAM-64GB]` so either Windows machine can pick up any Unity job. The
   `fast` label is no longer requested by any job.
@@ -133,9 +132,11 @@ RAM-64GB]` so either Windows machine can pick up any Unity job. The
 - [ ] Confirm at least one online self-hosted Windows runner has the labels
       `self-hosted`, `Windows`, and `RAM-64GB`.
 - [ ] Confirm `ELI-MACHINE` retains its `fast` label for future opt-in use.
-- [ ] Confirm each of `.github/workflows/unity-tests.yml`,
-      `.github/workflows/unity-benchmarks.yml`, and the `unity-checks`
-      job in `.github/workflows/release.yml` acquires
+- [ ] Confirm every licensed job in `.github/workflows/unity-tests.yml`,
+      `.github/workflows/unity-benchmarks.yml`,
+      `.github/workflows/unity-gameci-experiment.yml`,
+      `.github/workflows/perf-numbers.yml`, and `.github/workflows/release.yml`
+      acquires
       `wallstop-organization-builds`, validates Unity license secrets, runs
       `scripts/unity/run-ci-tests.ps1`, and releases the lock with
       `if: always()`.
@@ -181,6 +182,10 @@ Reference: [GitHub self-hosted runners documentation](https://docs.github.com/en
 
 The tracked workflows expose only secret names. Never write the values into a
 tracked file or generated artifact.
+
+- [ ] Store the Unity and build-lock credentials as organization secrets for
+      the intended organization-owned repositories. Do not add a
+      `unity-license` environment gate to licensed jobs.
 
 - [ ] Confirm Unity workflows can read the three required secret names:
       `UNITY_SERIAL`, `UNITY_EMAIL`, and `UNITY_PASSWORD` (the classic-serial

--- a/docs/ops/ci-and-github-settings.md
+++ b/docs/ops/ci-and-github-settings.md
@@ -23,21 +23,20 @@ default runner group.
 - Speed marker applied only to `ELI-MACHINE`:
   - `fast`
 
-The Unity serial allows only a small activation-seat pool (typically ~2
-concurrent seats) and has no server-side reclaim, so the organization lock
-serializes Unity jobs to one-at-a-time as a safety margin against seat
-exhaustion. GitHub native `concurrency` is repository-scoped and serializes
-whole jobs, so it is not the organization-level lock. All
-Unity-credential-using jobs (`unity-tests`, `benchmarks`, and the
-`unity-checks` job in `release.yml`) validate Unity license secret shape,
-then acquire the central lock immediately before the licensed Unity section:
+The Unity serial allows two concurrent activations and has no server-side
+reclaim. The organization lock admits at most two distinct runners, accounts
+for cooldowns and quarantines, and blocks all new admission during an account
+incident. GitHub native `concurrency` is repository-scoped and serializes whole
+jobs, so it is not the organization-level lock. Every
+Unity-credential-using job validates Unity license secret shape, then acquires
+the central lock immediately before the licensed Unity section:
 
 ```yaml
 - name: Validate Unity license secrets
   uses: ./.github/actions/validate-unity-license
 
 - name: Acquire organization Unity lock
-  uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
+  uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
   with:
     lock-name: wallstop-organization-builds
     runner-id: ${{ runner.name }}
@@ -46,15 +45,14 @@ then acquire the central lock immediately before the licensed Unity section:
     BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 ```
 
-The matching release step uses `release-build-lock@v1` with `if:
-always()`. This lets checkout, cache, Node setup, and assembly discovery
-split across eligible runners while preventing two repositories from
-using the Unity seat at the same time.
+The matching release step uses the same immutable lock commit with `if:
+always()`. This lets checkout, cache, Node setup, and assembly discovery split
+across eligible runners while the organization lock enforces the two-seat
+account boundary.
 
-Before these workflows can run, publish the scaffold in
-`.ambiguous-organization-build-lock/` to
-`Ambiguous-Interactive/ambiguous-organization-build-lock`, push a `v1` tag, and
-enable private action access for this repository if the lock repo is private.
+Before these workflows can run, enable private action access for this
+repository if the lock repository is private and expose the organization Unity
+and writer App secrets to this repository.
 
 Do not declare native `concurrency.group: wallstop-organization-builds`;
 that name is reserved for the central lock action input, not GitHub's
@@ -208,14 +206,10 @@ or manual dispatch only.
 
 ## Licensed Job Guardrails
 
-Licensed Unity jobs intentionally skip:
-
-- all pull requests, including same-repository branches
-- pushes to unprotected branches
-
-This is expected. Pull requests still run GitHub-hosted checks that do not need
-Unity credentials or self-hosted licensed execution. Licensed coverage runs
-after merge on the protected default branch or through controlled dispatch.
+Licensed Unity jobs admit same-repository pull requests, protected branch
+pushes, and controlled dispatches. They reject fork pull requests and pushes to
+unprotected branches. This gives trusted PRs Unity validation without exposing
+organization secrets to fork code.
 
 The workflows must not use `pull_request_target` to check out untrusted fork
 code.
@@ -255,25 +249,20 @@ credential values.
 
 Do not record secret existence, rotation status, the serial, or account
 credential state in tracked files or the local ignored runbook. Keep that
-security status in GitHub environment settings or the approved organization
+security status in GitHub organization settings or the approved organization
 password manager.
 
-## GitHub Environments
+## Organization Secrets and GitHub Environments
 
-Every licensed Unity job uses the protected `unity-license` environment. Store
-the five Unity/build-lock secrets listed above in that environment rather than
-repository-wide scope. Configure required reviewers and protected-branch
-deployment policy before enabling licensed jobs. This repository permits the
-`master` branch and `v*` release tags. npm Trusted Publishing may use a separate
-environment configured with its exact environment name.
+Store the five Unity/build-lock secrets as organization secrets available to
+the intended organization-owned repositories. Licensed jobs do not declare a
+`unity-license` environment, so eligible PR checks start without a deployment
+approval. Keep Unity and App credentials scoped to the exact validation,
+licensed work, cleanup, acquire, and release steps.
 
-For each environment, verify:
-
-1. Required reviewers.
-1. Wait timers.
-1. Deployment branch rules.
-1. Environment secret access through GitHub settings.
-1. Whether the release workflow can request the environment from tag builds.
+Other deployment workflows may still use purpose-specific environments such as
+`github-pages`. Configure reviewers, wait timers, and deployment branch rules
+only for those deployment environments; they must not gate Unity PR validation.
 
 ## Branch and Tag Protection
 

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -4,10 +4,11 @@ const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
+const { walkFiles } = require("../lib/repo-files.js");
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const WORKFLOW_DIR = path.join(REPO_ROOT, ".github", "workflows");
-const LOCK_ACTION_SHA = "cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af";
+const LOCK_ACTION_SHA = "f39ee38533b20592aa0fdf72b3e18d07c46325f3";
 const LOCK_ACTION_PREFIX =
   "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/";
 const UNITY_LOCK_WINDOWS = [
@@ -132,8 +133,7 @@ test("static CI checks stay consolidated behind CI Success", () => {
   const ciSuccess = getJobBlock(source, "ci-success");
   assert.match(ciSuccess, /\n    name: CI Success\n/);
   assert.match(ciSuccess, /\n    if: \$\{\{ always\(\) \}\}\n/);
-  // Pin the fail-closed aggregator action to a versioned tag, not @main/@master.
-  assert.match(ciSuccess, /uses: re-actors\/alls-green@[\w./-]*v\d/);
+  assert.match(ciSuccess, /uses: re-actors\/alls-green@[0-9a-f]{40}/);
   assert.match(ciSuccess, /allowed-skips: ""/);
   assert.match(ciSuccess, /allowed-failures: ""/);
 
@@ -312,7 +312,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     assert.deepEqual(positions, [...positions].sort((a, b) => a - b), `${label} lifecycle order`);
     const orderedContract = [escapeRegExp(acquire), "holder-id-suffix: (.+)\\n          runner-id: (.+)\\n", `- name: ${escapeRegExp(licensedWorkName)}`, "- name: Return Unity license\\n        id: return_unity_license\\n        if: always\\(\\)\\n        timeout-minutes: 5\\n        continue-on-error: true\\n        uses: \\.\\/\\.github\\/actions\\/return-unity-license", `- name: Release organization Unity lock\\n        if: always\\(\\)\\n        ${escapeRegExp(release)}`, "holder-id-suffix: \\1\\n          runner-id: \\2\\n          resource-cleanup-status: \\$\\{\\{ steps\\.return_unity_license\\.outputs\\.resource-cleanup-status \\}\\}\\n          resource-health: \\$\\{\\{ steps\\.return_unity_license\\.outputs\\.resource-health \\}\\}\\n          resource-reason: \\$\\{\\{ steps\\.return_unity_license\\.outputs\\.resource-reason \\}\\}"].join("[\\s\\S]*?");
     assert.match(job, new RegExp(orderedContract), label);
-    assert.match(job, /\n    environment: unity-license\n/, `${label} protected environment`);
+    assert.doesNotMatch(job, /\n    environment:/, `${label} must not require environment approval`);
   }
 });
 
@@ -332,14 +332,27 @@ test("Unity return proof classifications remain fail closed and non-masking", ()
   assert.match(source, /resource-health[\s\S]*resource-reason/); assert.match(actionSource, /resource-health=healthy[\s\S]*?resource-reason=\$healthyReason[\s\S]*?function Resolve-PythonApplication/); assert.match(actionSource, /function Resolve-PythonApplication[\s\S]*?Get-Command \$Name[^\n]*-All[\s\S]*?Test-Path[\s\S]*?--version[\s\S]*?LASTEXITCODE -eq 0/); assert.match(actionSource, /Resolve-PythonApplication -Name python3\b/); assert.match(actionSource, /Resolve-PythonApplication -Name python\b/); assert.doesNotMatch(actionSource, /run:\s*python3(?:\s|$)|run:\s*\|[^\n]*\n\s*python3(?:\s|$)/m);
 });
 // prettier-ignore
-test("licensed workflows pin external actions and reject pull-request licensing", () => {
+test("active workflows pin external actions and scope licensed credentials", () => {
+  const actionFiles = [WORKFLOW_DIR, path.join(REPO_ROOT, ".github", "actions")].flatMap(
+    (root) => walkFiles(root, { match: (file) => /\.ya?ml$/.test(file) })
+  );
+  for (const filePath of actionFiles) {
+    const source = fs.readFileSync(filePath, "utf8");
+    for (const line of source.split(/\r?\n/)) {
+      const match = /^\s*uses:\s+([^\s]+)(?:\s+#.*)?$/.exec(line);
+      if (match && !match[1].startsWith("./") && !match[1].startsWith("docker://")) {
+        assert.match(
+          match[1],
+          /@[0-9a-f]{40}$/,
+          `${path.relative(REPO_ROOT, filePath)}: ${match[1]} must be immutable`
+        );
+      }
+    }
+  }
+
   const files = [...new Set(UNITY_LOCK_WINDOWS.map(([file]) => file))];
   for (const file of files) {
     const source = fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8");
-    for (const line of source.split(/\r?\n/)) {
-      const match = /^\s*uses:\s+([^\s]+)(?:\s+#.*)?$/.exec(line);
-      if (match && !match[1].startsWith("./")) assert.match(match[1], /@[0-9a-f]{40}$/, `${file}: ${match[1]} must be immutable`);
-    }
     const credentialPattern = /secrets\.(?:UNITY_(?:SERIAL|EMAIL|PASSWORD)|BUILD_LOCK_APP_(?:ID|PRIVATE_KEY))/g;
     const sourceCredentialCount = [...source.matchAll(credentialPattern)].length;
     const jobs = UNITY_LOCK_WINDOWS.filter(([candidate]) => candidate === file).map(([, jobId]) => getJobBlock(source, jobId, file));

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -333,23 +333,10 @@ test("Unity return proof classifications remain fail closed and non-masking", ()
 });
 // prettier-ignore
 test("active workflows pin external actions and scope licensed credentials", () => {
-  const actionFiles = [WORKFLOW_DIR, path.join(REPO_ROOT, ".github", "actions")].flatMap(
-    (root) => walkFiles(root, { match: (file) => /\.ya?ml$/.test(file) })
-  );
-  for (const filePath of actionFiles) {
+  for (const filePath of [WORKFLOW_DIR, path.join(REPO_ROOT, ".github", "actions")].flatMap((root) => walkFiles(root, { match: (file) => /\.ya?ml$/.test(file) }))) {
     const source = fs.readFileSync(filePath, "utf8");
-    for (const line of source.split(/\r?\n/)) {
-      const match = /^\s*uses:\s+([^\s]+)(?:\s+#.*)?$/.exec(line);
-      if (match && !match[1].startsWith("./") && !match[1].startsWith("docker://")) {
-        assert.match(
-          match[1],
-          /@[0-9a-f]{40}$/,
-          `${path.relative(REPO_ROOT, filePath)}: ${match[1]} must be immutable`
-        );
-      }
-    }
+    for (const match of source.matchAll(/^\s*uses:\s+([^\s#]+)(?:\s+#.*)?$/gm)) { const action = match[1]; if (!action.startsWith("./") && !action.startsWith("docker://")) assert.match(action, /@[0-9a-f]{40}$/, `${path.relative(REPO_ROOT, filePath)}: ${action} must be immutable`); }
   }
-
   const files = [...new Set(UNITY_LOCK_WINDOWS.map(([file]) => file))];
   for (const file of files) {
     const source = fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8");

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -89,7 +89,10 @@ def validate() -> None:
         BLANKET_PR_REJECTION.search(licensed) is None,
         "Unity job must not reject every pull request",
     )
-    require("environment: unity-license" in licensed, "Unity job must use the protected environment")
+    require(
+        "environment:" not in licensed,
+        "Unity job must use organization secrets without an environment approval gate",
+    )
 
     gate = job_block(source, "unity-ci-success")
     require("if: ${{ always() }}" in gate, "aggregate must always report")


### PR DESCRIPTION
## Outcome

- remove per-repository `unity-license` approval gates from all six licensed jobs
- preserve automatic same-repository PR Unity validation and fork rejection
- update every acquire/release call to the current immutable organization-consumer lock commit
- pin every remote action in active workflows/composites to a full commit SHA, retaining version comments
- update operator and agent guidance for organization secrets, schema 5, and two-seat capacity

## Verification

- red/green: workflow contracts failed on environment gates, old lock refs, docs, and mutable action refs; now 13/13 pass
- `validate:unity-pr-policy`, both cleanup classifier self-tests, actionlint, Prettier, markdownlint, cspell, npm packaging, Unity version validation, and JS budget (13700/13700) pass
- full script suite: 244/247 pass locally; three failures are unchanged Windows-host prerequisites (symlink privilege, Git Bash path form, ANSI wrapping)
- `validate:all` reaches analyzer payload verification, which requires pinned SDK 9.0.314; this host has 9.0.315/10.0.301, so GitHub CI is authoritative for that gate

The PR Unity matrix is the live no-approval canary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Licensed Unity and build-lock credentials move to org-scoped access without environment approval on PRs, and the org lock commit changes—both affect who can trigger secret use and cross-repo seat admission.
> 
> **Overview**
> **Removes `unity-license` environment gates** from licensed Unity jobs (tests, benchmarks, perf, release, GameCI experiment) so same-repo PRs can run Unity validation using **organization secrets** without deployment approval; fork PRs stay excluded.
> 
> **Pins every third-party `uses:` reference** in active workflows and composites to **full commit SHAs** (version kept in comments) and bumps **organization build-lock** acquire/release to `f39ee385…`. **`.devcontainer/validate-caching.sh`** now requires GHCR login steps to match that pinned `docker/login-action` pattern.
> 
> **Docs and agent skills** are updated for **two-seat** Unity capacity, **schema 5** lock behavior, and org-secret setup. **Contract tests** (`ci-aggregate-workflow.test.js`, `validate-unity-pr-policy.py`) enforce no environment on licensed jobs, immutable actions, and the new lock SHA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d55001786d15463481d92c767015ac3ea340a404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->