### PR TITLE
Fail closed when Unity runners are unavailable

### DIFF
--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -75,24 +75,11 @@ permissions:
 jobs:
   runner-preflight:
     name: Self-hosted runner access preflight
-    # Mirrors unity-tests.yml's preflight. Runs on ubuntu-latest BEFORE the
-    # self-hosted perf-benchmarks job tries to queue, converting a missing
-    # ELI-MACHINE from a "queued forever" hang into a fast, explained failure.
-    # It also resolves the canonical Unity version and the licensed-secret
-    # presence so the expensive job and the doc job consume ONE cheap preflight.
-    # CRITICAL CONTRACT: this preflight must NEVER make perf CI more broken than
-    # the no-preflight baseline. If the token cannot list either the org-level
-    # OR repo-level runner inventory (403/404 from both), it emits a
-    # ::warning:: and exits 0 (soft pass). Only a provably-wrong inventory
-    # fails hard. See docs/runbooks/unity-runners-after-transfer.md.
+    # Runs on GitHub-hosted infrastructure before the self-hosted matrix can
+    # queue. The dedicated reader App makes missing inventory a hard failure.
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    # Job-level permissions REPLACE the default set entirely (any scope not listed
-    # becomes 'none'), so contents:read is required for the folded-in checkout step
-    # to read .github/unity-versions.json; actions:read is for the runner-inventory
-    # gh api probe.
     permissions:
-      actions: read
       contents: read
     concurrency:
       group: ${{ github.workflow }}-runner-preflight-${{ github.ref }}
@@ -108,72 +95,12 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Probe self-hosted runner availability
-        env:
-          GH_TOKEN: ${{ secrets.RUNNER_AUDIT_PAT || secrets.GITHUB_TOKEN }}
-          # The `fast` label pins this workflow to ELI-MACHINE specifically (the
-          # only self-hosted Windows runner carrying `fast`). A missing
-          # ELI-MACHINE therefore fails this preflight fast. Keep in sync with
-          # the perf-benchmarks `runs-on:` below.
-          REQUIRED_LABELS: "self-hosted,Windows,RAM-64GB,fast"
-        # gh api --paginate | jq -s pattern mirrors unity-tests.yml /
-        # stuck-job-watchdog.yml; see those files for why `jq -s` is required.
-        run: |
-          set -euo pipefail
-          echo "::group::Runner-access preflight"
-          echo "Required labels: ${REQUIRED_LABELS}"
-          IFS=',' read -r -a required <<< "${REQUIRED_LABELS}"
-          runners_json="$(mktemp)"
-          runners_scope=""
-          if gh api --paginate \
-              "orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners?per_page=100" \
-              2>/dev/null \
-              | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-            runners_scope="org"
-          else
-            if gh api --paginate \
-                "repos/${GITHUB_REPOSITORY}/actions/runners?per_page=100" \
-                2>/dev/null \
-                | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-              runners_scope="repo"
-            fi
-          fi
-          if [ -z "${runners_scope}" ]; then
-            org_url="orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners"
-            repo_url="repos/${GITHUB_REPOSITORY}/actions/runners"
-            {
-              echo "::warning::Runner inventory unavailable from both ${org_url}"
-              echo "::warning::and ${repo_url} (likely 403: GITHUB_TOKEN lacks admin:org"
-              echo "::warning::or administration:read)."
-              echo "::warning::See docs/runbooks/unity-runners-after-transfer.md"
-              echo "::warning::for how to plumb a RUNNER_AUDIT_PAT secret to upgrade"
-              echo "::warning::this soft-pass to a hard-pass."
-            }
-            echo "Soft pass: skipping runner inventory check."
-            echo "::endgroup::"
-            exit 0
-          fi
-          echo "Runner inventory scope: ${runners_scope}"
-          total="$(jq 'length' < "${runners_json}")"
-          echo "Visible runners (${runners_scope} scope): ${total}"
-          matched="$(jq --argjson labels "$(printf '%s\n' "${required[@]}" | jq -R . | jq -s .)" '
-            [ .[]
-              | select(.status == "online")
-              | select(($labels | all(. as $l | (.labels // []) | map(.name) | index($l) | type == "number")))
-            ] | length
-          ' < "${runners_json}")"
-          echo "Runners satisfying ${REQUIRED_LABELS}: ${matched}"
-          if [ "${matched}" -lt 1 ]; then
-            {
-              echo "::error::No online self-hosted runner satisfies the required labels (${REQUIRED_LABELS})."
-              echo "The perf benchmark job would queue forever."
-              echo "See docs/runbooks/unity-runners-after-transfer.md for the post-transfer runner-group ACL fix."
-            }
-            jq '[ .[] | {name, status, busy, labels: [(.labels // [])[].name]} ]' \
-              < "${runners_json}"
-            exit 1
-          fi
-          echo "::endgroup::"
+      - name: Require an online performance runner
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        with:
+          reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
+          reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
+          required-label-sets: '[["self-hosted","Windows","RAM-64GB","fast"]]'
 
       - name: Resolve Unity version from canonical source
         id: versions
@@ -378,7 +305,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: perf-${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -445,7 +372,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: perf-${{ matrix.unity-version }}-${{ matrix.test-mode }}

--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -96,7 +96,7 @@ jobs:
           persist-credentials: false
 
       - name: Require an online performance runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -305,7 +305,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: perf-${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -372,7 +372,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: perf-${{ matrix.unity-version }}-${{ matrix.test-mode }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,87 +157,19 @@ jobs:
 
   runner-preflight:
     name: Self-hosted runner access preflight
-    # See docs/runbooks/unity-runners-after-transfer.md for the design
-    # contract. CRITICAL: this preflight must NEVER make CI more broken
-    # than the no-preflight baseline -- if both runner-inventory endpoints
-    # return 403/404, soft-pass with a ::warning::.
     needs: verify-tag
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    permissions:
-      actions: read
-      # NOTE: `administration: read` is NOT a valid permissions key for
-      # workflow GITHUB_TOKEN (per actionlint and the GitHub docs schema).
-      # Listing self-hosted runners requires admin:org (org-scope) OR a
-      # fine-grained PAT with repo "Administration: read" -- neither of
-      # which the default GITHUB_TOKEN can carry. The soft-pass path in
-      # the run script below is the supported coverage when the token
-      # is unscoped. See docs/runbooks/unity-runners-after-transfer.md.
     concurrency:
       group: ${{ github.workflow }}-runner-preflight-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: Probe self-hosted runner availability
-        env:
-          GH_TOKEN: ${{ secrets.RUNNER_AUDIT_PAT || secrets.GITHUB_TOKEN }}
-          REQUIRED_LABELS: "self-hosted,Windows,RAM-64GB"
-        # gh api --paginate | jq -s pattern mirrors stuck-job-watchdog.yml.
-        run: |
-          set -euo pipefail
-          echo "::group::Runner-access preflight"
-          echo "Required labels: ${REQUIRED_LABELS}"
-          IFS=',' read -r -a required <<< "${REQUIRED_LABELS}"
-          runners_json="$(mktemp)"
-          runners_scope=""
-          if gh api --paginate \
-              "orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners?per_page=100" \
-              2>/dev/null \
-              | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-            runners_scope="org"
-          else
-            if gh api --paginate \
-                "repos/${GITHUB_REPOSITORY}/actions/runners?per_page=100" \
-                2>/dev/null \
-                | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-              runners_scope="repo"
-            fi
-          fi
-          if [ -z "${runners_scope}" ]; then
-            org_url="orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners"
-            repo_url="repos/${GITHUB_REPOSITORY}/actions/runners"
-            {
-              echo "::warning::Runner inventory unavailable from both ${org_url}"
-              echo "::warning::and ${repo_url} (likely 403: GITHUB_TOKEN lacks admin:org"
-              echo "::warning::or administration:read)."
-              echo "::warning::See docs/runbooks/unity-runners-after-transfer.md"
-              echo "::warning::for how to plumb a RUNNER_AUDIT_PAT secret to upgrade"
-              echo "::warning::this soft-pass to a hard-pass."
-            }
-            echo "Soft pass: skipping runner inventory check."
-            echo "::endgroup::"
-            exit 0
-          fi
-          echo "Runner inventory scope: ${runners_scope}"
-          total="$(jq 'length' < "${runners_json}")"
-          echo "Visible runners (${runners_scope} scope): ${total}"
-          matched="$(jq --argjson labels "$(printf '%s\n' "${required[@]}" | jq -R . | jq -s .)" '
-            [ .[]
-              | select(.status == "online")
-              | select(($labels | all(. as $l | (.labels // []) | map(.name) | index($l) | type == "number")))
-            ] | length
-          ' < "${runners_json}")"
-          echo "Runners satisfying ${REQUIRED_LABELS}: ${matched}"
-          if [ "${matched}" -lt 1 ]; then
-            {
-              echo "::error::No online self-hosted runner satisfies the required labels (${REQUIRED_LABELS})."
-              echo "The release would block forever on unity-checks."
-              echo "See docs/runbooks/unity-runners-after-transfer.md for the post-transfer runner-group ACL fix."
-            }
-            jq '[ .[] | {name, status, busy, labels: [(.labels // [])[].name]} ]' \
-              < "${runners_json}"
-            exit 1
-          fi
-          echo "::endgroup::"
+      - name: Require an online Unity runner
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        with:
+          reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
+          reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
+          required-label-sets: '[["self-hosted","Windows","RAM-64GB"]]'
 
   unity-checks:
     name: Trusted Unity release checks
@@ -330,7 +262,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-editmode
@@ -377,7 +309,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-editmode
@@ -514,7 +446,7 @@ jobs:
           overwrite: true
 
       - name: Acquire organization Unity lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-unitypackage
@@ -559,7 +491,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-unitypackage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require an online Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -262,7 +262,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-editmode
@@ -309,7 +309,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-editmode
@@ -446,7 +446,7 @@ jobs:
           overwrite: true
 
       - name: Acquire organization Unity lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-unitypackage
@@ -491,7 +491,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-unitypackage

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -74,7 +74,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require an online Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -198,7 +198,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -250,7 +250,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -67,86 +67,18 @@ jobs:
 
   runner-preflight:
     name: Self-hosted runner access preflight
-    # See docs/runbooks/unity-runners-after-transfer.md for the design
-    # contract. CRITICAL: this preflight must NEVER make Unity CI more
-    # broken than the no-preflight baseline -- if both runner-inventory
-    # endpoints return 403/404, soft-pass with a ::warning::.
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    permissions:
-      actions: read
-      # NOTE: `administration: read` is NOT a valid permissions key for
-      # workflow GITHUB_TOKEN (per actionlint and the GitHub docs schema).
-      # Listing self-hosted runners requires admin:org (org-scope) OR a
-      # fine-grained PAT with repo "Administration: read" -- neither of
-      # which the default GITHUB_TOKEN can carry. The soft-pass path in
-      # the run script below is the supported coverage when the token
-      # is unscoped. See docs/runbooks/unity-runners-after-transfer.md.
     concurrency:
       group: ${{ github.workflow }}-runner-preflight-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: Probe self-hosted runner availability
-        env:
-          GH_TOKEN: ${{ secrets.RUNNER_AUDIT_PAT || secrets.GITHUB_TOKEN }}
-          REQUIRED_LABELS: "self-hosted,Windows,RAM-64GB"
-        # gh api --paginate | jq -s pattern mirrors stuck-job-watchdog.yml.
-        run: |
-          set -euo pipefail
-          echo "::group::Runner-access preflight"
-          echo "Required labels: ${REQUIRED_LABELS}"
-          IFS=',' read -r -a required <<< "${REQUIRED_LABELS}"
-          runners_json="$(mktemp)"
-          runners_scope=""
-          if gh api --paginate \
-              "orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners?per_page=100" \
-              2>/dev/null \
-              | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-            runners_scope="org"
-          else
-            if gh api --paginate \
-                "repos/${GITHUB_REPOSITORY}/actions/runners?per_page=100" \
-                2>/dev/null \
-                | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-              runners_scope="repo"
-            fi
-          fi
-          if [ -z "${runners_scope}" ]; then
-            org_url="orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners"
-            repo_url="repos/${GITHUB_REPOSITORY}/actions/runners"
-            {
-              echo "::warning::Runner inventory unavailable from both ${org_url}"
-              echo "::warning::and ${repo_url} (likely 403: GITHUB_TOKEN lacks admin:org"
-              echo "::warning::or administration:read)."
-              echo "::warning::See docs/runbooks/unity-runners-after-transfer.md"
-              echo "::warning::for how to plumb a RUNNER_AUDIT_PAT secret to upgrade"
-              echo "::warning::this soft-pass to a hard-pass."
-            }
-            echo "Soft pass: skipping runner inventory check."
-            echo "::endgroup::"
-            exit 0
-          fi
-          echo "Runner inventory scope: ${runners_scope}"
-          total="$(jq 'length' < "${runners_json}")"
-          echo "Visible runners (${runners_scope} scope): ${total}"
-          matched="$(jq --argjson labels "$(printf '%s\n' "${required[@]}" | jq -R . | jq -s .)" '
-            [ .[]
-              | select(.status == "online")
-              | select(($labels | all(. as $l | (.labels // []) | map(.name) | index($l) | type == "number")))
-            ] | length
-          ' < "${runners_json}")"
-          echo "Runners satisfying ${REQUIRED_LABELS}: ${matched}"
-          if [ "${matched}" -lt 1 ]; then
-            {
-              echo "::error::No online self-hosted runner satisfies the required labels (${REQUIRED_LABELS})."
-              echo "The Unity matrix would queue forever."
-              echo "See docs/runbooks/unity-runners-after-transfer.md for the post-transfer runner-group ACL fix."
-            }
-            jq '[ .[] | {name, status, busy, labels: [(.labels // [])[].name]} ]' \
-              < "${runners_json}"
-            exit 1
-          fi
-          echo "::endgroup::"
+      - name: Require an online Unity runner
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        with:
+          reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
+          reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
+          required-label-sets: '[["self-hosted","Windows","RAM-64GB"]]'
 
   benchmarks:
     name: Benchmarks ${{ matrix.unity-version }} ${{ matrix.test-mode }}
@@ -266,7 +198,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -318,7 +250,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}

--- a/.github/workflows/unity-gameci-experiment.yml
+++ b/.github/workflows/unity-gameci-experiment.yml
@@ -27,49 +27,13 @@ jobs:
     name: Self-hosted runner access preflight
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    permissions:
-      actions: read
     steps:
-      - name: Probe self-hosted runner availability
-        env:
-          GH_TOKEN: ${{ secrets.RUNNER_AUDIT_PAT || secrets.GITHUB_TOKEN }}
-          REQUIRED_LABELS: "self-hosted,Windows,RAM-64GB"
-        run: |
-          set -euo pipefail
-          echo "::group::Runner-access preflight"
-          echo "Required labels: ${REQUIRED_LABELS}"
-          IFS=',' read -r -a required <<< "${REQUIRED_LABELS}"
-          runners_json="$(mktemp)"
-          runners_scope=""
-          if gh api --paginate \
-              "orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners?per_page=100" \
-              2>/dev/null \
-              | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-            runners_scope="org"
-          else
-            if gh api --paginate \
-                "repos/${GITHUB_REPOSITORY}/actions/runners?per_page=100" \
-                2>/dev/null \
-                | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-              runners_scope="repo"
-            fi
-          fi
-          if [ -z "${runners_scope}" ]; then
-            echo "::warning::Runner inventory unavailable; soft-passing GameCI experiment preflight."
-            echo "::endgroup::"
-            exit 0
-          fi
-          matched="$(jq --argjson labels "$(printf '%s\n' "${required[@]}" | jq -R . | jq -s .)" '
-            [ .[]
-              | select(.status == "online")
-              | select(($labels | all(. as $l | (.labels // []) | map(.name) | index($l) | type == "number")))
-            ] | length
-          ' < "${runners_json}")"
-          if [ "${matched}" -lt 1 ]; then
-            echo "::error::No online self-hosted runner satisfies ${REQUIRED_LABELS}."
-            exit 1
-          fi
-          echo "::endgroup::"
+      - name: Require an online Unity runner
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        with:
+          reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
+          reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
+          required-label-sets: '[["self-hosted","Windows","RAM-64GB"]]'
 
   game-ci-experiment:
     name: GameCI ${{ inputs.unity-version }} ${{ inputs.test-mode }}
@@ -168,7 +132,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: game-ci-experiment
@@ -219,7 +183,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: game-ci-experiment

--- a/.github/workflows/unity-gameci-experiment.yml
+++ b/.github/workflows/unity-gameci-experiment.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Require an online Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -132,7 +132,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: game-ci-experiment
@@ -183,7 +183,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: game-ci-experiment

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -123,17 +123,8 @@ jobs:
 
   runner-preflight:
     name: Self-hosted runner access preflight
-    # Runs on ubuntu-latest BEFORE any self-hosted matrix entry tries to
-    # queue. This converts the "stuck forever" failure mode that motivated
-    # docs/runbooks/unity-runners-after-transfer.md into a fast,
-    # clearly-explained failure. The runbook explains the post-transfer
-    # runner-group ACL pitfall and the resolution paths.
-    #
-    # CRITICAL CONTRACT: this preflight must NEVER make Unity CI more
-    # broken than the no-preflight baseline. If the token cannot list
-    # either the org-level OR repo-level runner inventory (403/404 from
-    # both), the preflight emits a ::warning:: and exits 0 (soft pass).
-    # Only when we can prove the inventory is wrong do we fail hard.
+    # Runs on GitHub-hosted infrastructure before any self-hosted matrix entry
+    # can queue. Reader-App or inventory failures are intentionally fail closed.
     if: >-
       ${{
         (github.event_name != 'pull_request' ||
@@ -142,95 +133,16 @@ jobs:
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    permissions:
-      actions: read
-      # NOTE: `administration: read` is NOT a valid permissions key for
-      # workflow GITHUB_TOKEN (per actionlint and the GitHub docs schema).
-      # Listing self-hosted runners requires admin:org (org-scope) OR a
-      # fine-grained PAT with repo "Administration: read" -- neither of
-      # which the default GITHUB_TOKEN can carry. The soft-pass path in
-      # the run script below is the supported coverage when the token
-      # is unscoped. See docs/runbooks/unity-runners-after-transfer.md.
     concurrency:
       group: ${{ github.workflow }}-runner-preflight-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: Probe self-hosted runner availability
-        env:
-          GH_TOKEN: ${{ secrets.RUNNER_AUDIT_PAT || secrets.GITHUB_TOKEN }}
-          REQUIRED_LABELS: "self-hosted,Windows,RAM-64GB"
-        # Repeated literal of the labels list. Keep in sync with unity-tests
-        # `runs-on:` declaration below; this preflight must run before any
-        # self-hosted matrix in this workflow.
-        # gh api --paginate | jq -s pattern mirrors stuck-job-watchdog.yml;
-        # see that file's comments for why `jq -s` is required.
-        run: |
-          set -euo pipefail
-          echo "::group::Runner-access preflight"
-          echo "Required labels: ${REQUIRED_LABELS}"
-          IFS=',' read -r -a required <<< "${REQUIRED_LABELS}"
-          runners_json="$(mktemp)"
-          runners_scope=""
-          # 1) Try the ORG-scoped endpoint first. Self-hosted runners live
-          # at org scope in this repo (group "Default" in Ambiguous-Interactive).
-          # The default GITHUB_TOKEN often lacks admin:org and will 403 here.
-          if gh api --paginate \
-              "orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners?per_page=100" \
-              2>/dev/null \
-              | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-            runners_scope="org"
-          else
-            # 2) Fall back to the REPO-scoped endpoint. Requires
-            # administration:read; less common to be granted but possible.
-            if gh api --paginate \
-                "repos/${GITHUB_REPOSITORY}/actions/runners?per_page=100" \
-                2>/dev/null \
-                | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-              runners_scope="repo"
-            fi
-          fi
-          if [ -z "${runners_scope}" ]; then
-            # 3) Soft pass: both endpoints failed (almost certainly the
-            # default GITHUB_TOKEN lacks scope). DO NOT fail the build --
-            # that would make Unity CI strictly more broken than baseline.
-            # The watchdog + manual unstick workflows still cover the
-            # actually-stuck case.
-            org_url="orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners"
-            repo_url="repos/${GITHUB_REPOSITORY}/actions/runners"
-            {
-              echo "::warning::Runner inventory unavailable from both ${org_url}"
-              echo "::warning::and ${repo_url} (likely 403: GITHUB_TOKEN lacks admin:org"
-              echo "::warning::or administration:read)."
-              echo "::warning::See docs/runbooks/unity-runners-after-transfer.md"
-              echo "::warning::for how to plumb a RUNNER_AUDIT_PAT secret to upgrade"
-              echo "::warning::this soft-pass to a hard-pass."
-            }
-            echo "Soft pass: skipping runner inventory check."
-            echo "::endgroup::"
-            exit 0
-          fi
-          echo "Runner inventory scope: ${runners_scope}"
-          total="$(jq 'length' < "${runners_json}")"
-          echo "Visible runners (${runners_scope} scope): ${total}"
-          # Find at least one ONLINE runner with all required labels.
-          matched="$(jq --argjson labels "$(printf '%s\n' "${required[@]}" | jq -R . | jq -s .)" '
-            [ .[]
-              | select(.status == "online")
-              | select(($labels | all(. as $l | (.labels // []) | map(.name) | index($l) | type == "number")))
-            ] | length
-          ' < "${runners_json}")"
-          echo "Runners satisfying ${REQUIRED_LABELS}: ${matched}"
-          if [ "${matched}" -lt 1 ]; then
-            {
-              echo "::error::No online self-hosted runner satisfies the required labels (${REQUIRED_LABELS})."
-              echo "The Unity matrix would queue forever."
-              echo "See docs/runbooks/unity-runners-after-transfer.md for the post-transfer runner-group ACL fix."
-            }
-            jq '[ .[] | {name, status, busy, labels: [(.labels // [])[].name]} ]' \
-              < "${runners_json}"
-            exit 1
-          fi
-          echo "::endgroup::"
+      - name: Require an online Unity runner
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        with:
+          reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
+          reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
+          required-label-sets: '[["self-hosted","Windows","RAM-64GB"]]'
 
   unity-tests:
     name: Unity ${{ matrix.unity-version }} ${{ matrix.test-mode }}
@@ -363,7 +275,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -419,7 +331,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -138,7 +138,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require an online Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -275,7 +275,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -331,7 +331,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}

--- a/docs/ops/ambiguous-release-migration.md
+++ b/docs/ops/ambiguous-release-migration.md
@@ -101,7 +101,7 @@ organization lock.
     uses: ./.github/actions/validate-unity-license
 
   - name: Acquire organization Unity lock
-    uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+    uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
     with:
       lock-name: wallstop-organization-builds
       runner-id: ${{ runner.name }}

--- a/docs/ops/ambiguous-release-migration.md
+++ b/docs/ops/ambiguous-release-migration.md
@@ -101,7 +101,7 @@ organization lock.
     uses: ./.github/actions/validate-unity-license
 
   - name: Acquire organization Unity lock
-    uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+    uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
     with:
       lock-name: wallstop-organization-builds
       runner-id: ${{ runner.name }}

--- a/docs/ops/ci-and-github-settings.md
+++ b/docs/ops/ci-and-github-settings.md
@@ -36,7 +36,7 @@ the central lock immediately before the licensed Unity section:
   uses: ./.github/actions/validate-unity-license
 
 - name: Acquire organization Unity lock
-  uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+  uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
   with:
     lock-name: wallstop-organization-builds
     runner-id: ${{ runner.name }}

--- a/docs/ops/ci-and-github-settings.md
+++ b/docs/ops/ci-and-github-settings.md
@@ -36,7 +36,7 @@ the central lock immediately before the licensed Unity section:
   uses: ./.github/actions/validate-unity-license
 
 - name: Acquire organization Unity lock
-  uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
+  uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@59a2fa98224569e5a697f271a3ac4b866c53ac2c # v1.8.3
   with:
     lock-name: wallstop-organization-builds
     runner-id: ${{ runner.name }}

--- a/docs/runbooks/unity-runners-after-transfer.md
+++ b/docs/runbooks/unity-runners-after-transfer.md
@@ -74,25 +74,21 @@ After applying the chosen resolution, re-run the queued workflow from the Action
 
 ## Preflight diagnostic in this repository
 
-Unity workflows in this repository run a `runner-preflight` job on `ubuntu-latest` before the self-hosted matrix. That preflight queries `gh api orgs/${OWNER}/actions/runners` first and, on 403/404 (the default `secrets.GITHUB_TOKEN` cannot list org-scoped runners under most org policies), falls back to `gh api repos/${GITHUB_REPOSITORY}/actions/runners`. If both endpoints fail (typically a 403 from each because the token is unscoped for runner administration), the preflight emits a `::warning::` and exits 0 (soft pass). The preflight must NEVER be more strict than the no-preflight baseline; its only job is to surface a fast, clear failure when it can prove the runner inventory is wrong.
+Unity workflows in this repository run a `runner-preflight` job on
+`ubuntu-latest` before the self-hosted matrix. The immutable central
+`check-unity-runner-availability` action uses the organization-scoped
+`BUILD_LOCK_READER_APP_ID` and `BUILD_LOCK_READER_APP_PRIVATE_KEY` secrets. Its
+reader App has Metadata, Actions, and organization self-hosted runner read
+permission. It filters runner groups through the repository-visible API and
+requires an online runner with the exact labels requested by the downstream
+job.
 
-### Upgrading the soft pass to a hard pass
-
-The default `secrets.GITHUB_TOKEN` cannot list runners under a repo-level scope strict enough to reflect the runner-group ACL, so the preflight falls back to a soft pass on most installations. To upgrade the soft-pass path to a hard-pass:
-
-1. Mint a fine-grained personal access token (or a GitHub App installation token) holding the repository-level "Administration: read" permission, scoped to `Ambiguous-Interactive/DxMessaging` only. Do NOT use a classic PAT with `admin:org`, and do NOT use the fine-grained "Organization administration: read" permission: both grant org-wide visibility, which causes `gh api orgs/<org>/actions/runners` to return the entire org runner inventory regardless of any individual repository's runner-group ACL. That would let the preflight see runners as online and silently pass even when the post-transfer ACL is broken, which is exactly the pitfall this runbook addresses.
-1. Add the token as a repository secret named `RUNNER_AUDIT_PAT`.
-1. Wire the workflow to prefer `RUNNER_AUDIT_PAT` over `GITHUB_TOKEN` when set, and to query the repo-scoped endpoint `repos/<owner>/<repo>/actions/runners`. That endpoint enforces the runner-group ACL: if the repository does not have access to a runner via its group, the runner is invisible there, which is the live ACL state we want the preflight to detect. The preflight retains the same soft-pass behavior if the secret is absent, so this is opt-in.
-
-The rationale is deliberate: we want the upgrade token to FAIL when the ACL is misconfigured, not paper over it; that is why we use the repo-scoped "Administration: read" permission rather than any org admin scope. Without that property the hard-pass mode would be worse than the soft-pass mode it replaces.
-
-This is intentionally documented but NOT enabled by default: the soft pass is the correct conservative behavior given the threat model. Operators see a `::warning::` annotation rather than a green check, and the existing watchdog + manual unstick workflows continue to recover any actually-stuck job.
-
-Because `administration` is not a valid `permissions:` key for the workflow-scoped `GITHUB_TOKEN`, the only way to grant the preflight read access to the runner inventory under a repo-level scope is to provision an external token (PAT or app installation token) via `RUNNER_AUDIT_PAT` (see above). Without that, the preflight falls back to the soft-pass path, which is the design intent.
-
-### Follow-up: composite action factoring
-
-The preflight shell currently lives inline in three workflows (`unity-tests.yml`, `unity-benchmarks.yml`, `release.yml`). A composite action under `.github/actions/runner-access-preflight/` would deduplicate the block. Out of scope for the current change; track here so the next maintainer can find it.
+The preflight is fail closed. Missing reader credentials, an unreadable
+inventory, a runner-group ACL that excludes this repository, or no matching
+online runner makes the workflow red before any self-hosted job is queued. Do
+not restore the retired `RUNNER_AUDIT_PAT` soft-pass path. Organization secrets
+avoid per-repository environment provisioning or manual approvals while the
+reader App remains the least-privilege inventory boundary.
 
 If the preflight passes but the matrix job still stays queued, the cause is more likely the dispatcher bug (see [GitHub Community Discussion #186811](https://github.com/orgs/community/discussions/186811)) than the access list. Use the recovery workflows in this repository: [unstick-run.yml](https://github.com/Ambiguous-Interactive/DxMessaging/blob/master/.github/workflows/unstick-run.yml) for manual recovery and [stuck-job-watchdog.yml](https://github.com/Ambiguous-Interactive/DxMessaging/blob/master/.github/workflows/stuck-job-watchdog.yml) for the automated path.
 

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -8,7 +8,7 @@ const { walkFiles } = require("../lib/repo-files.js");
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const WORKFLOW_DIR = path.join(REPO_ROOT, ".github", "workflows");
-const LOCK_ACTION_SHA = "092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315";
+const LOCK_ACTION_SHA = "a8d43dd87a938f1b3417fd8a9310354bf38e2fd1";
 const LOCK_ACTION_PREFIX =
   "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/";
 const UNITY_LOCK_WINDOWS = [
@@ -271,7 +271,7 @@ test("copyable build-lock documentation follows the runner and App credential co
   ]) {
     const source = fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
     const acquireExample = new RegExp(
-      `uses: ${escapeRegExp(LOCK_ACTION_PREFIX)}acquire-build-lock@${LOCK_ACTION_SHA} # v1.7.1[\\s\\S]*?\`\`\``
+      `uses: ${escapeRegExp(LOCK_ACTION_PREFIX)}acquire-build-lock@${LOCK_ACTION_SHA} # v1.8.2[\\s\\S]*?\`\`\``
     ).exec(source);
 
     assert.ok(acquireExample, `${relativePath} must contain a copyable acquire example`);
@@ -296,9 +296,9 @@ test("copyable build-lock documentation follows the runner and App credential co
 });
 // prettier-ignore
 test("every Unity lock window releases with explicit cleanup proof", () => {
-  const acquire = `uses: ${LOCK_ACTION_PREFIX}acquire-build-lock@${LOCK_ACTION_SHA} # v1.7.1`;
-  const release = `uses: ${LOCK_ACTION_PREFIX}release-build-lock@${LOCK_ACTION_SHA} # v1.7.1`;
-  const workflowSources = fs.readdirSync(WORKFLOW_DIR).filter((file) => /\.ya?ml$/.test(file)).map((file) => fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8"));
+  const acquire = `uses: ${LOCK_ACTION_PREFIX}acquire-build-lock@${LOCK_ACTION_SHA} # v1.8.2`;
+  const release = `uses: ${LOCK_ACTION_PREFIX}release-build-lock@${LOCK_ACTION_SHA} # v1.8.2`;
+  const runnerLabels = new Map([["perf-numbers.yml", '[["self-hosted","Windows","RAM-64GB","fast"]]'], ["release.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-benchmarks.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-gameci-experiment.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-tests.yml", '[["self-hosted","Windows","RAM-64GB"]]']]); const preflightAction = `${LOCK_ACTION_PREFIX}check-unity-runner-availability@${LOCK_ACTION_SHA} # v1.8.2`; const workflowSources = fs.readdirSync(WORKFLOW_DIR).filter((file) => /\.ya?ml$/.test(file)).map((file) => fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8")); for (const [file, labels] of runnerLabels) { const source = fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8"); const preflight = getJobBlock(source, "runner-preflight", file); assert.match(preflight, /\n    runs-on: ubuntu-latest\n/, file); assert.match(preflight, new RegExp(`uses: ${escapeRegExp(preflightAction)}`), file); assert.match(preflight, /reader-app-id: \$\{\{ secrets\.BUILD_LOCK_READER_APP_ID \}\}/, file); assert.match(preflight, /reader-app-private-key: \$\{\{ secrets\.BUILD_LOCK_READER_APP_PRIVATE_KEY \}\}/, file); assert.match(preflight, new RegExp(`required-label-sets: '${escapeRegExp(labels)}'`), file); assert.doesNotMatch(preflight, /RUNNER_AUDIT_PAT|Soft pass|soft-pass/i, file); }
   assert.equal(workflowSources.reduce((count, source) => count + source.split(acquire).length - 1, 0), UNITY_LOCK_WINDOWS.length);
   assert.equal(workflowSources.reduce((count, source) => count + source.split(release).length - 1, 0), UNITY_LOCK_WINDOWS.length);
   for (const [file, jobId, licensedWorkName] of UNITY_LOCK_WINDOWS) {

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -8,7 +8,7 @@ const { walkFiles } = require("../lib/repo-files.js");
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const WORKFLOW_DIR = path.join(REPO_ROOT, ".github", "workflows");
-const LOCK_ACTION_SHA = "a8d43dd87a938f1b3417fd8a9310354bf38e2fd1";
+const LOCK_ACTION_SHA = "59a2fa98224569e5a697f271a3ac4b866c53ac2c";
 const LOCK_ACTION_PREFIX =
   "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/";
 const UNITY_LOCK_WINDOWS = [
@@ -271,7 +271,7 @@ test("copyable build-lock documentation follows the runner and App credential co
   ]) {
     const source = fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
     const acquireExample = new RegExp(
-      `uses: ${escapeRegExp(LOCK_ACTION_PREFIX)}acquire-build-lock@${LOCK_ACTION_SHA} # v1.8.2[\\s\\S]*?\`\`\``
+      `uses: ${escapeRegExp(LOCK_ACTION_PREFIX)}acquire-build-lock@${LOCK_ACTION_SHA} # v1.8.3[\\s\\S]*?\`\`\``
     ).exec(source);
 
     assert.ok(acquireExample, `${relativePath} must contain a copyable acquire example`);
@@ -296,9 +296,9 @@ test("copyable build-lock documentation follows the runner and App credential co
 });
 // prettier-ignore
 test("every Unity lock window releases with explicit cleanup proof", () => {
-  const acquire = `uses: ${LOCK_ACTION_PREFIX}acquire-build-lock@${LOCK_ACTION_SHA} # v1.8.2`;
-  const release = `uses: ${LOCK_ACTION_PREFIX}release-build-lock@${LOCK_ACTION_SHA} # v1.8.2`;
-  const runnerLabels = new Map([["perf-numbers.yml", '[["self-hosted","Windows","RAM-64GB","fast"]]'], ["release.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-benchmarks.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-gameci-experiment.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-tests.yml", '[["self-hosted","Windows","RAM-64GB"]]']]); const preflightAction = `${LOCK_ACTION_PREFIX}check-unity-runner-availability@${LOCK_ACTION_SHA} # v1.8.2`; const workflowSources = fs.readdirSync(WORKFLOW_DIR).filter((file) => /\.ya?ml$/.test(file)).map((file) => fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8")); for (const [file, labels] of runnerLabels) { const source = fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8"); const preflight = getJobBlock(source, "runner-preflight", file); assert.match(preflight, /\n    runs-on: ubuntu-latest\n/, file); assert.match(preflight, new RegExp(`uses: ${escapeRegExp(preflightAction)}`), file); assert.match(preflight, /reader-app-id: \$\{\{ secrets\.BUILD_LOCK_READER_APP_ID \}\}/, file); assert.match(preflight, /reader-app-private-key: \$\{\{ secrets\.BUILD_LOCK_READER_APP_PRIVATE_KEY \}\}/, file); assert.match(preflight, new RegExp(`required-label-sets: '${escapeRegExp(labels)}'`), file); assert.doesNotMatch(preflight, /RUNNER_AUDIT_PAT|Soft pass|soft-pass/i, file); }
+  const acquire = `uses: ${LOCK_ACTION_PREFIX}acquire-build-lock@${LOCK_ACTION_SHA} # v1.8.3`;
+  const release = `uses: ${LOCK_ACTION_PREFIX}release-build-lock@${LOCK_ACTION_SHA} # v1.8.3`;
+  const runnerLabels = new Map([["perf-numbers.yml", '[["self-hosted","Windows","RAM-64GB","fast"]]'], ["release.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-benchmarks.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-gameci-experiment.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-tests.yml", '[["self-hosted","Windows","RAM-64GB"]]']]); const preflightAction = `${LOCK_ACTION_PREFIX}check-unity-runner-availability@${LOCK_ACTION_SHA} # v1.8.3`; const workflowSources = fs.readdirSync(WORKFLOW_DIR).filter((file) => /\.ya?ml$/.test(file)).map((file) => fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8")); for (const [file, labels] of runnerLabels) { const source = fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8"); const preflight = getJobBlock(source, "runner-preflight", file); assert.match(preflight, /\n    runs-on: ubuntu-latest\n/, file); assert.match(preflight, new RegExp(`uses: ${escapeRegExp(preflightAction)}`), file); assert.match(preflight, /reader-app-id: \$\{\{ secrets\.BUILD_LOCK_READER_APP_ID \}\}/, file); assert.match(preflight, /reader-app-private-key: \$\{\{ secrets\.BUILD_LOCK_READER_APP_PRIVATE_KEY \}\}/, file); assert.match(preflight, new RegExp(`required-label-sets: '${escapeRegExp(labels)}'`), file); assert.doesNotMatch(preflight, /RUNNER_AUDIT_PAT|Soft pass|soft-pass/i, file); }
   assert.equal(workflowSources.reduce((count, source) => count + source.split(acquire).length - 1, 0), UNITY_LOCK_WINDOWS.length);
   assert.equal(workflowSources.reduce((count, source) => count + source.split(release).length - 1, 0), UNITY_LOCK_WINDOWS.length);
   for (const [file, jobId, licensedWorkName] of UNITY_LOCK_WINDOWS) {


### PR DESCRIPTION
## Summary
- replace five PAT/GITHUB_TOKEN soft-pass probes with the v1.8.2 reader-App preflight
- pin all six Unity lock lifecycles to the schema-5-capable v1.8.2 SHA
- preserve same-repository PR Unity validation without environments or manual approvals
- keep every aggregate verdict fail closed when preflight or Unity work fails

## Verification
- focused CI contract: 13/13 pass
- validate:all policy, version, line-budget, and license-classifier gates pass (local analyzer payload remains limited by the repo-pinned .NET 9.0.314 SDK not installed on this host)
- actionlint built-in validation passes for all five workflows
- Prettier check passes
- full npm test baseline-only Windows/WSL portability failures reproduced on untouched master

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Unity CI and release gates now depend on org reader App secrets and will hard-fail if misconfigured, whereas the old soft-pass could still queue indefinitely; lock action upgrades touch every licensed job path.
> 
> **Overview**
> Replaces duplicated inline `gh api` runner probes in five Unity workflows with the shared **`check-unity-runner-availability`** action at **v1.8.3**, wired to **`BUILD_LOCK_READER_APP_*`** secrets and per-workflow **`required-label-sets`** (perf keeps the extra **`fast`** label).
> 
> **Preflight behavior shifts from soft-pass** (warn and continue when `GITHUB_TOKEN`/`RUNNER_AUDIT_PAT` could not list runners) **to fail-closed**: missing reader credentials, unreadable inventory, ACL gaps, or no matching online runner fails before self-hosted jobs queue. Job-level **`actions: read`** on preflight is dropped where it only served the old probe.
> 
> All **`acquire-build-lock`** / **`release-build-lock`** pins move from **v1.7.1** to the same **v1.8.3** SHA across perf, release, benchmarks, GameCI experiment, and unity-tests. Docs and **`ci-aggregate-workflow.test.js`** are updated to match the new contract and drop **`RUNNER_AUDIT_PAT`** guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce87d7ab9a2c98ebab82bbaf36088326c5fb656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->