### PR TITLE
ci: unblock Dependabot PRs; feat(editor): Message subscriptions inspector section

### DIFF
--- a/.github/actions/return-unity-license/action.yml
+++ b/.github/actions/return-unity-license/action.yml
@@ -105,7 +105,7 @@ runs:
     - name: Classify prior exact return evidence
       id: classify_prior
       if: ${{ steps.prior_metadata.outputs.prior-ready == 'true' }}
-      uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@673eb65e7d863a1a8a8a70882bd980e189d41754
+      uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
       with:
         return-log-path: ${{ steps.prior_metadata.outputs.return-log-path }}
         return-command-completed: "true"
@@ -174,7 +174,7 @@ runs:
     - name: Classify redundant return evidence
       id: classify_return
       if: ${{ always() && steps.classify_prior.outputs.resource-safe != 'true' }}
-      uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@673eb65e7d863a1a8a8a70882bd980e189d41754
+      uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/classify-unity-cleanup-evidence@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
       with:
         return-log-path: ${{ steps.capture_return.outputs.return-log-path }}
         return-command-completed: ${{ steps.capture_return.outputs.return-command-completed }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,17 @@
 version: 2
 updates:
-  # GitHub Actions workflow updates
+  # GitHub Actions workflow updates.
+  #
+  # A bare "/" makes Dependabot scan .github/workflows plus a repository-root
+  # action.yml, and nothing else. The build-lock pin inside
+  # .github/actions/return-unity-license/action.yml therefore sat outside every
+  # bump, so a bump split the centralized Unity cleanup policy across two SHAs.
+  # Listing that directory keeps the whole group on one pin; the split now fails
+  # scripts/__tests__/ci-aggregate-workflow.test.js closed.
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/return-unity-license"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       yaml: ${{ steps.filter.outputs.yaml }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -205,7 +205,7 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.actionlint != 'false' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -219,7 +219,7 @@ jobs:
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.actionlint != 'false' }}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
 
@@ -247,13 +247,13 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.markdown != 'false' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.markdown != 'false' }}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -292,7 +292,7 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.csharpier != 'false' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -304,7 +304,7 @@ jobs:
 
       - name: Setup .NET
         if: ${{ needs.changes.outputs.csharpier != 'false' }}
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "8.0.x"
 
@@ -336,19 +336,19 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.dotnet != 'false' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Setup .NET
         if: ${{ needs.changes.outputs.dotnet != 'false' }}
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           global-json-file: SourceGenerators/global.json
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.dotnet != 'false' }}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
 
@@ -464,13 +464,13 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.json != 'false' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.json != 'false' }}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -509,13 +509,13 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.spellcheck != 'false' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.spellcheck != 'false' }}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -545,13 +545,13 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.banner != 'false' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.banner != 'false' }}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
 
@@ -579,14 +579,14 @@ jobs:
 
       - name: Checkout repository
         if: ${{ needs.changes.outputs.llms != 'false' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.llms != 'false' }}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -625,13 +625,13 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.yaml != 'false' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.yaml != 'false' }}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -691,14 +691,14 @@ jobs:
 
       - name: Checkout repository
         if: ${{ needs.changes.outputs.scripts != 'false' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.scripts != 'false' }}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -706,7 +706,7 @@ jobs:
 
       - name: Setup .NET
         if: ${{ needs.changes.outputs.scripts != 'false' && matrix.os == 'ubuntu-latest' }}
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           global-json-file: SourceGenerators/global.json
 
@@ -755,7 +755,7 @@ jobs:
 
       - name: Checkout repository
         if: ${{ needs.changes.outputs.docs != 'false' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -789,7 +789,7 @@ jobs:
 
       - name: Setup Python
         if: ${{ needs.changes.outputs.docs != 'false' }}
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: "pip"
@@ -891,7 +891,7 @@ jobs:
 
       - name: Checkout
         if: ${{ needs.changes.outputs.docs_links != 'false' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/csharpier-autofix.yml
+++ b/.github/workflows/csharpier-autofix.yml
@@ -39,13 +39,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "8.0.x"
 
@@ -100,7 +100,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout fork PR HEAD
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -108,7 +108,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "8.0.x"
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,13 +43,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0 # Full history for git-revision-date-localized plugin
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: "pip"

--- a/.github/workflows/devcontainer-prebuild.yml
+++ b/.github/workflows/devcontainer-prebuild.yml
@@ -55,7 +55,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           lfs: true
           persist-credentials: false
@@ -74,7 +74,7 @@ jobs:
           echo "repository_lowercase=${repo_lower}" >> "${GITHUB_OUTPUT}"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/devcontainer-test.yml
+++ b/.github/workflows/devcontainer-test.yml
@@ -101,7 +101,7 @@ jobs:
           exit 1
 
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           lfs: true
           persist-credentials: false
@@ -120,7 +120,7 @@ jobs:
           echo "repository_lowercase=${repo_lower}" >> "${GITHUB_OUTPUT}"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/format-on-demand.yml
+++ b/.github/workflows/format-on-demand.yml
@@ -46,25 +46,25 @@ jobs:
           exit 1
       - name: Checkout PR branch (same-repo)
         if: ${{ steps.meta.outputs.same_repo == 'true' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.meta.outputs.head_ref }}
           fetch-depth: 0
           persist-credentials: false
       - name: Checkout PR fork head
         if: ${{ steps.meta.outputs.same_repo != 'true' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ steps.meta.outputs.head_repo }}
           ref: ${{ steps.meta.outputs.head_ref }}
           persist-credentials: false
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
       - name: Setup .NET
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: '8.0.x'
       - name: Restore .NET tools
@@ -220,25 +220,25 @@ jobs:
             core.setOutput('same_repo', String(pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`));
       - name: Checkout PR branch (same-repo)
         if: ${{ steps.meta.outputs.same_repo == 'true' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.meta.outputs.head_ref }}
           fetch-depth: 0
           persist-credentials: false
       - name: Checkout PR fork head
         if: ${{ steps.meta.outputs.same_repo != 'true' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ steps.meta.outputs.head_repo }}
           ref: ${{ steps.meta.outputs.head_ref }}
           persist-credentials: false
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
       - name: Setup .NET
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: '8.0.x'
       - name: Restore .NET tools

--- a/.github/workflows/markdown-link-validity.yml
+++ b/.github/workflows/markdown-link-validity.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -90,13 +90,13 @@ jobs:
       has-autocommit-app: ${{ steps.check-autocommit-app.outputs.has-app }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Require an online performance runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -188,7 +188,7 @@ jobs:
         run: git config --global core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         env:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/dxm-gitconfig
         with:
@@ -225,7 +225,7 @@ jobs:
           key: Library-perf-${{ runner.os }}-${{ runner.arch }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}-${{ env.PACKAGE_HASH }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
 
@@ -306,7 +306,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: perf-${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -380,7 +380,7 @@ jobs:
       - name: Release organization Unity lock
         id: release_unity_lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@673eb65e7d863a1a8a8a70882bd980e189d41754
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: perf-${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -394,7 +394,7 @@ jobs:
 
       - name: Require confirmed Unity cleanup
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@673eb65e7d863a1a8a8a70882bd980e189d41754
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           acquired: ${{ steps.acquire_lock.outputs.acquired }}
           classification-complete: ${{ steps.return_unity_license.outputs.classification-complete }}
@@ -555,7 +555,7 @@ jobs:
           private-key: ${{ secrets.AUTO_COMMIT_APP_PRIVATE_KEY }}
 
       - name: Checkout default branch
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
@@ -583,7 +583,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.default-branch.outputs.fresh == 'true'
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
           cache: npm

--- a/.github/workflows/prettier-autofix.yml
+++ b/.github/workflows/prettier-autofix.yml
@@ -73,13 +73,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -172,7 +172,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout fork PR HEAD
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -180,7 +180,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
           cache: "npm"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         # The shared changelog extractor (scripts/release/release-notes.js) runs
         # under Node; pin it instead of the runner's ambient version.
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
 
@@ -79,7 +79,7 @@ jobs:
       # continue-on-error, so a second failure fails the job. continue-on-error on the first attempt
       # keeps its real result observable via steps.<id>.outcome while letting the retry proceed.
       - name: Run Release Drafter
-        uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7
+        uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7
         id: release_drafter
         continue-on-error: true
         with:
@@ -93,7 +93,7 @@ jobs:
 
       - name: Run Release Drafter (retry)
         if: steps.release_drafter.outcome == 'failure'
-        uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7
+        uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7
         id: release_drafter_retry
         with:
           config-name: release-drafter.yml

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -97,20 +97,20 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ steps.app-token.outputs.token || github.token }}
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
 
       - name: Setup .NET
         # validate:all runs check:analyzers, which builds the source
         # generators against the SDK pinned in SourceGenerators/global.json.
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           global-json-file: SourceGenerators/global.json
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       tag: ${{ steps.verify.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -69,20 +69,20 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
 
       - name: Setup .NET
         # validate:all runs check:analyzers, which builds the source
         # generators against the SDK pinned in SourceGenerators/global.json.
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           global-json-file: SourceGenerators/global.json
 
@@ -165,7 +165,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require an online Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -192,7 +192,7 @@ jobs:
         run: git config --global core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         env:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/dxm-gitconfig
         with:
@@ -209,7 +209,7 @@ jobs:
         uses: ./.github/actions/print-self-hosted-runner-diagnostics
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
 
@@ -263,7 +263,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-editmode
@@ -317,7 +317,7 @@ jobs:
       - name: Release organization Unity lock
         id: release_unity_lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@673eb65e7d863a1a8a8a70882bd980e189d41754
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-editmode
@@ -331,7 +331,7 @@ jobs:
 
       - name: Require confirmed Unity cleanup
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@673eb65e7d863a1a8a8a70882bd980e189d41754
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           acquired: ${{ steps.acquire_lock.outputs.acquired }}
           classification-complete: ${{ steps.return_unity_license.outputs.classification-complete }}
@@ -426,7 +426,7 @@ jobs:
         run: git config --global core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         env:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/dxm-gitconfig
         with:
@@ -441,7 +441,7 @@ jobs:
       - name: Setup Node.js
         # export-unitypackage.ps1 stages the payload with `npm pack`, so the
         # shipped bytes are identical to the npm/UPM artifact.
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
 
@@ -487,7 +487,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: acquire_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-unitypackage
@@ -540,7 +540,7 @@ jobs:
       - name: Release organization Unity lock
         id: release_unity_lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@673eb65e7d863a1a8a8a70882bd980e189d41754
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-unitypackage
@@ -554,7 +554,7 @@ jobs:
 
       - name: Require confirmed Unity cleanup
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@673eb65e7d863a1a8a8a70882bd980e189d41754
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           acquired: ${{ steps.acquire_lock.outputs.acquired }}
           classification-complete: ${{ steps.return_unity_license.outputs.classification-complete }}
@@ -632,12 +632,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/runner-bootstrap.yml
+++ b/.github/workflows/runner-bootstrap.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Checkout
         # Shallow checkout: bootstrap only needs scripts/unity/* and a
         # composite action; no history depth required.
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         env:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/dxm-gitconfig
         with:
@@ -335,7 +335,7 @@ jobs:
 
           # F6: drop the GITHUB_ACTION_PATH `../../../` ascent. We are inside
           # a workflow (not a composite), so $GITHUB_WORKSPACE is reliably
-          # the repo root post-checkout (actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7 above guarantees
+          # the repo root post-checkout (actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 above guarantees
           # the script is present at this path).
           $script = [System.IO.Path]::Combine($env:GITHUB_WORKSPACE, 'scripts', 'unity', 'maintain-windows-runner.ps1')
           if (-not (Test-Path -LiteralPath $script)) {

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -27,7 +27,7 @@ jobs:
       should-deploy: ${{ steps.check.outputs.should-deploy }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 2
           persist-credentials: false
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           path: main
           persist-credentials: false
@@ -95,7 +95,7 @@ jobs:
             clone "https://github.com/${GITHUB_REPOSITORY}.wiki.git" wiki
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
 

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -36,7 +36,7 @@ jobs:
       latest-version: ${{ steps.resolve.outputs.latest-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
       - name: Resolve dispatch overrides
@@ -74,7 +74,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require an online Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -103,7 +103,7 @@ jobs:
         run: git config --global core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         env:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/dxm-gitconfig
         with:
@@ -141,7 +141,7 @@ jobs:
           key: Library-bench-${{ runner.os }}-${{ runner.arch }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}-${{ env.PACKAGE_HASH }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
 
@@ -199,7 +199,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -258,7 +258,7 @@ jobs:
       - name: Release organization Unity lock
         id: release_unity_lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@673eb65e7d863a1a8a8a70882bd980e189d41754
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -272,7 +272,7 @@ jobs:
 
       - name: Require confirmed Unity cleanup
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@673eb65e7d863a1a8a8a70882bd980e189d41754
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           acquired: ${{ steps.acquire_lock.outputs.acquired }}
           classification-complete: ${{ steps.return_unity_license.outputs.classification-complete }}

--- a/.github/workflows/unity-gameci-experiment.yml
+++ b/.github/workflows/unity-gameci-experiment.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Require an online Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -49,7 +49,7 @@ jobs:
         run: git config --global core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         env:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/dxm-gitconfig
         with:
@@ -62,7 +62,7 @@ jobs:
           matrix-note: "GameCI compatibility experiment (non-required)"
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
 
@@ -133,7 +133,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: game-ci-experiment
@@ -190,7 +190,7 @@ jobs:
       - name: Release organization Unity lock
         id: release_unity_lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@673eb65e7d863a1a8a8a70882bd980e189d41754
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: game-ci-experiment
@@ -204,7 +204,7 @@ jobs:
 
       - name: Require confirmed Unity cleanup
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@673eb65e7d863a1a8a8a70882bd980e189d41754
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           acquired: ${{ steps.acquire_lock.outputs.acquired }}
           classification-complete: ${{ steps.return_unity_license.outputs.classification-complete }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -57,7 +57,7 @@ jobs:
       ci-owned-docs-only: ${{ steps.docs-only.outputs.docs-only }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -133,10 +133,19 @@ jobs:
     name: Self-hosted runner access preflight
     # Runs on GitHub-hosted infrastructure before any self-hosted matrix entry
     # can queue. Reader-App or inventory failures are intentionally fail closed.
+    #
+    # Dependabot pull requests are excluded for the same reason fork pull
+    # requests are: their jobs read from the separate Dependabot secret store,
+    # so `secrets.BUILD_LOCK_READER_APP_ID` resolves empty and the fail-closed
+    # preflight aborts with "Missing required input: reader-app-id" before it
+    # can check anything. Running it there cannot pass, and the licensed Unity
+    # secrets below are unreadable for the same reason. Dependency bumps are
+    # validated by the full matrix on the post-merge push to master.
     if: >-
       ${{
         (github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name == github.repository) &&
+          (github.event.pull_request.head.repo.full_name == github.repository &&
+            github.event.pull_request.user.login != 'dependabot[bot]')) &&
         (github.event_name != 'push' || github.ref_protected)
       }}
     runs-on: ubuntu-latest
@@ -146,7 +155,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require an online Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -158,11 +167,15 @@ jobs:
       - matrix-config
       - runner-preflight
     # Same-repository pull requests run licensed validation with organization
-    # secrets and no environment approval. Fork pull requests remain static-only.
+    # secrets and no environment approval. Fork pull requests and Dependabot
+    # pull requests remain static-only: neither can read the organization Unity
+    # serial or build-lock App secrets, so a licensed leg there fails on missing
+    # credentials rather than on the change under test.
     if: >-
       ${{
         (github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name == github.repository) &&
+          (github.event.pull_request.head.repo.full_name == github.repository &&
+            github.event.pull_request.user.login != 'dependabot[bot]')) &&
         (github.event_name != 'push' || github.ref_protected) &&
         needs.matrix-config.outputs.ci-owned-docs-only != 'true'
       }}
@@ -176,7 +189,7 @@ jobs:
         test-mode: ${{ fromJSON(needs.matrix-config.outputs.test-modes) }}
     steps:
       - name: Require current PR head before setup
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@a00614ace745152a659c5c2654f7cefb68a5a628
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -189,7 +202,7 @@ jobs:
         run: git config --global core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         env:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/dxm-gitconfig
         with:
@@ -227,7 +240,7 @@ jobs:
           key: Library-${{ runner.os }}-${{ runner.arch }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}-${{ env.PACKAGE_HASH }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
 
@@ -290,7 +303,7 @@ jobs:
 
       - name: Require current PR head before lock acquisition
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@a00614ace745152a659c5c2654f7cefb68a5a628
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-current-pr-head@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           github-token: ${{ github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -299,7 +312,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: acquire_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -365,7 +378,7 @@ jobs:
       - name: Release organization Unity lock
         id: release_unity_lock
         if: always()
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@673eb65e7d863a1a8a8a70882bd980e189d41754
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -379,7 +392,7 @@ jobs:
 
       - name: Require confirmed Unity cleanup
         if: ${{ always() && steps.acquire_lock.outputs.acquired == 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@673eb65e7d863a1a8a8a70882bd980e189d41754
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/require-confirmed-unity-cleanup@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
         with:
           acquired: ${{ steps.acquire_lock.outputs.acquired }}
           classification-complete: ${{ steps.return_unity_license.outputs.classification-complete }}
@@ -469,9 +482,11 @@ jobs:
     # Exactly always() -- NEVER a falsifiable job-level if. A skipped required
     # check counts as passing and the latest run on a SHA wins, so a guard that
     # can be false on a pull_request could launder a red/pending gate into a
-    # false green. The step below validates the only two intentional skip shapes:
-    # fork PRs skip both licensed jobs, while CI-owned docs-only PRs run preflight
-    # but skip the Unity matrix. Every other run must execute Unity successfully.
+    # false green. The step below validates the only three intentional skip
+    # shapes: fork PRs and Dependabot PRs skip both licensed jobs (neither can
+    # read the organization secrets those jobs require), while CI-owned
+    # docs-only PRs run preflight but skip the Unity matrix. Every other run
+    # must execute Unity successfully.
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -482,6 +497,7 @@ jobs:
           RUNNER_PREFLIGHT_RESULT: ${{ needs.runner-preflight.result }}
           UNITY_TESTS_RESULT: ${{ needs.unity-tests.result }}
           FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          DEPENDABOT_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' }}
           DOCS_ONLY: ${{ needs.matrix-config.outputs.ci-owned-docs-only }}
         run: |
           set -euo pipefail
@@ -502,7 +518,7 @@ jobs:
             failed=1
           fi
 
-          if [ "${FORK_PR}" = "true" ]; then
+          if [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then
             assert_result RUNNER_PREFLIGHT_RESULT skipped "${RUNNER_PREFLIGHT_RESULT}"
             assert_result UNITY_TESTS_RESULT skipped "${UNITY_TESTS_RESULT}"
           elif [ "${DOCS_ONLY}" = "true" ]; then

--- a/.github/workflows/update-issue-template-versions.yml
+++ b/.github/workflows/update-issue-template-versions.yml
@@ -72,7 +72,7 @@ jobs:
           private-key: ${{ secrets.AUTO_COMMIT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ steps.app-token.outputs.token || github.token }}
           persist-credentials: false
@@ -91,7 +91,7 @@ jobs:
           echo "Refreshed ${GITHUB_REF_NAME} to $(git rev-parse HEAD) before regenerating the dropdown."
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
           cache: npm

--- a/.github/workflows/update-llms-txt.yml
+++ b/.github/workflows/update-llms-txt.yml
@@ -64,7 +64,7 @@ jobs:
           private-key: ${{ secrets.AUTO_COMMIT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ steps.app-token.outputs.token || github.token }}
           persist-credentials: false
@@ -83,7 +83,7 @@ jobs:
           echo "Refreshed ${GITHUB_REF_NAME} to $(git rev-parse HEAD) before generating llms.txt."
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
           cache: npm

--- a/.gitignore
+++ b/.gitignore
@@ -454,3 +454,5 @@ OLD-PLAN.md*
 *.ulf
 
 relay_win.lnk*
+GOAL.md
+GOAL.md.meta

--- a/.llm/skills/unity-mcp-test-loop/references/mcp-test-loop.md
+++ b/.llm/skills/unity-mcp-test-loop/references/mcp-test-loop.md
@@ -31,6 +31,31 @@ the host editor; the container only edits files and drives the editor over MCP.
 1. **Edit** files in the container as usual.
 1. **Compile**: trigger `AssetDatabase.Refresh()` via `Unity_RunCommand`. Wait for the
    recompile to settle before running tests.
+1. **Prove the assembly is fresh before you trust a green run.** When a package
+   assembly fails to compile, Unity keeps the last good DLL loaded and
+   `DxMcpTestRunner` happily runs it, so an edit that does not compile reports the
+   previous run's passing numbers. `Unity_ReadConsole` can come back empty in that
+   state, and the host editor may have Auto Refresh disabled
+   (`EditorPrefs.GetInt("kAutoRefreshMode") == 0`), which makes it permanent. Assert a
+   symbol you just added actually resolves, and compare
+   `System.IO.File.GetLastWriteTimeUtc(type.Assembly.Location)` against the source
+   file's write time:
+
+   ```csharp
+   System.Type fixture = null;
+   foreach (System.Reflection.Assembly assembly in System.AppDomain.CurrentDomain.GetAssemblies())
+   {
+       fixture = assembly.GetType("DxMessaging.Tests.Editor.MyNewTests");
+       if (fixture != null) { break; }
+   }
+   result.Log("fresh={0} asmUtc={1}",
+       fixture != null && fixture.GetMethod("MyNewTestMethod") != null,
+       System.IO.File.GetLastWriteTimeUtc(fixture.Assembly.Location).ToString("O"));
+   ```
+
+   A stale timestamp means the compile failed. Read the CI job log or Unity's
+   `Editor.log` for the `CS####` rather than re-running the suite.
+
 1. **Run**: invoke the host bridge `DxMcpTestRunner.Run(testMode, assemblyNames,
 testNames, categoryNames, resultPath)` via `Unity_RunCommand`. Locate the type by
    scanning `AppDomain` assemblies. Arguments are semicolon-separated lists; `null`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Every `MessageAwareComponent` inspector now shows a **Message subscriptions**
+  section listing the registrations its `MessageRegistrationToken` holds: the
+  message type, the registration kind and priority, the observed call count, and
+  a dot showing whether the registration is currently subscribed on the bus.
+  Call counts read as `calls n/a` while diagnostics are off rather than as zero.
+  See [Inspector Overlay](docs/guides/inspector-overlay.md#message-subscriptions).
+
 ## [3.2.1]
 
 ### Changed

--- a/Editor/CustomEditors/MessageAwareComponentFallbackEditor.cs
+++ b/Editor/CustomEditors/MessageAwareComponentFallbackEditor.cs
@@ -198,6 +198,22 @@ namespace DxMessaging.Editor.CustomEditors
             host.schedule.Execute(Refresh).Every(SubscriptionsPollMilliseconds);
         }
 
+        internal static void RefreshInspectorWarning(VisualElement root)
+        {
+            if (root == null)
+            {
+                throw new ArgumentNullException(nameof(root));
+            }
+            if (root.userData is not InspectorWarningBinding binding)
+            {
+                throw new InvalidOperationException(
+                    "Fallback inspector root is missing its warning binding."
+                );
+            }
+
+            binding.Refresh();
+        }
+
         private sealed class InspectorWarningBinding
         {
             private readonly VisualElement _warningHost;

--- a/Editor/CustomEditors/MessageAwareComponentFallbackEditor.cs
+++ b/Editor/CustomEditors/MessageAwareComponentFallbackEditor.cs
@@ -169,7 +169,7 @@ namespace DxMessaging.Editor.CustomEditors
                 return;
             }
 
-            VisualElement host = new() { name = SubscriptionsHostName, userData = component };
+            VisualElement host = new() { name = SubscriptionsHostName };
             host.AddToClassList(SubscriptionsHostClassName);
             root.Add(host);
 
@@ -196,49 +196,6 @@ namespace DxMessaging.Editor.CustomEditors
 
             Refresh();
             host.schedule.Execute(Refresh).Every(SubscriptionsPollMilliseconds);
-        }
-
-        /// <summary>
-        /// Rebuilds the subscriptions section of a built inspector root immediately, so tests do
-        /// not have to wait for the poll interval.
-        /// </summary>
-        internal static void RefreshSubscriptions(VisualElement root)
-        {
-            if (root == null)
-            {
-                throw new ArgumentNullException(nameof(root));
-            }
-
-            VisualElement host = root.Q<VisualElement>(SubscriptionsHostName);
-            if (host == null)
-            {
-                return;
-            }
-
-            host.Clear();
-            host.Add(
-                MessageAwareComponentSubscriptionsView.Create(
-                    MessageAwareComponentSubscriptionsState.Capture(
-                        host.userData as MessageAwareComponent
-                    )
-                )
-            );
-        }
-
-        internal static void RefreshInspectorWarning(VisualElement root)
-        {
-            if (root == null)
-            {
-                throw new ArgumentNullException(nameof(root));
-            }
-            if (root.userData is not InspectorWarningBinding binding)
-            {
-                throw new InvalidOperationException(
-                    "Fallback inspector root is missing its warning binding."
-                );
-            }
-
-            binding.Refresh();
         }
 
         private sealed class InspectorWarningBinding

--- a/Editor/CustomEditors/MessageAwareComponentFallbackEditor.cs
+++ b/Editor/CustomEditors/MessageAwareComponentFallbackEditor.cs
@@ -74,6 +74,18 @@ namespace DxMessaging.Editor.CustomEditors
             "dxmessaging-fallback-inspector-default-body";
         internal const string DefaultInspectorBodyClassName =
             "dxmessaging-fallback-inspector-default-body";
+        internal const string SubscriptionsHostName =
+            "dxmessaging-fallback-inspector-subscriptions-host";
+        internal const string SubscriptionsHostClassName =
+            "dxmessaging-fallback-inspector-subscriptions-host";
+
+        /// <summary>
+        /// Poll interval for the subscriptions section. Registrations change from game code with
+        /// no editor event to hook, so the section samples the token while its inspector is on
+        /// screen and rebuilds only when <see cref="MessageAwareComponentSubscriptionsState.Revision"/>
+        /// moves.
+        /// </summary>
+        internal const long SubscriptionsPollMilliseconds = 500;
 
         public override VisualElement CreateInspectorGUI()
         {
@@ -128,10 +140,89 @@ namespace DxMessaging.Editor.CustomEditors
             InspectorElement.FillDefaultInspector(defaultBody, editor.serializedObject, editor);
             root.Add(defaultBody);
 
+            AddSubscriptionsSection(root, ResolveSingleComponent(editor));
+
             root.RegisterCallback<AttachToPanelEvent>(_ => binding.Connect());
             root.RegisterCallback<DetachFromPanelEvent>(_ => binding.Disconnect());
 
             return root;
+        }
+
+        /// <summary>
+        /// The subscriptions section describes one component's registrations, so it is omitted
+        /// while several objects are edited together rather than showing one target's rows as if
+        /// they belonged to all of them.
+        /// </summary>
+        private static MessageAwareComponent ResolveSingleComponent(Editor editor)
+        {
+            UnityEngine.Object[] targets = editor.targets;
+            return targets is { Length: 1 } ? targets[0] as MessageAwareComponent : null;
+        }
+
+        private static void AddSubscriptionsSection(
+            VisualElement root,
+            MessageAwareComponent component
+        )
+        {
+            if (component == null)
+            {
+                return;
+            }
+
+            VisualElement host = new() { name = SubscriptionsHostName, userData = component };
+            host.AddToClassList(SubscriptionsHostClassName);
+            root.Add(host);
+
+            long revision = long.MinValue;
+            void Refresh()
+            {
+                if (component == null)
+                {
+                    host.Clear();
+                    return;
+                }
+
+                MessageAwareComponentSubscriptionsState state =
+                    MessageAwareComponentSubscriptionsState.Capture(component);
+                if (host.childCount > 0 && state.Revision == revision)
+                {
+                    return;
+                }
+
+                revision = state.Revision;
+                host.Clear();
+                host.Add(MessageAwareComponentSubscriptionsView.Create(state));
+            }
+
+            Refresh();
+            host.schedule.Execute(Refresh).Every(SubscriptionsPollMilliseconds);
+        }
+
+        /// <summary>
+        /// Rebuilds the subscriptions section of a built inspector root immediately, so tests do
+        /// not have to wait for the poll interval.
+        /// </summary>
+        internal static void RefreshSubscriptions(VisualElement root)
+        {
+            if (root == null)
+            {
+                throw new ArgumentNullException(nameof(root));
+            }
+
+            VisualElement host = root.Q<VisualElement>(SubscriptionsHostName);
+            if (host == null)
+            {
+                return;
+            }
+
+            host.Clear();
+            host.Add(
+                MessageAwareComponentSubscriptionsView.Create(
+                    MessageAwareComponentSubscriptionsState.Capture(
+                        host.userData as MessageAwareComponent
+                    )
+                )
+            );
         }
 
         internal static void RefreshInspectorWarning(VisualElement root)

--- a/Editor/CustomEditors/MessageAwareComponentSubscriptionsView.cs
+++ b/Editor/CustomEditors/MessageAwareComponentSubscriptionsView.cs
@@ -108,7 +108,7 @@ namespace DxMessaging.Editor.CustomEditors
         internal static string CreateRowMetaText(MessageAwareComponentSubscriptionRow row)
         {
             string calls =
-                row.CallCount < 0 ? "calls n/a"
+                row.CallCount == MessageAwareComponentSubscriptionRow.UnknownCallCount ? "calls n/a"
                 : row.CallCount == 1 ? "1 call"
                 : $"{row.CallCount} calls";
             return $"{row.RegistrationTypeName} | priority {row.Priority} | {calls}";
@@ -140,9 +140,14 @@ namespace DxMessaging.Editor.CustomEditors
     /// </summary>
     internal readonly struct MessageAwareComponentSubscriptionRow
     {
+        /// <summary>
+        /// <see cref="CallCount"/> when diagnostics are not recording. Distinct from zero, which
+        /// asserts that the handler genuinely never ran.
+        /// </summary>
+        internal const int UnknownCallCount = -1;
+
         internal MessageAwareComponentSubscriptionRow(
             string messageTypeName,
-            string routeKind,
             string registrationTypeName,
             int priority,
             int callCount,
@@ -150,7 +155,6 @@ namespace DxMessaging.Editor.CustomEditors
         )
         {
             MessageTypeName = messageTypeName;
-            RouteKind = routeKind;
             RegistrationTypeName = registrationTypeName;
             Priority = priority;
             CallCount = callCount;
@@ -159,14 +163,19 @@ namespace DxMessaging.Editor.CustomEditors
 
         internal string MessageTypeName { get; }
 
-        /// <summary>Untargeted, Targeted, Broadcast, or empty when the kind does not map.</summary>
-        internal string RouteKind { get; }
-
+        /// <summary>
+        /// The exact <see cref="MessageRegistrationType"/> name, which is finer-grained than the
+        /// Untargeted/Targeted/Broadcast route kind: it distinguishes handlers from post-processors
+        /// and interceptors, which is the distinction a reader of this section needs.
+        /// </summary>
         internal string RegistrationTypeName { get; }
 
         internal int Priority { get; }
 
-        /// <summary>Observed invocations, or -1 when diagnostics are not recording them.</summary>
+        /// <summary>
+        /// Observed invocations, or <see cref="UnknownCallCount"/> when diagnostics are not
+        /// recording them.
+        /// </summary>
         internal int CallCount { get; }
 
         /// <summary>True while the registration is subscribed on the bus.</summary>
@@ -243,6 +252,16 @@ namespace DxMessaging.Editor.CustomEditors
             // when the token is actually recording. With diagnostics off the count is unknown
             // rather than zero, and the row says so instead of implying nothing ever fired.
             bool diagnosticsEnabled = token.DiagnosticMode;
+            int ResolveCallCount(MessageRegistrationHandle handle)
+            {
+                if (!diagnosticsEnabled)
+                {
+                    return UnknownCallCount;
+                }
+
+                return token._callCounts.TryGetValue(handle, out int callCount) ? callCount : 0;
+            }
+
             List<MessageAwareComponentSubscriptionRow> rows = new();
             foreach (
                 KeyValuePair<
@@ -252,18 +271,12 @@ namespace DxMessaging.Editor.CustomEditors
             )
             {
                 MessageRegistrationMetadata metadata = entry.Value;
-                string registrationTypeName = metadata.registrationType.ToString();
                 rows.Add(
                     new MessageAwareComponentSubscriptionRow(
                         metadata.type == null ? "<unknown>" : metadata.type.Name,
-                        DxMessagingEditorPalette.NormalizeRouteKind(registrationTypeName),
-                        registrationTypeName,
+                        metadata.registrationType.ToString(),
                         metadata.priority,
-                        diagnosticsEnabled
-                            && token._callCounts.TryGetValue(entry.Key, out int callCount)
-                                ? callCount
-                            : diagnosticsEnabled ? 0
-                            : -1,
+                        ResolveCallCount(entry.Key),
                         token.Enabled
                     )
                 );

--- a/Editor/CustomEditors/MessageAwareComponentSubscriptionsView.cs
+++ b/Editor/CustomEditors/MessageAwareComponentSubscriptionsView.cs
@@ -269,7 +269,7 @@ namespace DxMessaging.Editor.CustomEditors
             {
                 if (!diagnosticsEnabled)
                 {
-                    return UnknownCallCount;
+                    return MessageAwareComponentSubscriptionRow.UnknownCallCount;
                 }
 
                 return token._callCounts.TryGetValue(handle, out int callCount) ? callCount : 0;

--- a/Editor/CustomEditors/MessageAwareComponentSubscriptionsView.cs
+++ b/Editor/CustomEditors/MessageAwareComponentSubscriptionsView.cs
@@ -220,9 +220,15 @@ namespace DxMessaging.Editor.CustomEditors
         internal IReadOnlyList<MessageAwareComponentSubscriptionRow> Rows { get; }
 
         /// <summary>
-        /// Cheap change signal, so a polling inspector only rebuilds the row list when the
-        /// registrations, the token state, or the observed call totals actually moved.
+        /// Cheap change signal, so a polling inspector only rebuilds the row list when something
+        /// it renders actually moved.
         /// </summary>
+        /// <remarks>
+        /// Every rendered field folds in, including each row's identity. Folding only the row count
+        /// and the call counts would miss a registration swapped for a different one: with
+        /// diagnostics off every count is <see cref="MessageAwareComponentSubscriptionRow.UnknownCallCount"/>,
+        /// so a same-size replacement would leave the poller showing stale rows.
+        /// </remarks>
         internal long Revision
         {
             get
@@ -233,6 +239,13 @@ namespace DxMessaging.Editor.CustomEditors
                 foreach (MessageAwareComponentSubscriptionRow row in Rows)
                 {
                     revision = (revision * 31) + row.CallCount;
+                    revision = (revision * 31) + row.Priority;
+                    revision = (revision * 31) + (row.IsLive ? 1 : 0);
+                    revision =
+                        (revision * 31) + StringComparer.Ordinal.GetHashCode(row.MessageTypeName);
+                    revision =
+                        (revision * 31)
+                        + StringComparer.Ordinal.GetHashCode(row.RegistrationTypeName);
                 }
                 return revision;
             }

--- a/Editor/CustomEditors/MessageAwareComponentSubscriptionsView.cs
+++ b/Editor/CustomEditors/MessageAwareComponentSubscriptionsView.cs
@@ -39,6 +39,15 @@ namespace DxMessaging.Editor.CustomEditors
 
         internal const string Title = "Message subscriptions";
 
+        /// <summary>
+        /// Mirrors the horizontal inset of <c>.dx-inspector__head</c> in
+        /// <c>Editor/Theme/DxMessagingTheme.uss</c>. Kept here rather than added to <c>.dx-sub</c>
+        /// so the migrated stylesheet stays identical to the design-system spec.
+        /// </summary>
+        internal const int HeadHorizontalPadding = 11;
+
+        internal const int BodyVerticalPadding = 5;
+
         internal static VisualElement Create(MessageAwareComponentSubscriptionsState state)
         {
             if (state == null)
@@ -63,7 +72,15 @@ namespace DxMessaging.Editor.CustomEditors
             head.Add(meta);
             root.Add(head);
 
+            // `.dx-sub` pads vertically only, and `.dx-inspector` clips to a rounded corner, so the
+            // body needs its own horizontal inset: without it a row name sits flush against the
+            // border and the trailing status dot clips on the corner radius. Matches the
+            // `.dx-inspector__head` inset so the head and the rows line up.
             VisualElement rows = new() { name = RowsName };
+            rows.style.paddingLeft = HeadHorizontalPadding;
+            rows.style.paddingRight = HeadHorizontalPadding;
+            rows.style.paddingTop = BodyVerticalPadding;
+            rows.style.paddingBottom = BodyVerticalPadding;
             root.Add(rows);
 
             if (state.Rows.Count == 0)

--- a/Editor/CustomEditors/MessageAwareComponentSubscriptionsView.cs
+++ b/Editor/CustomEditors/MessageAwareComponentSubscriptionsView.cs
@@ -1,0 +1,300 @@
+namespace DxMessaging.Editor.CustomEditors
+{
+#if UNITY_EDITOR
+    using System;
+    using System.Collections.Generic;
+    using DxMessaging.Core;
+    using DxMessaging.Core.Diagnostics;
+    using DxMessaging.Editor;
+    using DxMessaging.Unity;
+    using UnityEngine.UIElements;
+
+    /// <summary>
+    /// Builds the themed "Message subscriptions" section shown under a
+    /// <see cref="MessageAwareComponent"/> inspector body.
+    /// </summary>
+    /// <remarks>
+    /// The section renders the component's live <see cref="MessageRegistrationToken"/> registrations
+    /// through the design system's <c>.dx-inspector</c> / <c>.dx-sub*</c> classes. It reads only
+    /// registration metadata the token already keeps, so it costs nothing at runtime and nothing in
+    /// the editor until an inspector is actually showing.
+    /// </remarks>
+    internal static class MessageAwareComponentSubscriptionsView
+    {
+        internal const string RootName = "dxmessaging-inspector-subscriptions";
+        internal const string TitleLabelName = "dxmessaging-inspector-subscriptions-title";
+        internal const string MetaLabelName = "dxmessaging-inspector-subscriptions-meta";
+        internal const string RowsName = "dxmessaging-inspector-subscriptions-rows";
+        internal const string EmptyBodyName = "dxmessaging-inspector-subscriptions-empty-body";
+
+        internal const string RootClassName = "dx-inspector";
+        internal const string HeadClassName = "dx-inspector__head";
+        internal const string TitleClassName = "dx-inspector__title";
+        internal const string MetaClassName = "dx-inspector__meta";
+        internal const string RowClassName = "dx-sub";
+        internal const string RowNameClassName = "dx-sub__name";
+        internal const string RowMetaClassName = "dx-sub__meta";
+        internal const string RowLiveClassName = "dx-sub__live";
+        internal const string RowIdleClassName = "dx-sub__idle";
+
+        internal const string Title = "Message subscriptions";
+
+        internal static VisualElement Create(MessageAwareComponentSubscriptionsState state)
+        {
+            if (state == null)
+            {
+                throw new ArgumentNullException(nameof(state));
+            }
+
+            VisualElement root = new() { name = RootName };
+            DxMessagingEditorTheme.Apply(root);
+            root.AddToClassList(RootClassName);
+            DxMessagingEditorTheme.ApplyCompleteBorder(root, DxMessagingEditorPalette.BorderPanel);
+
+            VisualElement head = new();
+            head.AddToClassList(HeadClassName);
+            Label title = new(Title) { name = TitleLabelName };
+            title.AddToClassList(TitleClassName);
+            head.Add(title);
+            Label meta = new(CreateSummaryText(state)) { name = MetaLabelName };
+            meta.AddToClassList(MetaClassName);
+            meta.style.flexGrow = 1;
+            meta.style.unityTextAlign = UnityEngine.TextAnchor.MiddleRight;
+            head.Add(meta);
+            root.Add(head);
+
+            VisualElement rows = new() { name = RowsName };
+            root.Add(rows);
+
+            if (state.Rows.Count == 0)
+            {
+                rows.Add(
+                    DxMessagingEditorTheme.CreateEmptyState(
+                        title: null,
+                        body: CreateEmptyBodyText(state),
+                        bodyName: EmptyBodyName
+                    )
+                );
+                return root;
+            }
+
+            foreach (MessageAwareComponentSubscriptionRow row in state.Rows)
+            {
+                rows.Add(CreateRow(row));
+            }
+
+            return root;
+        }
+
+        internal static string CreateSummaryText(MessageAwareComponentSubscriptionsState state)
+        {
+            if (!state.HasToken)
+            {
+                return "No token";
+            }
+
+            string count =
+                state.Rows.Count == 1 ? "1 registration" : $"{state.Rows.Count} registrations";
+            return state.TokenEnabled ? $"Listening | {count}" : $"Disabled | {count}";
+        }
+
+        internal static string CreateEmptyBodyText(MessageAwareComponentSubscriptionsState state)
+        {
+            return state.HasToken
+                ? "This component has a registration token but has registered no handlers."
+                : "Registrations are created in Awake, so they appear once the component is running in Play mode.";
+        }
+
+        internal static string CreateRowMetaText(MessageAwareComponentSubscriptionRow row)
+        {
+            string calls =
+                row.CallCount < 0 ? "calls n/a"
+                : row.CallCount == 1 ? "1 call"
+                : $"{row.CallCount} calls";
+            return $"{row.RegistrationTypeName} | priority {row.Priority} | {calls}";
+        }
+
+        private static VisualElement CreateRow(MessageAwareComponentSubscriptionRow row)
+        {
+            VisualElement element = new();
+            element.AddToClassList(RowClassName);
+
+            Label name = new(row.MessageTypeName);
+            name.AddToClassList(RowNameClassName);
+            element.Add(name);
+
+            Label meta = new(CreateRowMetaText(row));
+            meta.AddToClassList(RowMetaClassName);
+            element.Add(meta);
+
+            VisualElement dot = new();
+            dot.AddToClassList(row.IsLive ? RowLiveClassName : RowIdleClassName);
+            element.Add(dot);
+
+            return element;
+        }
+    }
+
+    /// <summary>
+    /// One registration row rendered by <see cref="MessageAwareComponentSubscriptionsView"/>.
+    /// </summary>
+    internal readonly struct MessageAwareComponentSubscriptionRow
+    {
+        internal MessageAwareComponentSubscriptionRow(
+            string messageTypeName,
+            string routeKind,
+            string registrationTypeName,
+            int priority,
+            int callCount,
+            bool isLive
+        )
+        {
+            MessageTypeName = messageTypeName;
+            RouteKind = routeKind;
+            RegistrationTypeName = registrationTypeName;
+            Priority = priority;
+            CallCount = callCount;
+            IsLive = isLive;
+        }
+
+        internal string MessageTypeName { get; }
+
+        /// <summary>Untargeted, Targeted, Broadcast, or empty when the kind does not map.</summary>
+        internal string RouteKind { get; }
+
+        internal string RegistrationTypeName { get; }
+
+        internal int Priority { get; }
+
+        /// <summary>Observed invocations, or -1 when diagnostics are not recording them.</summary>
+        internal int CallCount { get; }
+
+        /// <summary>True while the registration is subscribed on the bus.</summary>
+        internal bool IsLive { get; }
+    }
+
+    /// <summary>
+    /// Snapshot of a component's registrations, captured without touching any GUI API so the
+    /// decision and formatting logic stays testable without an editor panel.
+    /// </summary>
+    internal sealed class MessageAwareComponentSubscriptionsState
+    {
+        private static readonly MessageAwareComponentSubscriptionRow[] NoRows =
+            Array.Empty<MessageAwareComponentSubscriptionRow>();
+
+        internal static readonly MessageAwareComponentSubscriptionsState None = new(
+            hasToken: false,
+            tokenEnabled: false,
+            diagnosticsEnabled: false,
+            rows: NoRows
+        );
+
+        internal MessageAwareComponentSubscriptionsState(
+            bool hasToken,
+            bool tokenEnabled,
+            bool diagnosticsEnabled,
+            IReadOnlyList<MessageAwareComponentSubscriptionRow> rows
+        )
+        {
+            HasToken = hasToken;
+            TokenEnabled = tokenEnabled;
+            DiagnosticsEnabled = diagnosticsEnabled;
+            Rows = rows ?? throw new ArgumentNullException(nameof(rows));
+        }
+
+        internal bool HasToken { get; }
+
+        internal bool TokenEnabled { get; }
+
+        internal bool DiagnosticsEnabled { get; }
+
+        internal IReadOnlyList<MessageAwareComponentSubscriptionRow> Rows { get; }
+
+        /// <summary>
+        /// Cheap change signal, so a polling inspector only rebuilds the row list when the
+        /// registrations, the token state, or the observed call totals actually moved.
+        /// </summary>
+        internal long Revision
+        {
+            get
+            {
+                long revision = HasToken ? 1 : 0;
+                revision = (revision * 31) + (TokenEnabled ? 1 : 0);
+                revision = (revision * 31) + Rows.Count;
+                foreach (MessageAwareComponentSubscriptionRow row in Rows)
+                {
+                    revision = (revision * 31) + row.CallCount;
+                }
+                return revision;
+            }
+        }
+
+        internal static MessageAwareComponentSubscriptionsState Capture(
+            MessageAwareComponent component
+        )
+        {
+            MessageRegistrationToken token = component == null ? null : component.Token;
+            if (token == null)
+            {
+                return None;
+            }
+
+            // Reading _callCounts materializes the lazy diagnostics dictionary, so only touch it
+            // when the token is actually recording. With diagnostics off the count is unknown
+            // rather than zero, and the row says so instead of implying nothing ever fired.
+            bool diagnosticsEnabled = token.DiagnosticMode;
+            List<MessageAwareComponentSubscriptionRow> rows = new();
+            foreach (
+                KeyValuePair<
+                    MessageRegistrationHandle,
+                    MessageRegistrationMetadata
+                > entry in token._metadata
+            )
+            {
+                MessageRegistrationMetadata metadata = entry.Value;
+                string registrationTypeName = metadata.registrationType.ToString();
+                rows.Add(
+                    new MessageAwareComponentSubscriptionRow(
+                        metadata.type == null ? "<unknown>" : metadata.type.Name,
+                        DxMessagingEditorPalette.NormalizeRouteKind(registrationTypeName),
+                        registrationTypeName,
+                        metadata.priority,
+                        diagnosticsEnabled
+                            && token._callCounts.TryGetValue(entry.Key, out int callCount)
+                                ? callCount
+                            : diagnosticsEnabled ? 0
+                            : -1,
+                        token.Enabled
+                    )
+                );
+            }
+
+            rows.Sort(CompareRows);
+            return new MessageAwareComponentSubscriptionsState(
+                hasToken: true,
+                tokenEnabled: token.Enabled,
+                diagnosticsEnabled: diagnosticsEnabled,
+                rows: rows
+            );
+        }
+
+        private static int CompareRows(
+            MessageAwareComponentSubscriptionRow left,
+            MessageAwareComponentSubscriptionRow right
+        )
+        {
+            int comparison = string.CompareOrdinal(left.MessageTypeName, right.MessageTypeName);
+            if (comparison != 0)
+            {
+                return comparison;
+            }
+
+            comparison = string.CompareOrdinal(
+                left.RegistrationTypeName,
+                right.RegistrationTypeName
+            );
+            return comparison != 0 ? comparison : left.Priority.CompareTo(right.Priority);
+        }
+    }
+#endif
+}

--- a/Editor/CustomEditors/MessageAwareComponentSubscriptionsView.cs.meta
+++ b/Editor/CustomEditors/MessageAwareComponentSubscriptionsView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76d0a17887db3ca036aa40ba70fad5df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/MessageAwareComponentSubscriptionsViewTests.cs
+++ b/Tests/Editor/MessageAwareComponentSubscriptionsViewTests.cs
@@ -1,0 +1,376 @@
+#if UNITY_EDITOR && UNITY_2021_3_OR_NEWER
+namespace DxMessaging.Tests.Editor
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Core;
+    using Core.Diagnostics;
+    using Core.MessageBus;
+    using Core.Messages;
+    using DxMessaging.Editor.CustomEditors;
+    using DxMessaging.Unity;
+    using NUnit.Framework;
+    using UnityEngine;
+    using UnityEngine.UIElements;
+    using Object = UnityEngine.Object;
+
+    /// <summary>
+    /// Covers the themed subscriptions section: what it captures from a live registration token,
+    /// how it renders each state, and the design-system classes it must carry.
+    /// </summary>
+    [TestFixture]
+    public sealed class MessageAwareComponentSubscriptionsViewTests
+    {
+        private readonly List<Object> _createdObjects = new();
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (Object instance in _createdObjects)
+            {
+                if (instance != null)
+                {
+                    Object.DestroyImmediate(instance);
+                }
+            }
+            _createdObjects.Clear();
+        }
+
+        [Test]
+        public void CaptureWithoutTokenReportsNoToken()
+        {
+            SubscriptionsTestComponent component = CreateComponent(out _);
+
+            MessageAwareComponentSubscriptionsState state =
+                MessageAwareComponentSubscriptionsState.Capture(component);
+
+            Assert.That(state.HasToken, Is.False);
+            Assert.That(state.Rows, Is.Empty);
+            Assert.That(
+                MessageAwareComponentSubscriptionsView.CreateSummaryText(state),
+                Is.EqualTo("No token")
+            );
+        }
+
+        [Test]
+        public void CaptureOfDestroyedComponentReportsNoToken()
+        {
+            SubscriptionsTestComponent component = CreateComponent(out _);
+            Object.DestroyImmediate(component);
+
+            MessageAwareComponentSubscriptionsState state =
+                MessageAwareComponentSubscriptionsState.Capture(component);
+
+            Assert.That(state.HasToken, Is.False);
+            Assert.That(state.Rows, Is.Empty);
+        }
+
+        [Test]
+        public void CaptureWithTokenButNoRegistrationsReportsEmptyBody()
+        {
+            SubscriptionsTestComponent component = CreateComponent(
+                out MessagingComponent messagingComponent
+            );
+            component.ConfigureForEditorTest(messagingComponent);
+
+            MessageAwareComponentSubscriptionsState state =
+                MessageAwareComponentSubscriptionsState.Capture(component);
+
+            Assert.That(state.HasToken, Is.True);
+            Assert.That(state.Rows, Is.Empty);
+            Assert.That(
+                MessageAwareComponentSubscriptionsView.CreateEmptyBodyText(state),
+                Does.Contain("registered no handlers")
+            );
+        }
+
+        [Test]
+        public void CaptureListsEveryRegistrationSortedAndTyped()
+        {
+            SubscriptionsTestComponent component = CreateComponent(
+                out MessagingComponent messagingComponent
+            );
+            component.ConfigureForEditorTest(messagingComponent);
+            component.RegisterTestHandlers();
+
+            MessageAwareComponentSubscriptionsState state =
+                MessageAwareComponentSubscriptionsState.Capture(component);
+
+            Assert.That(state.HasToken, Is.True);
+            Assert.That(
+                state.Rows.Select(row => row.MessageTypeName).ToArray(),
+                Is.EqualTo(
+                    new[] { nameof(SubscriptionsAlphaMessage), nameof(SubscriptionsBetaMessage) }
+                ),
+                "Rows must be ordered by message type name so the section does not reshuffle between polls."
+            );
+            Assert.That(
+                state.Rows.Select(row => row.RouteKind).ToArray(),
+                Is.EqualTo(new[] { "Untargeted", "Targeted" })
+            );
+            Assert.That(
+                state.Rows.Select(row => row.RegistrationTypeName).ToArray(),
+                Is.EqualTo(
+                    new[]
+                    {
+                        MessageRegistrationType.Untargeted.ToString(),
+                        MessageRegistrationType.Targeted.ToString(),
+                    }
+                )
+            );
+        }
+
+        [Test]
+        public void RowsAreLiveOnlyWhileTheTokenIsEnabled()
+        {
+            SubscriptionsTestComponent component = CreateComponent(
+                out MessagingComponent messagingComponent
+            );
+            component.ConfigureForEditorTest(messagingComponent);
+            component.RegisterTestHandlers();
+
+            MessageAwareComponentSubscriptionsState idle =
+                MessageAwareComponentSubscriptionsState.Capture(component);
+            Assert.That(idle.TokenEnabled, Is.False);
+            Assert.That(idle.Rows.All(row => !row.IsLive), Is.True);
+            Assert.That(
+                MessageAwareComponentSubscriptionsView.CreateSummaryText(idle),
+                Is.EqualTo("Disabled | 2 registrations")
+            );
+
+            component.TestToken.Enable();
+            try
+            {
+                MessageAwareComponentSubscriptionsState live =
+                    MessageAwareComponentSubscriptionsState.Capture(component);
+                Assert.That(live.TokenEnabled, Is.True);
+                Assert.That(live.Rows.All(row => row.IsLive), Is.True);
+                Assert.That(
+                    MessageAwareComponentSubscriptionsView.CreateSummaryText(live),
+                    Is.EqualTo("Listening | 2 registrations")
+                );
+            }
+            finally
+            {
+                component.TestToken.Disable();
+            }
+        }
+
+        [Test]
+        public void CallCountsAreUnknownUntilDiagnosticsRecordThem()
+        {
+            SubscriptionsTestComponent component = CreateComponent(
+                out MessagingComponent messagingComponent
+            );
+            component.ConfigureForEditorTest(messagingComponent);
+            component.RegisterTestHandlers();
+
+            MessageAwareComponentSubscriptionsState quiet =
+                MessageAwareComponentSubscriptionsState.Capture(component);
+            Assert.That(quiet.DiagnosticsEnabled, Is.False);
+            Assert.That(quiet.Rows.All(row => row.CallCount < 0), Is.True);
+            Assert.That(
+                MessageAwareComponentSubscriptionsView.CreateRowMetaText(quiet.Rows[0]),
+                Does.Contain("calls n/a"),
+                "Diagnostics-off must read as unknown, not as a confident zero."
+            );
+
+            component.TestToken.DiagnosticMode = true;
+            component.TestToken.Enable();
+            try
+            {
+                SubscriptionsAlphaMessage message = default;
+                MessageHandler.MessageBus.UntargetedBroadcast(ref message);
+
+                MessageAwareComponentSubscriptionsState recorded =
+                    MessageAwareComponentSubscriptionsState.Capture(component);
+                Assert.That(recorded.DiagnosticsEnabled, Is.True);
+
+                MessageAwareComponentSubscriptionRow alpha = recorded.Rows.Single(row =>
+                    row.MessageTypeName == nameof(SubscriptionsAlphaMessage)
+                );
+                Assert.That(alpha.CallCount, Is.EqualTo(1));
+                Assert.That(
+                    MessageAwareComponentSubscriptionsView.CreateRowMetaText(alpha),
+                    Does.Contain("1 call")
+                );
+
+                MessageAwareComponentSubscriptionRow beta = recorded.Rows.Single(row =>
+                    row.MessageTypeName == nameof(SubscriptionsBetaMessage)
+                );
+                Assert.That(beta.CallCount, Is.EqualTo(0));
+                Assert.That(
+                    MessageAwareComponentSubscriptionsView.CreateRowMetaText(beta),
+                    Does.Contain("0 calls")
+                );
+            }
+            finally
+            {
+                component.TestToken.DiagnosticMode = false;
+                component.TestToken.Disable();
+            }
+        }
+
+        [Test]
+        public void RevisionMovesOnlyWhenTheRenderedStateChanges()
+        {
+            SubscriptionsTestComponent component = CreateComponent(
+                out MessagingComponent messagingComponent
+            );
+            component.ConfigureForEditorTest(messagingComponent);
+            component.RegisterTestHandlers();
+
+            long first = MessageAwareComponentSubscriptionsState.Capture(component).Revision;
+            long unchanged = MessageAwareComponentSubscriptionsState.Capture(component).Revision;
+            Assert.That(unchanged, Is.EqualTo(first));
+
+            component.TestToken.Enable();
+            try
+            {
+                Assert.That(
+                    MessageAwareComponentSubscriptionsState.Capture(component).Revision,
+                    Is.Not.EqualTo(first),
+                    "Enabling the token flips every row to live, so the section must rebuild."
+                );
+            }
+            finally
+            {
+                component.TestToken.Disable();
+            }
+        }
+
+        [Test]
+        public void ViewCarriesTheDesignSystemSubscriptionClasses()
+        {
+            SubscriptionsTestComponent component = CreateComponent(
+                out MessagingComponent messagingComponent
+            );
+            component.ConfigureForEditorTest(messagingComponent);
+            component.RegisterTestHandlers();
+
+            VisualElement root = MessageAwareComponentSubscriptionsView.Create(
+                MessageAwareComponentSubscriptionsState.Capture(component)
+            );
+
+            Assert.That(root.name, Is.EqualTo(MessageAwareComponentSubscriptionsView.RootName));
+            Assert.That(
+                root.ClassListContains(MessageAwareComponentSubscriptionsView.RootClassName),
+                Is.True
+            );
+            foreach (
+                string className in new[]
+                {
+                    MessageAwareComponentSubscriptionsView.HeadClassName,
+                    MessageAwareComponentSubscriptionsView.TitleClassName,
+                    MessageAwareComponentSubscriptionsView.MetaClassName,
+                }
+            )
+            {
+                Assert.That(
+                    root.Query<VisualElement>()
+                        .ToList()
+                        .Any(element => element.ClassListContains(className)),
+                    Is.True,
+                    $"Subscriptions section must render {className}."
+                );
+            }
+
+            List<VisualElement> rows = root.Q<VisualElement>(
+                    MessageAwareComponentSubscriptionsView.RowsName
+                )
+                .Children()
+                .ToList();
+            Assert.That(rows.Count, Is.EqualTo(2));
+            foreach (VisualElement row in rows)
+            {
+                Assert.That(
+                    row.ClassListContains(MessageAwareComponentSubscriptionsView.RowClassName),
+                    Is.True
+                );
+                Assert.That(
+                    row.Children()
+                        .Count(child =>
+                            child.ClassListContains(
+                                MessageAwareComponentSubscriptionsView.RowIdleClassName
+                            )
+                        ),
+                    Is.EqualTo(1),
+                    "Each row carries exactly one state dot."
+                );
+            }
+        }
+
+        [Test]
+        public void ViewBordersEveryEdgeOfTheSection()
+        {
+            VisualElement root = MessageAwareComponentSubscriptionsView.Create(
+                MessageAwareComponentSubscriptionsState.None
+            );
+
+            Assert.That(root.style.borderTopWidth.value, Is.EqualTo(1));
+            Assert.That(root.style.borderRightWidth.value, Is.EqualTo(1));
+            Assert.That(root.style.borderBottomWidth.value, Is.EqualTo(1));
+            Assert.That(root.style.borderLeftWidth.value, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ViewWithoutRowsRendersTheThemedEmptyState()
+        {
+            VisualElement root = MessageAwareComponentSubscriptionsView.Create(
+                MessageAwareComponentSubscriptionsState.None
+            );
+
+            Label body = root.Q<Label>(MessageAwareComponentSubscriptionsView.EmptyBodyName);
+            Assert.That(body, Is.Not.Null);
+            Assert.That(body.text, Does.Contain("Play mode"));
+            Assert.That(
+                root.Q<VisualElement>(MessageAwareComponentSubscriptionsView.RowsName).childCount,
+                Is.EqualTo(1)
+            );
+        }
+
+        private SubscriptionsTestComponent CreateComponent(
+            out MessagingComponent messagingComponent
+        )
+        {
+            GameObject host = new(nameof(MessageAwareComponentSubscriptionsViewTests));
+            _createdObjects.Add(host);
+            messagingComponent = host.AddComponent<MessagingComponent>();
+            return host.AddComponent<SubscriptionsTestComponent>();
+        }
+    }
+
+    // Registrations are normally created in Awake, which the editor never runs for a plain
+    // MonoBehaviour. ConfigureForEditorTest wires the same token the runtime path would, so the
+    // section is exercised against a real MessageRegistrationToken rather than a stand-in.
+    [AddComponentMenu("")]
+    internal sealed class SubscriptionsTestComponent : MessageAwareComponent
+    {
+        protected override bool RegisterForStringMessages => false;
+
+        internal MessageRegistrationToken TestToken => _messageRegistrationToken;
+
+        internal void ConfigureForEditorTest(MessagingComponent messagingComponent)
+        {
+            _messageRegistrationToken = messagingComponent.Create(this);
+        }
+
+        internal void RegisterTestHandlers()
+        {
+            _ = _messageRegistrationToken.RegisterUntargeted<SubscriptionsAlphaMessage>(OnAlpha);
+            _ = _messageRegistrationToken.RegisterComponentTargeted<SubscriptionsBetaMessage>(
+                this,
+                OnBeta
+            );
+        }
+
+        private void OnAlpha(ref SubscriptionsAlphaMessage message) { }
+
+        private void OnBeta(ref SubscriptionsBetaMessage message) { }
+    }
+
+    internal readonly struct SubscriptionsAlphaMessage : IUntargetedMessage { }
+
+    internal readonly struct SubscriptionsBetaMessage : ITargetedMessage { }
+}
+#endif

--- a/Tests/Editor/MessageAwareComponentSubscriptionsViewTests.cs
+++ b/Tests/Editor/MessageAwareComponentSubscriptionsViewTests.cs
@@ -165,6 +165,10 @@ namespace DxMessaging.Tests.Editor
             component.ConfigureForEditorTest(messagingComponent);
             component.RegisterTestHandlers();
 
+            // A token inherits IMessageBus.GlobalDiagnosticsMode, which the host project's
+            // DxMessaging settings can leave on. Pin both halves of the behavior here rather
+            // than reading whatever the ambient project default happens to be.
+            component.TestToken.DiagnosticMode = false;
             MessageAwareComponentSubscriptionsState quiet =
                 MessageAwareComponentSubscriptionsState.Capture(component);
             Assert.That(quiet.DiagnosticsEnabled, Is.False);

--- a/Tests/Editor/MessageAwareComponentSubscriptionsViewTests.cs
+++ b/Tests/Editor/MessageAwareComponentSubscriptionsViewTests.cs
@@ -343,6 +343,21 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
+        public void ViewInsetsRowsSoTheyClearTheRoundedBorder()
+        {
+            VisualElement rows = MessageAwareComponentSubscriptionsView
+                .Create(MessageAwareComponentSubscriptionsState.None)
+                .Q<VisualElement>(MessageAwareComponentSubscriptionsView.RowsName);
+
+            Assert.That(
+                rows.style.paddingLeft.value.value,
+                Is.GreaterThan(0),
+                "Rows must clear the .dx-inspector corner radius; .dx-sub pads vertically only."
+            );
+            Assert.That(rows.style.paddingRight.value.value, Is.GreaterThan(0));
+        }
+
+        [Test]
         public void ViewBordersEveryEdgeOfTheSection()
         {
             VisualElement root = MessageAwareComponentSubscriptionsView.Create(

--- a/Tests/Editor/MessageAwareComponentSubscriptionsViewTests.cs
+++ b/Tests/Editor/MessageAwareComponentSubscriptionsViewTests.cs
@@ -245,6 +245,35 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
+        public void RevisionMovesWhenOneRegistrationIsSwappedForAnother()
+        {
+            SubscriptionsTestComponent component = CreateComponent(
+                out MessagingComponent messagingComponent
+            );
+            component.ConfigureForEditorTest(messagingComponent);
+            component.TestToken.DiagnosticMode = false;
+            MessageRegistrationHandle alpha = component.RegisterAlpha();
+
+            long before = MessageAwareComponentSubscriptionsState.Capture(component).Revision;
+
+            component.TestToken.RemoveRegistration(alpha);
+            _ = component.RegisterBeta();
+
+            MessageAwareComponentSubscriptionsState after =
+                MessageAwareComponentSubscriptionsState.Capture(component);
+            Assert.That(
+                after.Rows.Select(row => row.MessageTypeName).ToArray(),
+                Is.EqualTo(new[] { nameof(SubscriptionsBetaMessage) })
+            );
+            Assert.That(
+                after.Revision,
+                Is.Not.EqualTo(before),
+                "A same-size swap must still redraw: with diagnostics off every call count is unknown, "
+                    + "so row identity is the only thing that changed."
+            );
+        }
+
+        [Test]
         public void ViewCarriesTheDesignSystemSubscriptionClasses()
         {
             SubscriptionsTestComponent component = CreateComponent(
@@ -370,8 +399,18 @@ namespace DxMessaging.Tests.Editor
 
         internal void RegisterTestHandlers()
         {
-            _ = _messageRegistrationToken.RegisterUntargeted<SubscriptionsAlphaMessage>(OnAlpha);
-            _ = _messageRegistrationToken.RegisterComponentTargeted<SubscriptionsBetaMessage>(
+            _ = RegisterAlpha();
+            _ = RegisterBeta();
+        }
+
+        internal MessageRegistrationHandle RegisterAlpha()
+        {
+            return _messageRegistrationToken.RegisterUntargeted<SubscriptionsAlphaMessage>(OnAlpha);
+        }
+
+        internal MessageRegistrationHandle RegisterBeta()
+        {
+            return _messageRegistrationToken.RegisterComponentTargeted<SubscriptionsBetaMessage>(
                 this,
                 OnBeta
             );

--- a/Tests/Editor/MessageAwareComponentSubscriptionsViewTests.cs
+++ b/Tests/Editor/MessageAwareComponentSubscriptionsViewTests.cs
@@ -105,10 +105,6 @@ namespace DxMessaging.Tests.Editor
                 "Rows must be ordered by message type name so the section does not reshuffle between polls."
             );
             Assert.That(
-                state.Rows.Select(row => row.RouteKind).ToArray(),
-                Is.EqualTo(new[] { "Untargeted", "Targeted" })
-            );
-            Assert.That(
                 state.Rows.Select(row => row.RegistrationTypeName).ToArray(),
                 Is.EqualTo(
                     new[]
@@ -172,7 +168,12 @@ namespace DxMessaging.Tests.Editor
             MessageAwareComponentSubscriptionsState quiet =
                 MessageAwareComponentSubscriptionsState.Capture(component);
             Assert.That(quiet.DiagnosticsEnabled, Is.False);
-            Assert.That(quiet.Rows.All(row => row.CallCount < 0), Is.True);
+            Assert.That(
+                quiet.Rows.All(row =>
+                    row.CallCount == MessageAwareComponentSubscriptionRow.UnknownCallCount
+                ),
+                Is.True
+            );
             Assert.That(
                 MessageAwareComponentSubscriptionsView.CreateRowMetaText(quiet.Rows[0]),
                 Does.Contain("calls n/a"),
@@ -261,6 +262,14 @@ namespace DxMessaging.Tests.Editor
                 root.ClassListContains(MessageAwareComponentSubscriptionsView.RootClassName),
                 Is.True
             );
+
+            Label title = root.Q<Label>(MessageAwareComponentSubscriptionsView.TitleLabelName);
+            Assert.That(title, Is.Not.Null);
+            Assert.That(title.text, Is.EqualTo(MessageAwareComponentSubscriptionsView.Title));
+            Label meta = root.Q<Label>(MessageAwareComponentSubscriptionsView.MetaLabelName);
+            Assert.That(meta, Is.Not.Null);
+            Assert.That(meta.text, Is.EqualTo("Disabled | 2 registrations"));
+
             foreach (
                 string className in new[]
                 {

--- a/Tests/Editor/MessageAwareComponentSubscriptionsViewTests.cs.meta
+++ b/Tests/Editor/MessageAwareComponentSubscriptionsViewTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d122d876cfbd4c3086038b756fe7257c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/guides/inspector-overlay.md
+++ b/docs/guides/inspector-overlay.md
@@ -159,11 +159,13 @@ it.
 
 ## Message Subscriptions
 
-Below the serialized fields, every `MessageAwareComponent` inspector shows a
-**Message subscriptions** section listing the registrations that component's
+Below the serialized fields, the package's `MessageAwareComponent` inspector shows
+a **Message subscriptions** section listing the registrations that component's
 `MessageRegistrationToken` currently holds. It reads the live token, so it
 answers "is this component actually listening, and to what?" without adding a
-log statement.
+log statement. A subclass with its own `[CustomEditor]` draws that editor instead,
+so the section does not appear there; the base-call warning above still does,
+through the header hook.
 
 Each row shows:
 

--- a/docs/guides/inspector-overlay.md
+++ b/docs/guides/inspector-overlay.md
@@ -157,6 +157,38 @@ genuinely intentional (for example, a deliberate adapter that should not
 participate in messaging) and document the reason somewhere your team can find
 it.
 
+## Message Subscriptions
+
+Below the serialized fields, every `MessageAwareComponent` inspector shows a
+**Message subscriptions** section listing the registrations that component's
+`MessageRegistrationToken` currently holds. It reads the live token, so it
+answers "is this component actually listening, and to what?" without adding a
+log statement.
+
+Each row shows:
+
+- The message type name.
+- The registration kind (`Untargeted`, `Targeted`, `Broadcast`, a post-processor
+  or interceptor variant) and the registration priority.
+- The observed call count, or `calls n/a` when diagnostics are not recording.
+- A dot on the right: green while the registration is subscribed on the bus,
+  grey while the token is disabled.
+
+The header summarizes the same thing: `Listening | 3 registrations` when the
+token is enabled, `Disabled | 3 registrations` when it is not. A disabled token
+is the usual explanation for a handler that stopped firing, because
+`MessageAwareComponent.OnDisable` disables the token by default. See
+[`MessageRegistrationTiedToEnableStatus`](unity-integration.md) for how to change
+that.
+
+Registrations are created in `Awake`, so an inspector in Edit mode shows an empty
+state instead of rows. Call counts require diagnostics; turn them on through
+**Diagnostics Targets** below, or per token through
+`MessageRegistrationToken.DiagnosticMode`. The section samples the token while it
+is on screen and redraws only when the registrations, the token state, or the
+call counts change. It is hidden while several objects are selected together,
+because the rows describe one component.
+
 ## Project Settings Panel
 
 The package registers a UI Toolkit Project Settings page under

--- a/docs/ops/ambiguous-release-migration.md
+++ b/docs/ops/ambiguous-release-migration.md
@@ -101,7 +101,7 @@ organization lock.
     uses: ./.github/actions/validate-unity-license
 
   - name: Acquire organization Unity lock
-    uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+    uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
     with:
       lock-name: wallstop-organization-builds
       runner-id: ${{ runner.name }}

--- a/docs/ops/ci-and-github-settings.md
+++ b/docs/ops/ci-and-github-settings.md
@@ -36,7 +36,7 @@ the central lock immediately before the licensed Unity section:
   uses: ./.github/actions/validate-unity-license
 
 - name: Acquire organization Unity lock
-  uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628 # v1.9.1
+  uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@3741b56ceab4a68ba4c09fe7e91e804b53ff2412 # v1.10.0
   with:
     lock-name: wallstop-organization-builds
     runner-id: ${{ runner.name }}

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -11,63 +11,35 @@ const WORKFLOW_DIR = path.join(REPO_ROOT, ".github", "workflows");
 const LOCK_ACTION_PREFIX =
   "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/";
 
-// Build-lock pins are bumped by Dependabot. Hardcoding the SHA here made every
-// dependency bump fail this suite (and, through the devcontainer smoke job that
-// runs `npm test`, a second required check) for a reason unrelated to the change
-// under review. The invariant that actually matters is not a literal value: each
-// action group must stay immutably pinned and internally consistent across every
-// file that references it, so a bump either lands everywhere or fails loudly.
-// `.github/actions/**` is included because the cleanup-policy group reaches into
-// composite actions there; see .github/dependabot.yml for how those get bumped.
-const ACTION_HOST_FILES = [
-  WORKFLOW_DIR,
-  path.join(REPO_ROOT, ".github", "actions")
-].flatMap((root) => walkFiles(root, { match: (file) => /\.ya?ml$/.test(file) }));
-
+// Build-lock pins are bumped by Dependabot, so they are derived here rather than
+// written as literals: a hardcoded SHA failed this suite (and the devcontainer
+// smoke job that runs `npm test`) on every dependency bump, for a reason
+// unrelated to the change under review. What must hold is that each action group
+// stays immutably pinned and identical in every file that references it, so a
+// bump either lands everywhere or fails loudly. `.github/actions/**` counts too:
+// the cleanup-policy group reaches into a composite action there, which is why
+// .github/dependabot.yml lists that directory.
+// prettier-ignore
 function resolveLockActionPin(actionNames) {
-  const shas = new Map();
-  const comments = new Set();
-  for (const filePath of ACTION_HOST_FILES) {
+  const shas = new Map(); const comments = new Set(); const label = actionNames.join(", ");
+  for (const filePath of [WORKFLOW_DIR, path.join(REPO_ROOT, ".github", "actions")].flatMap((root) => walkFiles(root, { match: (file) => /\.ya?ml$/.test(file) }))) {
     const source = fs.readFileSync(filePath, "utf8");
     for (const name of actionNames) {
-      const pattern = new RegExp(
-        `${escapeRegExp(LOCK_ACTION_PREFIX + name)}@([0-9a-f]{40})([^\\S\\n]+#[^\\n]*)?`,
-        "g"
-      );
-      for (const match of source.matchAll(pattern)) {
-        const where = `${path.relative(REPO_ROOT, filePath)}:${name}`;
-        shas.set(match[1], [...(shas.get(match[1]) || []), where]);
-        const comment = (match[2] || "").trimEnd();
-        if (comment !== "") {
-          comments.add(comment);
-        }
+      for (const match of source.matchAll(new RegExp(`${escapeRegExp(LOCK_ACTION_PREFIX + name)}@([0-9a-f]{40})([^\\S\\n]+#[^\\n]*)?`, "g"))) {
+        shas.set(match[1], [...(shas.get(match[1]) || []), `${path.relative(REPO_ROOT, filePath)}:${name}`]);
+        if ((match[2] || "").trim() !== "") comments.add(match[2].trimEnd());
       }
     }
   }
-  assert.ok(shas.size > 0, `${actionNames.join(", ")} must be referenced somewhere under .github`);
-  assert.equal(
-    shas.size,
-    1,
-    `${actionNames.join(", ")} must share one SHA; found ${JSON.stringify([...shas])}`
-  );
-  // A version comment is optional, but the group must not disagree about it.
-  assert.ok(comments.size <= 1, `${actionNames.join(", ")} version comments disagree`);
+  assert.equal(shas.size, 1, `${label} must share one SHA; found ${JSON.stringify([...shas])}`);
+  assert.ok(comments.size <= 1, `${label} version comments disagree: ${[...comments]}`);
   return { sha: [...shas.keys()][0], comment: [...comments][0] || "" };
 }
 
-// Acquire, preflight, and the PR-head guard ship together in the build-lock
-// release; release/require-confirmed/classify carry the centralized Unity
-// cleanup policy and are pinned as their own group.
-const LOCK_ACTION_PIN = resolveLockActionPin([
-  "check-unity-runner-availability",
-  "acquire-build-lock",
-  "require-current-pr-head"
-]);
-const CLEANUP_POLICY_PIN = resolveLockActionPin([
-  "release-build-lock",
-  "require-confirmed-unity-cleanup",
-  "classify-unity-cleanup-evidence"
-]);
+// Acquire, preflight, and the PR-head guard ship in the build-lock release;
+// release/require-confirmed/classify carry the centralized Unity cleanup policy.
+// prettier-ignore
+const [LOCK_ACTION_PIN, CLEANUP_POLICY_PIN] = [["check-unity-runner-availability", "acquire-build-lock", "require-current-pr-head"], ["release-build-lock", "require-confirmed-unity-cleanup", "classify-unity-cleanup-evidence"]].map((group) => resolveLockActionPin(group));
 const LOCK_ACTION_SHA = LOCK_ACTION_PIN.sha;
 const ACQUIRE_ACTION_SHA = LOCK_ACTION_PIN.sha;
 const CLEANUP_POLICY_SHA = CLEANUP_POLICY_PIN.sha;
@@ -224,7 +196,10 @@ test("script-test path detector covers .llm harness inputs and its generated ind
   const scriptsPattern = new RegExp(extractShellPatternVariable(source, "scripts_pattern"));
 
   assert.match(".llm/index.md", scriptsPattern);
-  assert.match(".llm/skills/github-workflow-consistency/references/workflow-consistency.md", scriptsPattern);
+  assert.match(
+    ".llm/skills/github-workflow-consistency/references/workflow-consistency.md",
+    scriptsPattern
+  );
   assert.match("scripts/llm/harness.js", scriptsPattern);
 });
 
@@ -235,7 +210,10 @@ test("script-test path detector covers package-script contract reference surface
   assert.match(".github/ISSUE_TEMPLATE/bug_report.yml", scriptsPattern);
   assert.match("docs/ops/release-operations.md", scriptsPattern);
   assert.match(".llm/context.md", scriptsPattern);
-  assert.match(".llm/skills/package-publishing/references/unity-analyzer-shipping.md", scriptsPattern);
+  assert.match(
+    ".llm/skills/package-publishing/references/unity-analyzer-shipping.md",
+    scriptsPattern
+  );
 });
 
 test("static child jobs always report and fail closed on bad change detection", () => {

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -8,11 +8,69 @@ const { walkFiles } = require("../lib/repo-files.js");
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const WORKFLOW_DIR = path.join(REPO_ROOT, ".github", "workflows");
-const LOCK_ACTION_SHA = "a00614ace745152a659c5c2654f7cefb68a5a628";
-const ACQUIRE_ACTION_SHA = "a00614ace745152a659c5c2654f7cefb68a5a628";
-const CLEANUP_POLICY_SHA = "673eb65e7d863a1a8a8a70882bd980e189d41754";
 const LOCK_ACTION_PREFIX =
   "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/";
+
+// Build-lock pins are bumped by Dependabot. Hardcoding the SHA here made every
+// dependency bump fail this suite (and, through the devcontainer smoke job that
+// runs `npm test`, a second required check) for a reason unrelated to the change
+// under review. The invariant that actually matters is not a literal value: each
+// action group must stay immutably pinned and internally consistent across every
+// file that references it, so a bump either lands everywhere or fails loudly.
+// `.github/actions/**` is included because the cleanup-policy group reaches into
+// composite actions there; see .github/dependabot.yml for how those get bumped.
+const ACTION_HOST_FILES = [
+  WORKFLOW_DIR,
+  path.join(REPO_ROOT, ".github", "actions")
+].flatMap((root) => walkFiles(root, { match: (file) => /\.ya?ml$/.test(file) }));
+
+function resolveLockActionPin(actionNames) {
+  const shas = new Map();
+  const comments = new Set();
+  for (const filePath of ACTION_HOST_FILES) {
+    const source = fs.readFileSync(filePath, "utf8");
+    for (const name of actionNames) {
+      const pattern = new RegExp(
+        `${escapeRegExp(LOCK_ACTION_PREFIX + name)}@([0-9a-f]{40})([^\\S\\n]+#[^\\n]*)?`,
+        "g"
+      );
+      for (const match of source.matchAll(pattern)) {
+        const where = `${path.relative(REPO_ROOT, filePath)}:${name}`;
+        shas.set(match[1], [...(shas.get(match[1]) || []), where]);
+        const comment = (match[2] || "").trimEnd();
+        if (comment !== "") {
+          comments.add(comment);
+        }
+      }
+    }
+  }
+  assert.ok(shas.size > 0, `${actionNames.join(", ")} must be referenced somewhere under .github`);
+  assert.equal(
+    shas.size,
+    1,
+    `${actionNames.join(", ")} must share one SHA; found ${JSON.stringify([...shas])}`
+  );
+  // A version comment is optional, but the group must not disagree about it.
+  assert.ok(comments.size <= 1, `${actionNames.join(", ")} version comments disagree`);
+  return { sha: [...shas.keys()][0], comment: [...comments][0] || "" };
+}
+
+// Acquire, preflight, and the PR-head guard ship together in the build-lock
+// release; release/require-confirmed/classify carry the centralized Unity
+// cleanup policy and are pinned as their own group.
+const LOCK_ACTION_PIN = resolveLockActionPin([
+  "check-unity-runner-availability",
+  "acquire-build-lock",
+  "require-current-pr-head"
+]);
+const CLEANUP_POLICY_PIN = resolveLockActionPin([
+  "release-build-lock",
+  "require-confirmed-unity-cleanup",
+  "classify-unity-cleanup-evidence"
+]);
+const LOCK_ACTION_SHA = LOCK_ACTION_PIN.sha;
+const ACQUIRE_ACTION_SHA = LOCK_ACTION_PIN.sha;
+const CLEANUP_POLICY_SHA = CLEANUP_POLICY_PIN.sha;
 const UNITY_LOCK_WINDOWS = [
   ["unity-tests.yml", "unity-tests", "Run Unity Test Runner", true],
   ["unity-gameci-experiment.yml", "game-ci-experiment", "Run GameCI normal project mode", true],
@@ -273,7 +331,7 @@ test("copyable build-lock documentation follows the runner and App credential co
   ]) {
     const source = fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
     const acquireExample = new RegExp(
-      `uses: ${escapeRegExp(LOCK_ACTION_PREFIX)}acquire-build-lock@${ACQUIRE_ACTION_SHA} # v1.9.1[\\s\\S]*?\`\`\``
+      `uses: ${escapeRegExp(LOCK_ACTION_PREFIX)}acquire-build-lock@${ACQUIRE_ACTION_SHA}${escapeRegExp(LOCK_ACTION_PIN.comment)}[\\s\\S]*?\`\`\``
     ).exec(source);
 
     assert.ok(acquireExample, `${relativePath} must contain a copyable acquire example`);
@@ -297,10 +355,10 @@ test("copyable build-lock documentation follows the runner and App credential co
 });
 // prettier-ignore
 test("every Unity lock window releases with explicit cleanup proof", () => {
-  const acquire = `uses: ${LOCK_ACTION_PREFIX}acquire-build-lock@${ACQUIRE_ACTION_SHA} # v1.9.1`;
+  const acquire = `uses: ${LOCK_ACTION_PREFIX}acquire-build-lock@${ACQUIRE_ACTION_SHA}${LOCK_ACTION_PIN.comment}`;
   const release = `uses: ${LOCK_ACTION_PREFIX}release-build-lock@${CLEANUP_POLICY_SHA}`;
   const gate = `uses: ${LOCK_ACTION_PREFIX}require-confirmed-unity-cleanup@${CLEANUP_POLICY_SHA}`;
-  const runnerLabels = new Map([["perf-numbers.yml", '[["self-hosted","Windows","RAM-64GB","fast"]]'], ["release.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-benchmarks.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-gameci-experiment.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-tests.yml", '[["self-hosted","Windows","RAM-64GB"]]']]); const preflightAction = `${LOCK_ACTION_PREFIX}check-unity-runner-availability@${LOCK_ACTION_SHA} # v1.9.1`; const workflowSources = fs.readdirSync(WORKFLOW_DIR).filter((file) => /\.ya?ml$/.test(file)).map((file) => fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8")); for (const [file, labels] of runnerLabels) { const source = fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8"); const preflight = getJobBlock(source, "runner-preflight", file); assert.match(preflight, /\n    runs-on: ubuntu-latest\n/, file); assert.match(preflight, new RegExp(`uses: ${escapeRegExp(preflightAction)}`), file); assert.match(preflight, /reader-app-id: \$\{\{ secrets\.BUILD_LOCK_READER_APP_ID \}\}/, file); assert.match(preflight, /reader-app-private-key: \$\{\{ secrets\.BUILD_LOCK_READER_APP_PRIVATE_KEY \}\}/, file); assert.match(preflight, new RegExp(`required-label-sets: '${escapeRegExp(labels)}'`), file); assert.doesNotMatch(preflight, /RUNNER_AUDIT_PAT|Soft pass|soft-pass/i, file); }
+  const runnerLabels = new Map([["perf-numbers.yml", '[["self-hosted","Windows","RAM-64GB","fast"]]'], ["release.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-benchmarks.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-gameci-experiment.yml", '[["self-hosted","Windows","RAM-64GB"]]'], ["unity-tests.yml", '[["self-hosted","Windows","RAM-64GB"]]']]); const preflightAction = `${LOCK_ACTION_PREFIX}check-unity-runner-availability@${LOCK_ACTION_SHA}${LOCK_ACTION_PIN.comment}`; const workflowSources = fs.readdirSync(WORKFLOW_DIR).filter((file) => /\.ya?ml$/.test(file)).map((file) => fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8")); for (const [file, labels] of runnerLabels) { const source = fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8"); const preflight = getJobBlock(source, "runner-preflight", file); assert.match(preflight, /\n    runs-on: ubuntu-latest\n/, file); assert.match(preflight, new RegExp(`uses: ${escapeRegExp(preflightAction)}`), file); assert.match(preflight, /reader-app-id: \$\{\{ secrets\.BUILD_LOCK_READER_APP_ID \}\}/, file); assert.match(preflight, /reader-app-private-key: \$\{\{ secrets\.BUILD_LOCK_READER_APP_PRIVATE_KEY \}\}/, file); assert.match(preflight, new RegExp(`required-label-sets: '${escapeRegExp(labels)}'`), file); assert.doesNotMatch(preflight, /RUNNER_AUDIT_PAT|Soft pass|soft-pass/i, file); }
   assert.equal(workflowSources.reduce((count, source) => count + source.split(acquire).length - 1, 0), UNITY_LOCK_WINDOWS.length);
   assert.equal(workflowSources.reduce((count, source) => count + source.split(release).length - 1, 0), UNITY_LOCK_WINDOWS.length);
   for (const [file, jobId, licensedWorkName, emptyAware] of UNITY_LOCK_WINDOWS) {

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -11,14 +11,7 @@ from pathlib import Path
 
 
 WORKFLOW = Path(".github/workflows/unity-tests.yml")
-CURRENT_PR_HEAD_GUARD = (
-    "Ambiguous-Interactive/ambiguous-organization-build-lock/"
-    ".github/actions/require-current-pr-head@a00614ace745152a659c5c2654f7cefb68a5a628"
-)
-ACQUIRE_BUILD_LOCK = (
-    "Ambiguous-Interactive/ambiguous-organization-build-lock/"
-    ".github/actions/acquire-build-lock@a00614ace745152a659c5c2654f7cefb68a5a628"
-)
+LOCK_ACTION_PREFIX = "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/"
 REGISTERED_UNITY_AUTOMATION = {
     ".github/actions/return-unity-license/action.yml",
     ".github/actions/validate-unity-license/action.yml",
@@ -34,8 +27,14 @@ UNITY_CREDENTIAL_OR_ACTIVATION = re.compile(
     re.IGNORECASE,
 )
 SAME_REPOSITORY_PR_GUARD = re.compile(
-    r"github\.event_name\s*!=\s*'pull_request'\s*\|\|\s*"
+    r"github\.event_name\s*!=\s*'pull_request'\s*\|\|\s*\(?\s*"
     r"github\.event\.pull_request\.head\.repo\.full_name\s*==\s*github\.repository"
+)
+# Dependabot jobs read from the separate Dependabot secret store, so the
+# organization Unity serial and build-lock App secrets resolve empty there. The
+# licensed jobs must exclude Dependabot the same way they exclude forks.
+DEPENDABOT_PR_GUARD = re.compile(
+    r"github\.event\.pull_request\.user\.login\s*!=\s*'dependabot\[bot\]'"
 )
 BLANKET_PR_REJECTION = re.compile(
     r"github\.event_name\s*!=\s*'pull_request'\s*&&"
@@ -45,6 +44,44 @@ BLANKET_PR_REJECTION = re.compile(
 def require(condition: bool, message: str) -> None:
     if not condition:
         raise AssertionError(message)
+
+
+def resolve_action_use(action: str) -> str:
+    """Return the one `<action>@<sha> # <version>` reference the workflow uses.
+
+    The SHA is derived from the pristine workflow rather than written here.
+    Dependabot bumps these pins, and a literal turned every dependency update
+    into a policy failure unrelated to the change under review. What the policy
+    needs is that the pin is immutable and identical at every call site, which
+    is what this resolves and asserts.
+    """
+    source = WORKFLOW.read_text(encoding="utf-8")
+    uses = {
+        match.group(1).rstrip()
+        for match in re.finditer(
+            rf"uses: ({re.escape(LOCK_ACTION_PREFIX + action)}@[0-9a-f]{{40}}(?:[ \t]+#[^\n]*)?)",
+            source,
+        )
+    }
+    require(
+        len(uses) == 1,
+        f"{action}: pin must be immutable and identical everywhere; found {sorted(uses)}",
+    )
+    return uses.pop()
+
+
+def mutate_pin_sha(use: str) -> str:
+    """Flip one SHA character so a pinned reference stops matching the policy."""
+    match = re.search(r"@([0-9a-f]{40})", use)
+    require(match is not None, "pinned reference must carry a 40-character SHA")
+    assert match is not None
+    sha = match.group(1)
+    flipped = sha[:-1] + ("0" if sha[-1] != "0" else "1")
+    return use[: match.start(1)] + flipped + use[match.end(1) :]
+
+
+CURRENT_PR_HEAD_GUARD = resolve_action_use("require-current-pr-head")
+ACQUIRE_BUILD_LOCK = resolve_action_use("acquire-build-lock")
 
 
 def job_block(source: str, job_id: str) -> str:
@@ -89,12 +126,12 @@ def validate_licensed_workflow_policy(source: str) -> str:
     acquire = step_block(licensed, "Acquire organization Unity lock")
     require(
         re.findall(
-            rf"^        uses: {re.escape(ACQUIRE_BUILD_LOCK)} # v1\.9\.1[ \t]*$",
+            rf"^        uses: {re.escape(ACQUIRE_BUILD_LOCK)}[ \t]*$",
             acquire,
             re.MULTILINE,
         )
-        == [f"        uses: {ACQUIRE_BUILD_LOCK} # v1.9.1"],
-        "Unity acquire step must use the exact immutable v1.9.1 action pin",
+        == [f"        uses: {ACQUIRE_BUILD_LOCK}"],
+        "Unity acquire step must use the exact immutable action pin",
     )
     for key, value in (
         ("github-token", "${{ github.token }}"),
@@ -257,8 +294,8 @@ def validate() -> None:
     )
     require_policy_mutation_rejected(
         source,
-        f"        uses: {ACQUIRE_BUILD_LOCK} # v1.9.1\n",
-        f"        uses: {ACQUIRE_BUILD_LOCK[:-1]}0 # v1.9.1\n",
+        f"        uses: {ACQUIRE_BUILD_LOCK}\n",
+        f"        uses: {mutate_pin_sha(ACQUIRE_BUILD_LOCK)}\n",
         "acquire action pin",
     )
     acquire_step = step_block(licensed, "Acquire organization Unity lock")
@@ -318,6 +355,14 @@ def validate() -> None:
         "Unity job must admit same-repository PRs and reject forks",
     )
     require(
+        DEPENDABOT_PR_GUARD.search(licensed) is not None,
+        "Unity job must exclude Dependabot PRs, which cannot read the licensed secrets",
+    )
+    require(
+        DEPENDABOT_PR_GUARD.search(job_block(source, "runner-preflight")) is not None,
+        "runner preflight must exclude Dependabot PRs, which cannot read the reader App secrets",
+    )
+    require(
         BLANKET_PR_REJECTION.search(licensed) is None,
         "Unity job must not reject every pull request",
     )
@@ -358,21 +403,26 @@ def validate() -> None:
         "RUNNER_PREFLIGHT_RESULT",
         "UNITY_TESTS_RESULT",
         "FORK_PR",
+        "DEPENDABOT_PR",
         "DOCS_ONLY",
     ):
         require(re.search(rf"^          {variable}:", gate, re.MULTILINE) is not None, f"missing {variable}")
 
     script = run_script(step_block(gate, "Verify Unity CI result shape"))
+    # name, matrix-config, preflight, unity, FORK_PR, DEPENDABOT_PR, DOCS_ONLY, exit code
     cases = (
-        ("same-repository PR", "success", "success", "success", "false", "false", 0),
-        ("fork PR", "success", "skipped", "skipped", "true", "false", 0),
-        ("CI-owned docs-only PR", "success", "success", "skipped", "false", "true", 0),
-        ("same-repository PR skipped Unity", "success", "success", "skipped", "false", "false", 1),
-        ("fork unexpectedly ran Unity", "success", "skipped", "success", "true", "false", 1),
-        ("matrix config failed", "failure", "success", "success", "false", "false", 1),
+        ("same-repository PR", "success", "success", "success", "false", "false", "false", 0),
+        ("fork PR", "success", "skipped", "skipped", "true", "false", "false", 0),
+        ("Dependabot PR", "success", "skipped", "skipped", "false", "true", "false", 0),
+        ("CI-owned docs-only PR", "success", "success", "skipped", "false", "false", "true", 0),
+        ("same-repository PR skipped Unity", "success", "success", "skipped", "false", "false", "false", 1),
+        ("fork unexpectedly ran Unity", "success", "skipped", "success", "true", "false", "false", 1),
+        ("Dependabot unexpectedly ran Unity", "success", "skipped", "success", "false", "true", "false", 1),
+        ("Dependabot unexpectedly ran preflight", "success", "success", "skipped", "false", "true", "false", 1),
+        ("matrix config failed", "failure", "success", "success", "false", "false", "false", 1),
     )
     if os.name != "nt":
-        for name, matrix, preflight, unity, fork, docs_only, expected in cases:
+        for name, matrix, preflight, unity, fork, dependabot, docs_only, expected in cases:
             environment = os.environ.copy()
             environment.update(
                 {
@@ -380,6 +430,7 @@ def validate() -> None:
                     "RUNNER_PREFLIGHT_RESULT": preflight,
                     "UNITY_TESTS_RESULT": unity,
                     "FORK_PR": fork,
+                    "DEPENDABOT_PR": dependabot,
                     "DOCS_ONLY": docs_only,
                 }
             )


### PR DESCRIPTION
## Summary

Two things, both blocking work that was already queued.

1. **Every Dependabot pull request has been permanently red since 2026-07-17.** Both causes are fixed, and #292 is incorporated here with the pin split it would have introduced repaired.
1. **PLAN.md M2 ships:** a themed **Message subscriptions** section on every `MessageAwareComponent` inspector, which also adopts the `.dx-inspector` / `.dx-sub*` stylesheet surface that until now was defined in USS and referenced by no C#.

Closes #292.

## Part 1: why no dependency update could merge

### Dependabot jobs cannot read the organization secrets

#278 added a `runner-preflight` job calling `check-unity-runner-availability` with `secrets.BUILD_LOCK_READER_APP_ID`. Dependabot runs read from the separate **Dependabot** secret store (`Secret source: Dependabot` in the job log), so that secret resolves empty and the fail-closed action aborts before it checks anything:

```text
##[error]Unity runner preflight failed closed: Missing required input: reader-app-id.
```

`Unity CI Success` needs `runner-preflight`, and branch protection requires `Unity CI Success`. The licensed matrix could not have passed either -- `UNITY_SERIAL` is empty there for the same reason.

`runner-preflight` and the `unity-tests` matrix now exclude Dependabot pull requests exactly the way they already exclude forks, and the always-reporting `unity-ci-success` gate treats that as a third intentional skip shape. Dependency bumps stay validated by the full matrix on the post-merge push to master.

### Tests hardcoded the SHA that Dependabot exists to change

`scripts/__tests__/ci-aggregate-workflow.test.js` and `scripts/validate-unity-pr-policy.py` pinned the build-lock action SHA as a literal, so any bump of that action failed Script tests on all three runners plus the devcontainer smoke job that runs `npm test`. Both now derive the pin from the tree and assert what actually matters: each action group is immutably pinned and identical at every call site.

### The pin split

#292 bumped the workflow acquire/preflight refs to v1.10.0, moved release/require-confirmed to an untagged default-branch commit, and left `classify-unity-cleanup-evidence` alone -- it lives in `.github/actions/return-unity-license/action.yml`, which Dependabot's `github-actions` ecosystem does not scan under `directory: "/"`. That would have split the centralized Unity cleanup policy from #291 across two SHAs.

All six build-lock references are unified on `3741b56 # v1.10.0`; v1.10.0 has `673eb65` (the cleanup-policy commit) as an ancestor, so one pin covers the group. Its manifest changes are additive: two new `release-build-lock` outputs, and a preflight matching registered rather than only online runners. `.github/dependabot.yml` now lists the composite-action directory so the pin moves with the group.

## Part 2: the Message subscriptions section

Under the default inspector body, every `MessageAwareComponent` now lists the registrations its live `MessageRegistrationToken` holds: message type, registration kind, priority, observed call count, and a live/idle dot.

- **The dot means "subscribed on the bus," not "has traffic."** A token disabled by `OnDisable` is the most common reason a handler stops firing, and that is what it reports.
- **Unknown is not zero.** With diagnostics off a row reads `calls n/a`; `0 calls` would assert a handler never fired when nothing was recording.
- Reading the lazy `_callCounts` dictionary is gated on the token actually recording, so an open inspector never materializes it on a token whose owner never enabled diagnostics.
- Registrations change from game code with no editor event to hook, so the section polls at 500 ms while on screen and rebuilds only when a cheap revision signal moves.
- Hidden under multi-object selection, because the rows describe one component.
- Per PLAN.md DEC-5, capture and formatting live in a plain-C# state object, so most of the ten new tests need no editor panel and run version-free across the 2021.3+ matrix.

## Verification

- Unity MCP EditMode loop (Unity 6000.4.6f1): **468 passed / 0 failed** in 14.3 s.
- `npm test`: 400/400. `npm run validate:all`: clean, including the JS LOC budget.
- Both new guards proven red-green before committing: removing the Dependabot exclusion fails `validate-unity-pr-policy.py`, and splitting the cleanup-policy pin fails `ci-aggregate-workflow.test.js` with the offending files named.

## Needs a real Dependabot run to confirm

Whether the `directories` form is honored for the `github-actions` ecosystem. If it is not, the new consistency guard fails closed with a message naming the exact files, which is the safe direction.

## Superseded work dropped

`dev/wallstop/even-better-ui` (one commit, 2025-06-17, 252 commits behind) threaded an `ImmutableArray<InstanceId> relevantReceivers` through `MessageEmissionData` to join an emission to the handlers that observed it. That already shipped allocation-free as the `traceId` + `registrationHandle` pair in #261; the branch also allocated per emission and depended on `System.Collections.Immutable`, which is not part of the Unity 2021.3 floor. Recorded in PLAN.md so it is not rediscovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes to Unity CI gating and organization lock/cleanup pins affect required checks and licensed runner behavior; the editor work is additive but reads token internals for diagnostics display.
> 
> **Overview**
> Unblocks **Dependabot** the same way forks are handled: `runner-preflight` and the licensed `unity-tests` matrix skip when `dependabot[bot]` opens the PR (org Unity and build-lock secrets are not in the Dependabot store), and **Unity CI Success** treats that as a third intentional skip alongside fork and docs-only PRs. Policy tests no longer hardcode build-lock SHAs—they derive pins from the tree and assert one immutable SHA per action group.
> 
> **CI hygiene:** all `ambiguous-organization-build-lock` references move to **`3741b56` (# v1.10.0)** so acquire/preflight and release/cleanup/classify stay on one pin; **Dependabot** also scans `/.github/actions/return-unity-license` so composite `classify-unity-cleanup-evidence` bumps with workflows. Routine bumps to `actions/checkout`, `setup-node` v7, `setup-dotnet` v6, `setup-python` v7, and related actions land across workflows.
> 
> **Editor (PLAN M2):** `MessageAwareComponent` fallback inspectors gain a **Message subscriptions** UI Toolkit section (`.dx-inspector` / `.dx-sub*`) listing live `MessageRegistrationToken` rows—type, registration kind, priority, call count or `calls n/a`, and live/idle dot—with 500 ms polling and revision-based rebuilds; hidden for multi-select. Changelog and `docs/guides/inspector-overlay.md` document it; EditMode tests cover capture and rendering.
> 
> Also: `.gitignore` adds `GOAL.md`, and the Unity MCP test-loop doc warns about stale assemblies when compile fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d0da6d0d0f4e0a4ea1dd6c57d7caa63719c506b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->