### PR TITLE
feat(ci): bounded retry-with-backoff for Unity serial activation (build-lock #57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -724,6 +724,11 @@ jobs:
         shell: bash
         run: node --test scripts/
 
+      - name: Test Unity license activation retry
+        if: ${{ needs.changes.outputs.scripts != 'false' }}
+        shell: pwsh
+        run: ./scripts/__tests__/test-unity-license-activation-retry.ps1 -VerboseOutput
+
       - name: Run validators
         if: ${{ needs.changes.outputs.scripts != 'false' && matrix.os == 'ubuntu-latest' }}
         shell: bash

--- a/scripts/__tests__/test-unity-license-activation-retry.ps1
+++ b/scripts/__tests__/test-unity-license-activation-retry.ps1
@@ -1,0 +1,267 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Data-driven tests for the Unity serial-activation retry policy in
+    scripts/unity/run-ci-tests.ps1 (build-lock issue #57).
+
+.DESCRIPTION
+    The organization build lock's release cooldown is deliberately near-zero, so a
+    freshly acquired seat can hit Unity error 20111 ("maximum number of
+    activations") while the previous holder's seat is still propagating as
+    returned. Invoke-UnityLicenseActivate now retries that transient contention
+    within a bounded wall-clock budget with jittered exponential backoff, while
+    failing fast on permanent errors and preserving the 20111 evidence for the
+    account-incident path when contention does NOT clear.
+
+    This runner extracts the real function definitions from run-ci-tests.ps1 via
+    the PowerShell AST (the script's top-level param()/execution make it
+    non-dot-sourceable) and exercises them WITHOUT launching Unity:
+      * the pure classifier / backoff / budget helpers via data-driven tables, and
+      * the full retry loop via Invoke-UnityLicenseActivate's testability seam
+        (-ActivationInvoker), a fake editor that is deterministic and needs no
+        external process, so this runs on ubuntu-latest, macos-latest, and Windows
+        alike.
+#>
+[CmdletBinding()]
+param(
+    [switch]$VerboseOutput
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $PSScriptRoot
+$target = Join-Path $scriptRoot 'unity/run-ci-tests.ps1'
+if (-not (Test-Path -LiteralPath $target -PathType Leaf)) {
+    Write-Host "FATAL: cannot find run-ci-tests.ps1 at $target"
+    exit 1
+}
+
+# Pull the real function definitions out of run-ci-tests.ps1 without running its
+# main flow (top-level param() + execution make it non-dot-sourceable). Same idiom
+# as run-ci-tests-enter-play-mode.test.js's static extraction, but in-process so we
+# can actually invoke the functions.
+$tokens = $null
+$errs = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($target, [ref]$tokens, [ref]$errs)
+if ($errs -and $errs.Count -gt 0) {
+    Write-Host "FATAL: run-ci-tests.ps1 has parse errors:"
+    $errs | ForEach-Object { Write-Host "  $($_.Extent.StartLineNumber): $($_.Message)" }
+    exit 1
+}
+foreach ($name in @(
+    'Get-UnityActivationRetryBudgetSeconds',
+    'Get-UnityActivationRetryDelaySeconds',
+    'Get-UnityActivationFailureClass',
+    'Write-CiNotice',
+    'Invoke-UnityLicenseActivate'
+)) {
+    $fn = $ast.FindAll(
+        {
+            param($n)
+            $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq $name
+        },
+        $true
+    ) | Select-Object -First 1
+    if (-not $fn) {
+        Write-Host "FATAL: function '$name' not found in run-ci-tests.ps1"
+        exit 1
+    }
+    Invoke-Expression $fn.Extent.Text
+}
+
+$passed = 0
+$failed = 0
+
+function Assert-That {
+    param([string]$Description, [bool]$Condition)
+    if ($Condition) {
+        if ($VerboseOutput) { Write-Host "  PASS: $Description" }
+        $script:passed++
+    } else {
+        Write-Host "  FAIL: $Description"
+        $script:failed++
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 1. Classifier (Get-UnityActivationFailureClass) — data-driven.
+#    Real Unity licensing log fragments -> (Class, Reason). The boundary rows
+#    (201110 / 120111 must NOT match 20111) protect the incident guard rails.
+# ---------------------------------------------------------------------------
+$classifierCases = @(
+    @{ Name = 'exit 0 is success regardless of log'; ExitCode = 0; Log = 'anything at all'; Class = 'success'; Reason = 'activated' }
+    @{ Name = '20111 numeric code -> retryable account-limit'; ExitCode = 1; Log = 'Licensing::Client Error: Code 20111'; Class = 'retryable'; Reason = 'account-limit-20111' }
+    @{ Name = '20111 human string -> retryable account-limit'; ExitCode = 1; Log = 'serial has reached the maximum number of activations'; Class = 'retryable'; Reason = 'account-limit-20111' }
+    @{ Name = '20111 human string is case-insensitive'; ExitCode = 1; Log = 'Maximum Number Of Activations reached'; Class = 'retryable'; Reason = 'account-limit-20111' }
+    @{ Name = '20111 wins even with a nonzero-but-odd exit'; ExitCode = 137; Log = 'Error: Code 20111 reached'; Class = 'retryable'; Reason = 'account-limit-20111' }
+    @{ Name = '201110 does NOT match 20111 (trailing digit guard)'; ExitCode = 1; Log = 'Error: Code 201110 something else'; Class = 'retryable'; Reason = 'unknown' }
+    @{ Name = '120111 does NOT match 20111 (leading digit guard)'; ExitCode = 1; Log = 'Error: Code 120111 something else'; Class = 'retryable'; Reason = 'unknown' }
+    @{ Name = '20113 numeric code -> hard serial-expired'; ExitCode = 1; Log = 'Licensing::Client Error: Code 20113'; Class = 'hard'; Reason = 'serial-expired-20113' }
+    @{ Name = '20113 human string -> hard serial-expired'; ExitCode = 1; Log = 'the serial expired on 2026-01-01'; Class = 'hard'; Reason = 'serial-expired-20113' }
+    @{ Name = '20111 takes precedence over a co-occurring 20113'; ExitCode = 1; Log = 'Code 20113 ... maximum number of activations'; Class = 'retryable'; Reason = 'account-limit-20111' }
+    @{ Name = 'process kill (137) with empty log -> retryable unknown'; ExitCode = 137; Log = ''; Class = 'retryable'; Reason = 'unknown' }
+    @{ Name = 'timeout sentinel (124) -> retryable unknown'; ExitCode = 124; Log = 'wall-clock timeout'; Class = 'retryable'; Reason = 'unknown' }
+    @{ Name = 'network/token licensing error (20105) -> retryable unknown'; ExitCode = 1; Log = 'Licensing::Client Error: Code 20105 token unavailable'; Class = 'retryable'; Reason = 'unknown' }
+    @{ Name = 'generic nonzero with no signal -> retryable unknown'; ExitCode = 1; Log = 'some unrelated failure'; Class = 'retryable'; Reason = 'unknown' }
+    @{ Name = 'nonzero with null log is tolerated -> retryable unknown'; ExitCode = 1; Log = $null; Class = 'retryable'; Reason = 'unknown' }
+)
+foreach ($c in $classifierCases) {
+    $result = Get-UnityActivationFailureClass -ExitCode $c.ExitCode -LogText $c.Log
+    Assert-That "classify: $($c.Name) [Class]" ($result.Class -eq $c.Class)
+    Assert-That "classify: $($c.Name) [Reason]" ($result.Reason -eq $c.Reason)
+}
+
+# ---------------------------------------------------------------------------
+# 2. Backoff ceiling (Get-UnityActivationRetryDelaySeconds) — data-driven.
+#    min(cap, base * 2^(N-1)) with base=5, cap=30 by default.
+# ---------------------------------------------------------------------------
+$backoffCases = @(
+    @{ Attempt = 1; Expected = 5 }
+    @{ Attempt = 2; Expected = 10 }
+    @{ Attempt = 3; Expected = 20 }
+    @{ Attempt = 4; Expected = 30 }   # 40 capped to 30
+    @{ Attempt = 5; Expected = 30 }   # 80 capped to 30
+    @{ Attempt = 50; Expected = 30 }  # no overflow, stays capped
+    @{ Attempt = 0; Expected = 5 }    # clamped up to attempt 1
+    @{ Attempt = -3; Expected = 5 }   # negative clamped up to attempt 1
+)
+foreach ($b in $backoffCases) {
+    $d = Get-UnityActivationRetryDelaySeconds -Attempt $b.Attempt
+    Assert-That "backoff: attempt $($b.Attempt) -> $($b.Expected)s" ($d -eq $b.Expected)
+}
+Assert-That "backoff: custom base/cap honored (attempt 3, base 2, cap 100 -> 8)" (
+    (Get-UnityActivationRetryDelaySeconds -Attempt 3 -BaseSeconds 2 -CapSeconds 100) -eq 8
+)
+
+# ---------------------------------------------------------------------------
+# 3. Budget env parsing (Get-UnityActivationRetryBudgetSeconds).
+# ---------------------------------------------------------------------------
+$savedBudgetEnv = $env:DXM_ACTIVATION_RETRY_BUDGET_SECONDS
+try {
+    $env:DXM_ACTIVATION_RETRY_BUDGET_SECONDS = $null
+    Assert-That "budget: unset -> default 360" ((Get-UnityActivationRetryBudgetSeconds) -eq 360)
+    Assert-That "budget: unset honors an explicit default" ((Get-UnityActivationRetryBudgetSeconds -Default 90) -eq 90)
+
+    $env:DXM_ACTIVATION_RETRY_BUDGET_SECONDS = '120'
+    Assert-That "budget: valid override 120 -> 120" ((Get-UnityActivationRetryBudgetSeconds) -eq 120)
+
+    $env:DXM_ACTIVATION_RETRY_BUDGET_SECONDS = '0'
+    Assert-That "budget: 0 is the explicit opt-out (single attempt)" ((Get-UnityActivationRetryBudgetSeconds) -eq 0)
+
+    $env:DXM_ACTIVATION_RETRY_BUDGET_SECONDS = '-5'
+    Assert-That "budget: negative override ignored -> default 360" ((Get-UnityActivationRetryBudgetSeconds) -eq 360)
+
+    $env:DXM_ACTIVATION_RETRY_BUDGET_SECONDS = 'notanumber'
+    Assert-That "budget: non-integer override ignored -> default 360" ((Get-UnityActivationRetryBudgetSeconds) -eq 360)
+} finally {
+    if ($null -eq $savedBudgetEnv) {
+        Remove-Item Env:DXM_ACTIVATION_RETRY_BUDGET_SECONDS -ErrorAction SilentlyContinue
+    } else {
+        $env:DXM_ACTIVATION_RETRY_BUDGET_SECONDS = $savedBudgetEnv
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 4. Retry loop (Invoke-UnityLicenseActivate) via the -ActivationInvoker seam.
+#    The fake editor is deterministic, writes the log like Tee-Object (OVERWRITE
+#    each attempt), and needs no external process. We assert OUTCOMES (attempt
+#    count, throw/return, and the final-attempt log invariant), never timing.
+# ---------------------------------------------------------------------------
+$tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("dxm-activation-retry-{0}" -f ([System.Guid]::NewGuid().ToString('N')))
+New-Item -ItemType Directory -Force -Path $tmpRoot | Out-Null
+
+# Build a fake invoker from a per-attempt plan of tokens. Each token decides that
+# attempt's exit code + the log line the fake writes (mirroring Unity's -logFile -
+# stdout being Tee'd, OVERWRITING the log). $script:lastInvokerState records calls.
+function New-FakeInvoker {
+    param([string[]]$Plan)
+    $state = [pscustomobject]@{ Count = 0 }
+    $script:lastInvokerState = $state
+    return {
+        param($activateArgs, $logPath)
+        $state.Count++
+        $token = if ($state.Count -le $Plan.Count) { $Plan[$state.Count - 1] } else { $Plan[$Plan.Count - 1] }
+        switch ($token) {
+            '20111'   { $line = 'Licensing::Client Error: Code 20111 reached the maximum number of activations'; $code = 1 }
+            'expired' { $line = 'Licensing::Client Error: Code 20113 serial expired'; $code = 1 }
+            'fail'    { $line = 'generic activation failure with no known signal'; $code = 1 }
+            default   { $line = 'License activated successfully'; $code = 0 }
+        }
+        # OVERWRITE the log to mirror `Tee-Object -FilePath` (no -Append): the file
+        # must reflect ONLY this (final) attempt.
+        Set-Content -LiteralPath $logPath -Value $line -Encoding UTF8
+        return $code
+    }.GetNewClosure()
+}
+
+function Invoke-FakeActivation {
+    param([string[]]$Plan, [int]$BudgetSeconds, [string]$Label)
+    $log = Join-Path $tmpRoot ("activate-{0}.log" -f $Label)
+    $invoker = New-FakeInvoker -Plan $Plan
+    $threw = $false
+    $errMsg = ''
+    try {
+        # Distinctive secret sentinels so the credential-leak assertion is meaningful.
+        Invoke-UnityLicenseActivate -EditorPath 'fake' `
+            -Serial 'SECRET-SERIAL-ZZZ' -Email 'SECRET-EMAIL-ZZZ' -Password 'SECRET-PW-ZZZ' `
+            -LogPath $log -RetryBudgetSeconds $BudgetSeconds -ActivationInvoker $invoker
+    } catch {
+        $threw = $true
+        $errMsg = $_.Exception.Message
+    }
+    return [pscustomobject]@{
+        Threw    = $threw
+        Message  = $errMsg
+        Attempts = $script:lastInvokerState.Count
+        FinalLog = (Get-Content -LiteralPath $log -Raw)
+    }
+}
+
+# 4a. Success on the first attempt: no retry, returns cleanly.
+$r = Invoke-FakeActivation -Plan @('ok') -BudgetSeconds 60 -Label 'first-success'
+Assert-That "loop: first-attempt success does not throw" (-not $r.Threw)
+Assert-That "loop: first-attempt success makes exactly 1 attempt" ($r.Attempts -eq 1)
+
+# 4b. Transient 20111 then success: retries and succeeds; final log is CLEAN (no
+#     stale 20111 for the return-side classifier to mis-read as an incident).
+$r = Invoke-FakeActivation -Plan @('20111', 'ok') -BudgetSeconds 60 -Label 'retry-then-success'
+Assert-That "loop: 20111-then-success does not throw" (-not $r.Threw)
+Assert-That "loop: 20111-then-success makes exactly 2 attempts" ($r.Attempts -eq 2)
+Assert-That "loop: 20111-then-success leaves a CLEAN final log (no stale 20111)" ($r.FinalLog -notmatch '20111')
+
+# 4c. Persistent 20111 exhausts the budget: throws, names the account-limit
+#     reason, and the final log STILL contains 20111 so the existing return-side
+#     classifier raises the account incident.
+$r = Invoke-FakeActivation -Plan @('20111') -BudgetSeconds 2 -Label 'persistent-20111'
+Assert-That "loop: persistent 20111 throws once the budget is exhausted" ($r.Threw)
+Assert-That "loop: persistent 20111 makes at least 2 attempts before giving up" ($r.Attempts -ge 2)
+Assert-That "loop: persistent 20111 throw names the account-limit reason" ($r.Message -match 'account-limit-20111')
+Assert-That "loop: persistent 20111 preserves the 20111 evidence in the final log" ($r.FinalLog -match '20111')
+Assert-That "loop: throw message never leaks the serial/email/password" ($r.Message -notmatch 'SECRET')
+Assert-That "loop: throw message points at the non-uploaded activation log" ($r.Message -match 'activation log')
+
+# 4d. Hard failure (serial expired) fails fast: exactly one attempt, no retry.
+$r = Invoke-FakeActivation -Plan @('expired', 'ok') -BudgetSeconds 60 -Label 'hard-fast'
+Assert-That "loop: hard serial-expired throws" ($r.Threw)
+Assert-That "loop: hard serial-expired does NOT retry (exactly 1 attempt)" ($r.Attempts -eq 1)
+Assert-That "loop: hard serial-expired names the not-retryable reason" ($r.Message -match 'serial-expired-20113')
+
+# 4e. Budget 0 is the opt-out: a single attempt, legacy fail-fast on any nonzero.
+$r = Invoke-FakeActivation -Plan @('20111', 'ok') -BudgetSeconds 0 -Label 'budget-zero'
+Assert-That "loop: budget 0 makes exactly 1 attempt (no retry)" ($r.Attempts -eq 1)
+Assert-That "loop: budget 0 throws on the single failing attempt" ($r.Threw)
+
+# 4f. Budget 0 with an immediate success still succeeds in one attempt.
+$r = Invoke-FakeActivation -Plan @('ok') -BudgetSeconds 0 -Label 'budget-zero-success'
+Assert-That "loop: budget 0 success returns in exactly 1 attempt" (($r.Attempts -eq 1) -and (-not $r.Threw))
+
+Remove-Item -LiteralPath $tmpRoot -Recurse -Force -ErrorAction SilentlyContinue
+
+Write-Host ""
+Write-Host "Unity license activation-retry tests: $passed passed, $failed failed."
+if ($failed -gt 0) {
+    exit 1
+}
+Write-Host "All Unity license activation-retry tests passed."
+exit 0

--- a/scripts/__tests__/test-unity-license-activation-retry.ps1.meta
+++ b/scripts/__tests__/test-unity-license-activation-retry.ps1.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 763f6f7c37b445b9bd08be2a0e2dfb0a
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/scripts/unity/run-ci-tests.ps1
+++ b/scripts/unity/run-ci-tests.ps1
@@ -1546,19 +1546,144 @@ function Get-AcceleratorArguments {
     )
 }
 
+function Get-UnityActivationRetryBudgetSeconds {
+    # Total wall-clock budget for RETRYING transient Unity serial-activation
+    # failures. This exists for issue #57: the organization build lock's release
+    # cooldown is deliberately near-zero, so when this run acquires a seat the
+    # PRIOR holder's activation may not have propagated as returned yet and Unity
+    # answers 20111 "maximum number of activations". That is transient seat
+    # contention, so activation retries (bounded) until the seat frees instead of
+    # the lock blindly holding a slot for minutes. Honors
+    # DXM_ACTIVATION_RETRY_BUDGET_SECONDS. Default 360s matches the previously
+    # observed ~5-minute Unity activation handoff plus a margin. A NON-INTEGER or
+    # NEGATIVE override is ignored with a ::warning:: and the default is used. 0 is
+    # the explicit OPT-OUT: a single attempt with legacy fail-fast behavior (no
+    # retry) -- note this differs from the *-TIMEOUT_SECONDS helpers where 0 means
+    # "unbounded", because an unbounded activation retry could pin a lock slot
+    # forever on a real capacity leak. Mirrors Get-StandaloneTestPlayerTimeoutSeconds's
+    # env-parse idiom. StrictMode-safe: no collection reads.
+    param([int]$Default = 360)
+
+    if ($env:DXM_ACTIVATION_RETRY_BUDGET_SECONDS) {
+        $parsed = 0
+        if (
+            [int]::TryParse($env:DXM_ACTIVATION_RETRY_BUDGET_SECONDS, [ref]$parsed) -and
+            $parsed -ge 0
+        ) {
+            return $parsed
+        }
+        Write-Host "::warning::Ignoring invalid DXM_ACTIVATION_RETRY_BUDGET_SECONDS='$env:DXM_ACTIVATION_RETRY_BUDGET_SECONDS'; using $Default second(s)."
+    }
+    return $Default
+}
+
+function Get-UnityActivationRetryDelaySeconds {
+    # Deterministic (pre-jitter) exponential backoff CEILING for activation retry
+    # attempt N (1-based): min(CapSeconds, BaseSeconds * 2^(N-1)). The caller adds
+    # bounded random jitter and additionally clamps the sleep so it never overruns
+    # the retry-budget deadline. Pure + StrictMode-safe so the backoff policy is
+    # unit-tested without launching Unity.
+    param(
+        [Parameter(Mandatory = $true)][int]$Attempt,
+        [int]$BaseSeconds = 5,
+        [int]$CapSeconds = 30
+    )
+
+    if ($Attempt -lt 1) { $Attempt = 1 }
+    # Clamp the exponent so 2^(N-1) cannot overflow on a pathologically high attempt
+    # count; the min() against CapSeconds makes anything past the cap moot anyway.
+    $exponent = [Math]::Min($Attempt - 1, 30)
+    $scaled = [double]$BaseSeconds * [Math]::Pow(2, $exponent)
+    $ceiling = [Math]::Min([double]$CapSeconds, $scaled)
+    return [int][Math]::Ceiling($ceiling)
+}
+
+function Get-UnityActivationFailureClass {
+    # PURE classifier for a Unity SERIAL-activation attempt: given the editor exit
+    # code and the (possibly empty) activation log text, decide whether the run
+    # should proceed, retry, or fail fast. Returns a StrictMode-safe object with
+    #   Class  = 'success' | 'retryable' | 'hard'
+    #   Reason = a stable, credential-free tag for diagnostics
+    #
+    # Contract (see the org lock's RESOURCE_REASON_CODES + secure-two-seat-rollout):
+    #   * exit 0                                 -> success / activated
+    #   * 20111 "maximum number of activations"  -> retryable / account-limit-20111
+    #       The SEAT-CONTENTION signal. The lock caps concurrent holders, so a 20111
+    #       here is either a transient handoff (previous seat still freeing -> clears
+    #       within the budget) or a real capacity leak (persists). We retry it ONLY
+    #       within the bounded budget; a 20111 that survives the deadline is re-thrown
+    #       with the 20111 evidence still in the (OVERWRITTEN, final-attempt)
+    #       activation log, so the EXISTING return-side classifier still raises the
+    #       account-blocked incident. We never treat 20111 as success and never reset
+    #       the incident path.
+    #   * 20113 "serial expired"                 -> hard / serial-expired-20113
+    #       Calendar expiry; retrying is pointless until the serial is rotated.
+    #   * any other non-zero exit                -> retryable / unknown
+    #       Covers process kills (124/137/143), transient network/token licensing
+    #       errors (20105/20120/...), and unforeseen transients. Bounded by the
+    #       budget, so a genuine misconfiguration costs at most one budget then
+    #       surfaces the real error.
+    # The \b-style non-digit guards keep 201110 / 120111 from matching 20111.
+    # StrictMode-safe: no collection reads.
+    param(
+        [Parameter(Mandatory = $true)][int]$ExitCode,
+        [string]$LogText = ''
+    )
+
+    if ($ExitCode -eq 0) {
+        return [pscustomobject]@{ Class = 'success'; Reason = 'activated' }
+    }
+
+    $text = if ($null -eq $LogText) { '' } else { [string]$LogText }
+
+    if (
+        $text -match '(?i)maximum number of activations' -or
+        $text -match '(?<![0-9])20111(?![0-9])'
+    ) {
+        return [pscustomobject]@{ Class = 'retryable'; Reason = 'account-limit-20111' }
+    }
+
+    if (
+        $text -match '(?i)serial expired' -or
+        $text -match '(?<![0-9])20113(?![0-9])'
+    ) {
+        return [pscustomobject]@{ Class = 'hard'; Reason = 'serial-expired-20113' }
+    }
+
+    return [pscustomobject]@{ Class = 'retryable'; Reason = 'unknown' }
+}
+
 function Invoke-UnityLicenseActivate {
     param(
         [Parameter(Mandatory = $true)][string]$EditorPath,
         [Parameter(Mandatory = $true)][string]$Serial,
         [Parameter(Mandatory = $true)][string]$Email,
         [Parameter(Mandatory = $true)][string]$Password,
-        [Parameter(Mandatory = $true)][string]$LogPath
+        [Parameter(Mandatory = $true)][string]$LogPath,
+        [int]$RetryBudgetSeconds = -1,
+        # TESTABILITY SEAM (never passed in production): an optional invoker
+        # `{ param($activateArgs, $logPath) ... return [int]$exitCode }` that stands
+        # in for the real editor launch so the retry/deadline/backoff loop can be
+        # exercised cross-platform without Unity. When $null (the default) the real
+        # `& $EditorPath ... | Tee-Object` path runs and production behavior is
+        # byte-for-byte unchanged.
+        [scriptblock]$ActivationInvoker = $null
     )
 
-    # Classic SERIAL activation: a single editor invocation that activates the
-    # paid Unity seat and immediately quits. This MUST succeed before the test
-    # run, so unlike the return path it THROWS on a non-zero exit -- a failed
-    # activation means the test editor would launch unlicensed and fail opaquely.
+    # Classic SERIAL activation: an editor invocation that activates the paid Unity
+    # seat and immediately quits. This MUST succeed before the test run, so unlike
+    # the best-effort return path a terminal failure THROWS -- an unlicensed test
+    # editor fails opaquely.
+    #
+    # RETRY (issue #57): the organization lock's release cooldown is intentionally
+    # near-zero, so when this run acquires a seat the PRIOR holder's activation may
+    # not have propagated as returned yet and Unity answers 20111 "maximum number of
+    # activations". That is transient seat contention, not a hard error, so we retry
+    # within a bounded wall-clock budget (Get-UnityActivationRetryBudgetSeconds) with
+    # jittered exponential backoff (Get-UnityActivationRetryDelaySeconds). A 20111
+    # that SURVIVES the budget is a real capacity leak: we re-throw with the 20111
+    # evidence still in the activation log so the existing return-side classifier
+    # raises the account incident. Permanent failures (serial expiry) fail fast.
     $logDir = Split-Path -Parent $LogPath
     if ($logDir -and -not (Test-Path -LiteralPath $logDir -PathType Container)) {
         New-Item -ItemType Directory -Force -Path $logDir | Out-Null
@@ -1566,9 +1691,11 @@ function Invoke-UnityLicenseActivate {
 
     # SECURITY: the serial/email/password ride in the argument array, so this site
     # must NEVER echo the args (no "...$activateArgs..." Write-Host). The caller
-    # passes a $LogPath that lives under a NON-uploaded temp dir (RUNNER_TEMP /
-    # system temp), never under $ArtifactsPath, so the credentials cannot leak into
-    # an uploaded artifact.
+    # passes a $LogPath under a NON-uploaded temp dir (RUNNER_TEMP / system temp),
+    # never under $ArtifactsPath. Tee-Object OVERWRITES $LogPath each attempt, so the
+    # log reflects only the FINAL attempt: a success after a transient 20111 leaves a
+    # clean log (no stale 20111 for the return classifier to mis-read as an incident),
+    # while a persistent 20111 leaves the 20111 intact for the incident path.
     $activateArgs = @(
         '-quit',
         '-batchmode',
@@ -1579,22 +1706,67 @@ function Invoke-UnityLicenseActivate {
         '-logFile', '-'
     )
 
-    Write-Host "::group::Activate Unity license (serial)"
-    # Unity.exe is a Windows GUI-subsystem binary: PowerShell's `&` does NOT wait
-    # for it or set $LASTEXITCODE unless its stdout is consumed via the pipeline.
-    # `-logFile -` puts the Unity log on stdout and `| Tee-Object` forces the wait,
-    # sets $LASTEXITCODE, and persists the (non-uploaded) temp log. (Proven idiom;
-    # see Invoke-UnityEditor.)
-    & $EditorPath @activateArgs 2>&1 | Tee-Object -FilePath $LogPath
-    $exitCode = $LASTEXITCODE
-    Write-Host "::endgroup::"
-    if ($exitCode -ne 0) {
-        # The message names the failure and the (non-uploaded) log path ONLY -- it
-        # must never embed the serial/email/password values.
-        throw "Unity license activation failed with exit code $exitCode. See the activation log at $LogPath (not uploaded as an artifact)."
+    if ($RetryBudgetSeconds -lt 0) {
+        $RetryBudgetSeconds = Get-UnityActivationRetryBudgetSeconds
     }
+    $deadline = (Get-Date).AddSeconds($RetryBudgetSeconds)
+    $attempt = 0
 
-    Write-CiNotice 'Activated the Unity license (serial).'
+    while ($true) {
+        $attempt++
+
+        if ($ActivationInvoker) {
+            $exitCode = [int](& $ActivationInvoker $activateArgs $LogPath)
+        } else {
+            Write-Host "::group::Activate Unity license (serial) attempt $attempt"
+            # Unity.exe is a Windows GUI-subsystem binary: `&` does NOT wait for it or
+            # set $LASTEXITCODE unless its stdout is consumed. `-logFile -` + Tee-Object
+            # forces the wait, sets $LASTEXITCODE, and (over)writes the non-uploaded log.
+            & $EditorPath @activateArgs 2>&1 | Tee-Object -FilePath $LogPath
+            $exitCode = $LASTEXITCODE
+            Write-Host "::endgroup::"
+        }
+
+        $logText = ''
+        try {
+            if (Test-Path -LiteralPath $LogPath -PathType Leaf) {
+                $rawLog = Get-Content -LiteralPath $LogPath -Raw -ErrorAction Stop
+                if ($null -ne $rawLog) { $logText = $rawLog }
+            }
+        } catch {
+            $logText = ''
+        }
+
+        $decision = Get-UnityActivationFailureClass -ExitCode $exitCode -LogText $logText
+
+        if ($decision.Class -eq 'success') {
+            if ($attempt -gt 1) {
+                Write-CiNotice "Activated the Unity license (serial) on attempt $attempt."
+            } else {
+                Write-CiNotice 'Activated the Unity license (serial).'
+            }
+            return
+        }
+
+        # Every throw names the failure class + reason + attempt count + the
+        # (non-uploaded) log path ONLY -- never the serial/email/password values.
+        if ($decision.Class -eq 'hard') {
+            throw "Unity license activation failed with exit code $exitCode (reason=$($decision.Reason)) after $attempt attempt(s); not retryable. See the activation log at $LogPath (not uploaded as an artifact)."
+        }
+
+        $remainingSeconds = ($deadline - (Get-Date)).TotalSeconds
+        if ($RetryBudgetSeconds -le 0 -or $remainingSeconds -le 0) {
+            throw "Unity license activation failed with exit code $exitCode (reason=$($decision.Reason)) after $attempt attempt(s) within a $RetryBudgetSeconds s retry budget. See the activation log at $LogPath (not uploaded as an artifact)."
+        }
+
+        $delaySeconds = Get-UnityActivationRetryDelaySeconds -Attempt $attempt
+        # Full jitter in [1, delay], then clamp so we never sleep past the deadline
+        # (min 1s so a tiny remaining budget still makes one more attempt).
+        $jittered = Get-Random -Minimum 1 -Maximum ($delaySeconds + 1)
+        $sleepSeconds = [int][Math]::Max(1, [Math]::Min([double]$jittered, $remainingSeconds))
+        Write-Host "::warning::Unity license activation attempt $attempt failed (exit code $exitCode, reason=$($decision.Reason)); retrying in ${sleepSeconds}s (~$([int]$remainingSeconds)s of retry budget left). Expected transient seat contention under the organization lock's near-zero release cooldown."
+        Start-Sleep -Seconds $sleepSeconds
+    }
 }
 
 function Test-UnityLicenseReturnLogShowsEntitlementReturned {


### PR DESCRIPTION
## What

Propagates the proven unity-helpers change (PR #306) into DxMessaging: `Invoke-UnityLicenseActivate` in `scripts/unity/run-ci-tests.ps1` now retries transient Unity serial-activation contention within a bounded wall-clock budget with jittered exponential backoff, instead of failing the whole run on the first `20111`.

## Why (build-lock #57)

The organization build lock's release cooldown is deliberately near-zero. When this run acquires a Unity seat, the **prior** holder's activation may not have propagated as *returned* yet, so Unity answers error **20111 "maximum number of activations."** That is transient seat contention, not a hard error — retrying briefly lets the seat free instead of the run failing (or the lock blindly holding a slot for minutes).

## The 20111 retry-but-preserve-incident design

The subtlety is that `20111` is **two different things**:

- a **transient handoff** (previous seat still freeing) that clears within the budget, or
- a **real capacity leak** that persists past the budget.

So the change retries `20111` **only within a bounded budget** and, crucially, treats a `20111` that *survives* the deadline as a genuine account incident:

- **Log semantics are OVERWRITE-per-attempt** (`Tee-Object -FilePath`, no `-Append`). A success after a transient `20111` leaves a **clean** final log, so the existing return-side classifier never mis-reads a stale `20111` as an incident. A **persistent** `20111` leaves the `20111` intact in the final-attempt log, so the existing return-side account-incident classifier still fires. We never treat `20111` as success and never reset the incident path.
- **Permanent failures fail fast**: serial expiry (`20113`) throws immediately with no retry.
- **Every throw** names the reason + attempt count + the non-uploaded activation log path — **never** the serial/email/password.

### Shape

Three pure, StrictMode-safe helpers added before the function:

- `Get-UnityActivationRetryBudgetSeconds` — honors `DXM_ACTIVATION_RETRY_BUDGET_SECONDS` (DxMessaging's `DXM_` prefix), default `360s`. Non-integer/negative → `::warning::` + default; **`0` = explicit opt-out** (single attempt, legacy fail-fast). Note `0` differs from the `*-TIMEOUT_SECONDS` helpers where `0` means "unbounded", because an unbounded activation retry could pin a lock slot forever on a real capacity leak.
- `Get-UnityActivationRetryDelaySeconds` — `min(cap, base·2^(N-1))` backoff ceiling (base 5s, cap 30s), overflow-clamped.
- `Get-UnityActivationFailureClass` — `success`/`retryable`/`hard` classifier. The `20111`/`20113` matchers use non-digit boundary guards (`(?<![0-9])20111(?![0-9])`) so `201110` / `120111` do **not** match.

The refactored `Invoke-UnityLicenseActivate` gains a production-inert `-ActivationInvoker` testability seam (never passed in production; the real `& $EditorPath … | Tee-Object` path is byte-for-byte unchanged when it is `$null`) and a `-RetryBudgetSeconds` param.

## Tests

`scripts/__tests__/test-unity-license-activation-retry.ps1` (mirrors the reference's pwsh test) extracts the real function definitions from `run-ci-tests.ps1` via the PowerShell AST and exercises them **without launching Unity**:

- classifier table, **including the `201110`/`120111` boundary-guard rows** that must NOT match `20111`;
- backoff ceiling table;
- `DXM_ACTIVATION_RETRY_BUDGET_SECONDS` parsing (default / override / opt-out / invalid);
- retry loop via the fake invoker: first-success; `20111`-then-success asserts a **clean** final log; persistent-`20111` asserts throw + preserved `20111` + no credential leak; hard-fail-fast; budget-`0` single attempt.

Wired into the `script-tests` job in `ci.yml` as a `shell: pwsh` step (runs on the ubuntu/macos/windows matrix). A JS test was impractical here — the repo's JS LoC budget is at its `13700` ceiling — so this matches the reference's pwsh route.

Local run: **62 passed, 0 failed.** `node --test scripts/` matches the clean-master control exactly (no new failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI license activation behavior and credential-adjacent logging paths; mitigated by bounded retries, fail-fast on expiry, tests, and preserved incident semantics for persistent 20111.
> 
> **Overview**
> **`Invoke-UnityLicenseActivate`** in `run-ci-tests.ps1` no longer fails on the first Unity **20111** (“maximum activations”) when the org build lock hands off a seat. It retries within a **bounded wall-clock budget** (default 360s via `DXM_ACTIVATION_RETRY_BUDGET_SECONDS`, `0` = single attempt) with **jittered exponential backoff**, classifies outcomes (`20111` retry, `20113` fail-fast, others retry within budget), and **overwrites the activation log each attempt** so a later success clears stale `20111` while a budget-exhausted `20111` still leaves evidence for the existing return-side incident path. Credentials stay out of error text.
> 
> New **pure helpers** (`Get-UnityActivationRetryBudgetSeconds`, `Get-UnityActivationRetryDelaySeconds`, `Get-UnityActivationFailureClass`) support testing; production adds an optional **`-ActivationInvoker`** seam only for tests.
> 
> **`scripts/__tests__/test-unity-license-activation-retry.ps1`** AST-loads those functions and runs table-driven tests (classifier boundaries, backoff, env parsing, fake retry loop). **CI** runs it in the `script-tests` matrix via a new `pwsh` step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ddacac0b45acfbf298af86f12628239e352dc41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->