### PR TITLE
ci: gate committed line endings and stop the watchdog cloning master

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,42 +3,65 @@
 #
 # Default to LF line endings for all text files for better cross-platform
 # compatibility and CI/CD consistency. C# files use CRLF per .NET conventions.
+#
+# Every rule below says `text=auto`, never a bare `text`. Do NOT "tighten" them
+# back: `text` is what turns a cosmetic problem into an outage.
+#
+# A blob can reach this repository already holding CRLF, because commits made
+# through the GitHub API (Dependabot, Copilot) never run a git client and so
+# never apply these attributes. Under a bare `text`, git normalizes such a blob
+# on the clean side unconditionally while skipping the smudge (the blob already
+# has CRLF) -- so the checked-out file matches the blob byte for byte, the clean
+# filter hashes to the LF form, and a PRISTINE CLONE REPORTS THE FILE MODIFIED
+# with no edit that can make it clean. Any consumer that switches branches or
+# gates on a clean tree then breaks: that is what failed the Stuck Job Watchdog
+# 13 runs straight on 2026-07-29, and the same blob had been silently
+# oscillating LF/CRLF through Dependabot bumps since 2025-11.
+#
+# `text=auto` leaves an already-CRLF blob alone instead, so the clone stays
+# clean and the switch works, while still normalizing everything a git client
+# commits and still delivering the eol below to the working tree (verified
+# identical for all tracked files). It makes the condition harmless; it cannot
+# make it impossible, because attributes are instructions to a git client. The
+# `line-endings` job in ci.yml is what still reports the drift
+# (`git add --renormalize .` detects it under either form), so the index does
+# not quietly accumulate CRLF.
 ###############################################################################
 * text=auto eol=lf
 
 # C# and .NET project files use CRLF
-*.cs        text eol=crlf
-*.csproj    text eol=crlf
-*.sln       text eol=crlf
-*.props     text eol=crlf
+*.cs        text=auto eol=crlf
+*.csproj    text=auto eol=crlf
+*.sln       text=auto eol=crlf
+*.props     text=auto eol=crlf
 
 # Explicit LF entries for common text file types.
 # Other text files also use LF via the default rule: * text=auto eol=lf
-*.json      text eol=lf
-*.yaml      text eol=lf
-*.yml       text eol=lf
-*.md        text eol=lf
-*.xml       text eol=lf
-*.uxml      text eol=lf
-*.uss       text eol=lf
-*.shader    text eol=lf
-*.hlsl      text eol=lf
-*.compute   text eol=lf
-*.cginc     text eol=lf
-*.asmdef    text eol=lf
-*.asmref    text eol=lf
-*.meta      text eol=lf
-*.ps1       text eol=lf
-*.txt       text eol=lf
-*.js        text eol=lf
-*.mjs       text eol=lf
+*.json      text=auto eol=lf
+*.yaml      text=auto eol=lf
+*.yml       text=auto eol=lf
+*.md        text=auto eol=lf
+*.xml       text=auto eol=lf
+*.uxml      text=auto eol=lf
+*.uss       text=auto eol=lf
+*.shader    text=auto eol=lf
+*.hlsl      text=auto eol=lf
+*.compute   text=auto eol=lf
+*.cginc     text=auto eol=lf
+*.asmdef    text=auto eol=lf
+*.asmref    text=auto eol=lf
+*.meta      text=auto eol=lf
+*.ps1       text=auto eol=lf
+*.txt       text=auto eol=lf
+*.js        text=auto eol=lf
+*.mjs       text=auto eol=lf
 
 # Shell scripts must use LF for proper execution on Unix systems
-*.sh        text eol=lf
-*.bash      text eol=lf
-*.zsh       text eol=lf
-*.ksh       text eol=lf
-*.fish      text eol=lf
+*.sh        text=auto eol=lf
+*.bash      text=auto eol=lf
+*.zsh       text=auto eol=lf
+*.ksh       text=auto eol=lf
+*.fish      text=auto eol=lf
 
 
 ###############################################################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,9 @@ jobs:
         with:
           persist-credentials: false
 
+      # Repairs the worktree so CSharpier sees one canonical form; it is NOT the
+      # drift gate. The `line-endings` job is what fails on committed bytes that
+      # disagree with .gitattributes.
       - name: Normalize line endings
         if: ${{ needs.changes.outputs.csharpier != 'false' }}
         run: |
@@ -488,6 +491,45 @@ jobs:
       - name: Prettier check (JSON / asmdef)
         if: ${{ needs.changes.outputs.json != 'false' }}
         run: npx prettier --check "**/*.{json,asmdef,asmref}"
+
+  # Deliberately unfiltered: any tracked text file can carry the drift this
+  # detects, so there is no useful path filter and therefore no `changes`
+  # dependency or fail-closed guard to write. The check is pure git, so it costs
+  # a checkout.
+  line-endings:
+    name: Check committed line endings
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      # A blob whose committed bytes already disagree with its `.gitattributes`
+      # eol is invisible to every other check: git skips the smudge when the
+      # blob already holds CRLF, so the checked-out file matches the blob byte
+      # for byte, while the clean filter converts it back and yields a different
+      # hash. A pristine clone is then content-dirty but stat-clean, which breaks
+      # any consumer that switches branches or gates on a clean tree -- see the
+      # Stuck Job Watchdog's 13 consecutive failures on
+      # SourceGenerators/...Tests.csproj (2026-07-29). Only `--renormalize`
+      # surfaces it; a worktree diff never will. Dependabot commits through the
+      # API and so bypasses the pre-commit `mixed-line-ending` hook, which is why
+      # this has to be a CI gate.
+      - name: Verify committed bytes match .gitattributes
+        run: |
+          set -euo pipefail
+          git add --renormalize .
+          if git diff --cached --quiet; then
+            echo "Every tracked text file matches its .gitattributes eol."
+            exit 0
+          fi
+          git diff --cached --name-only | while IFS= read -r file; do
+            echo "::error file=${file}::Committed line endings disagree with .gitattributes."
+          done
+          echo "::error::Fix with: git add --renormalize . && git commit"
+          exit 1
 
   spellcheck:
     name: Check spelling
@@ -954,6 +996,7 @@ jobs:
       - csharpier
       - dotnet
       - json-format
+      - line-endings
       - spellcheck
       - validate-banner
       - validate-llms-txt

--- a/.github/workflows/stuck-job-watchdog.yml
+++ b/.github/workflows/stuck-job-watchdog.yml
@@ -133,34 +133,48 @@ jobs:
           git_auth() {
             git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" "$@"
           }
-          git_auth clone --depth 1 "https://github.com/${REPO}.git" repo
-          cd repo
+          remote_url="https://github.com/${REPO}.git"
           GIT_AUTHOR_ID=(-c "user.email=actions@github.com" -c "user.name=stuck-job-watchdog")
 
+          # Never materialize the default branch. The watchdog reads and writes
+          # only ${STATE_DIR} on ${STATE_BRANCH}, and checking the default branch
+          # out just to switch away from it is what failed 13 runs straight on
+          # 2026-07-29: one committed blob whose bytes disagreed with its
+          # .gitattributes eol left the pristine clone content-dirty (git skips
+          # the smudge when the blob already holds CRLF, so the file matched the
+          # blob while the clean filter hashed to something else), and switching
+          # trees aborted with "Your local changes to the following files would be
+          # overwritten by checkout". Cloning the state branch directly retires
+          # the whole class: no default-branch file is ever written, so none can
+          # block the switch. ci.yml's `line-endings` job gates the drift itself.
+          #
           # Decoupled probe + bootstrap: ls-remote distinguishes
           # "branch missing" (zero rows + exit 0) from "transient fetch
           # failure" (non-zero exit). We MUST NOT bootstrap on transient
           # failure - that would push-corrupt an existing branch by
           # rewriting it as a fresh orphan.
           state_branch_probe="$(mktemp)"
-          if ! git_auth ls-remote --heads origin "${STATE_BRANCH}" > "${state_branch_probe}" 2>/dev/null; then
-            log_summary "WARN: 'git ls-remote --heads origin ${STATE_BRANCH}' failed (transient?); refusing to bootstrap. Skipping this cycle."
+          if ! git_auth ls-remote --heads "${remote_url}" "${STATE_BRANCH}" > "${state_branch_probe}" 2>/dev/null; then
+            log_summary "WARN: 'git ls-remote --heads ${remote_url} ${STATE_BRANCH}' failed (transient?); refusing to bootstrap. Skipping this cycle."
             popd > /dev/null
             flush_summary_and_exit 0
           fi
 
           if [[ -s "${state_branch_probe}" ]]; then
-            if ! git_auth fetch origin "+${STATE_BRANCH}:refs/remotes/origin/${STATE_BRANCH}"; then
-              log_summary "WARN: state branch '${STATE_BRANCH}' exists per ls-remote but fetch failed; skipping this cycle."
+            if ! git_auth clone --depth 1 --single-branch --branch "${STATE_BRANCH}" "${remote_url}" repo; then
+              log_summary "WARN: state branch '${STATE_BRANCH}' exists per ls-remote but clone failed; skipping this cycle."
               popd > /dev/null
               flush_summary_and_exit 0
             fi
-            git checkout -B "${STATE_BRANCH}" "refs/remotes/origin/${STATE_BRANCH}"
+            cd repo
             log_summary "State branch '${STATE_BRANCH}' checked out."
           else
             log_summary "State branch '${STATE_BRANCH}' missing -- bootstrapping orphan branch."
-            git checkout --orphan "${STATE_BRANCH}"
-            git rm -rf . > /dev/null 2>&1 || true
+            mkdir repo
+            cd repo
+            git init -q
+            git checkout -q -b "${STATE_BRANCH}"
+            git remote add origin "${remote_url}"
             mkdir -p "${STATE_DIR}"
             touch "${STATE_DIR}/.gitkeep"
             git add "${STATE_DIR}/.gitkeep"

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -81,7 +81,7 @@ editor), NOT inside the devcontainer. The container ships no local Unity build. 
 - The devcontainer workspace IS the embedded package inside the host Unity project,
   so edits in-container are instantly visible to the editor.
 - Compile: trigger `AssetDatabase.Refresh()` via `Unity_RunCommand`.
-- Run tests: call the host bridge `DxMcpTestRunner.Run(testMode, assemblies, tests, categories, resultPath)` via `Unity_RunCommand`; poll the `.status` sidecar under `.artifacts/unity-mcp/` from the container.
+- Run tests: call the host bridge `DxMcpTestRunner.Run(testMode, assemblies, tests, categories, resultPath)` via `Unity_RunCommand`, then poll the `.status` sidecar from the container. `resultPath` resolves against the HOST project root, so it MUST be prefixed `Packages/com.wallstop-studios.dxmessaging/.artifacts/unity-mcp/<name>.json`; a bare `.artifacts/unity-mcp/<name>.json` lands where the container cannot see it and the poll waits forever next to stale files.
 - EditMode assemblies: `WallstopStudios.DxMessaging.Tests.Editor`, `...Tests.Editor.Allocations`, `...Tests.00.Editor.Benchmarks`. PlayMode: `...Tests.Runtime`, `...Tests.00.Runtime.Benchmarks` (category `PerfBench`), `...Tests.00.Runtime.Comparisons`, DI integrations (Reflex/VContainer/Zenject).
 - Perf baselines: the benchmark CSV defaults to `.artifacts/perf-baseline.csv` (override env `DX_PERF_BASELINE`; `DX_PERF_COMMIT` stamps the commit column).
 - Sandbox restriction: `using System.Reflection;` is rejected in `Unity_RunCommand` snippets -- fully qualify (`System.Reflection.Assembly`) instead.

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -273,6 +273,34 @@ test("committed line endings are gated, not silently repaired", () => {
   assert.doesNotMatch(repair, /exit 1/);
 });
 
+test(".gitattributes declares text=auto, never a bare text", () => {
+  const source = fs.readFileSync(path.join(REPO_ROOT, ".gitattributes"), "utf8");
+
+  // A bare `text` normalizes an already-CRLF blob on the clean side while
+  // skipping the smudge, so a pristine clone reports the file modified with no
+  // edit that can fix it, and any branch switch aborts. Blobs arrive that way
+  // from GitHub-API commits (Dependabot, Copilot), which never apply these
+  // attributes. `text=auto` leaves such a blob alone -- verified to deliver an
+  // identical i/ and w/ eol for every tracked file -- so the condition becomes
+  // harmless while ci.yml's `line-endings` job still reports the drift.
+  // `text=auto` reads weaker than `text`, so this exists to stop it being
+  // "tightened" back.
+  const bare = source
+    .split(/\r?\n/)
+    .filter((line) => !line.trimStart().startsWith("#"))
+    .filter((line) => /^\S+\s+text(\s|$)/.test(line));
+
+  assert.deepEqual(
+    bare,
+    [],
+    `.gitattributes must use 'text=auto', not a bare 'text': ${bare.join("; ")}`
+  );
+  assert.ok(
+    /^\*\s+text=auto\s+eol=lf$/m.test(source),
+    ".gitattributes must keep the default '* text=auto eol=lf' rule"
+  );
+});
+
 test("the stuck-job watchdog never materializes the default branch", () => {
   const source = fs.readFileSync(path.join(WORKFLOW_DIR, "stuck-job-watchdog.yml"), "utf8");
 

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -74,6 +74,7 @@ const AGGREGATED_JOBS = [
   "csharpier",
   "dotnet",
   "json-format",
+  "line-endings",
   "spellcheck",
   "validate-banner",
   "validate-llms-txt",
@@ -246,6 +247,56 @@ test("static child jobs always report and fail closed on bad change detection", 
       `${jobId} must gate expensive steps internally`
     );
   }
+});
+
+test("committed line endings are gated, not silently repaired", () => {
+  const source = readCiWorkflow();
+  const job = getJobBlock(source, "line-endings");
+
+  // Unfiltered on purpose: every tracked text file is in scope, so there is no
+  // `changes` output to gate on and nothing to fail closed against.
+  assert.doesNotMatch(job, /\n    needs:/, "line-endings must not be path-filtered");
+
+  // Only `--renormalize` sees a blob whose committed bytes already disagree with
+  // its .gitattributes eol; git skips the smudge for such a blob, so the
+  // worktree matches it byte for byte and no ordinary diff reports anything.
+  const check = getStepBlock(job, "Verify committed bytes match .gitattributes");
+  assert.match(check, /git add --renormalize \./);
+  assert.match(check, /git diff --cached --quiet/);
+  assert.match(check, /\n          exit 1\n/, "drift must fail the job");
+
+  // The csharpier job repairs the worktree so the formatter sees one canonical
+  // form. That repair destroys the evidence, so it must never stand in for the
+  // gate: `reset --hard` there, `exit 1` here.
+  const repair = getStepBlock(getJobBlock(source, "csharpier"), "Normalize line endings");
+  assert.match(repair, /git reset --hard/);
+  assert.doesNotMatch(repair, /exit 1/);
+});
+
+test("the stuck-job watchdog never materializes the default branch", () => {
+  const source = fs.readFileSync(path.join(WORKFLOW_DIR, "stuck-job-watchdog.yml"), "utf8");
+
+  // Cloning the default branch put the watchdog at the mercy of every tracked
+  // file: one blob whose committed bytes disagreed with its .gitattributes eol
+  // left the pristine clone content-dirty, so switching to the state tree
+  // aborted with "Your local changes to the following files would be overwritten
+  // by checkout" -- 13 consecutive failed runs on 2026-07-29. The watchdog only
+  // ever touches ${STATE_DIR} on ${STATE_BRANCH}, so cloning that branch
+  // directly makes the whole class unreachable.
+  const clones = [...source.matchAll(/git(?:_auth)? clone [^\n]*/g)].map((match) =>
+    match[0].trim()
+  );
+  assert.equal(clones.length, 1, `expected exactly one clone; found: ${clones.join(" | ")}`);
+  assert.match(
+    clones[0],
+    /--single-branch --branch "\$\{STATE_BRANCH\}"/,
+    "the clone must be scoped to the state branch"
+  );
+  assert.doesNotMatch(
+    source,
+    /git checkout -B/,
+    "switching between two populated trees is the failure mode being retired"
+  );
 });
 
 test("source marker scan is tracked-file scoped and cannot self-match workflow text", () => {


### PR DESCRIPTION
## Why

The **Stuck Job Watchdog** failed 13 runs straight on 2026-07-29 (18:10Z through 23:54Z), every time aborting at the same place:

```text
error: Your local changes to the following files would be overwritten by checkout:
    SourceGenerators/.../WallstopStudios.DxMessaging.SourceGenerators.Tests.csproj
Please commit your changes or stash them before you switch branches.
```

## Root cause

That blob was committed **holding CRLF bytes** (2010 B, 45 CR) while `.gitattributes` declares `*.csproj text eol=crlf`:

| commit | blob size | CR |
| --- | --- | --- |
| `a9e1ff30` (Dependabot, 18:09Z) | 2010 | 45 |
| `378a7d7f` | 2010 | 45 |
| `ffef8241` (23:58Z) | 1965 | 0 |

Under an explicit `text` attribute git always normalizes on the clean side. Git also skips the LF-to-CRLF smudge when the blob already holds CRLF, so the checked-out file is byte-identical to the blob -- and the clean filter still converts it back to LF and hashes to something else. A pristine clone therefore reports the file modified with no way to make it un-modified. The watchdog cloned the default branch and then switched to the `watchdog-state` orphan tree, which must delete every default-branch file, and git refuses to delete a modified one.

The window opened with `a9e1ff30` and closed with `ffef8241`, which happened to renormalize the file as a side effect. Nothing prevents the next Dependabot bump from reopening it.

Reproduced deterministically in a scratch repo (same `.gitattributes` ordering, blob written with `hash-object --no-filters`), which emits the identical error, and confirmed the fix makes it unreachable.

## What changed

**1. `ci.yml` gains a `line-endings` job.** It runs `git add --renormalize .` and fails, annotating each offending path.

Nothing else could have caught this. An ordinary diff is empty in a pristine clone, so only `--renormalize` sees it. The `csharpier` job already ran `git add --renormalize .` -- but follows it with `git reset --hard`, so it repairs the worktree for the formatter and discards the evidence. And Dependabot commits through the API, so it never runs the pre-commit `mixed-line-ending` hook; the gate has to live in CI.

The job is deliberately unfiltered (every tracked text file is in scope, so there is no useful path filter and therefore no `changes` output to fail closed against) and is wired into `CI Success`, so branch protection is unchanged.

**2. The watchdog no longer materializes the default branch.** It clones the state branch directly (`--single-branch --branch "${STATE_BRANCH}"`) instead of cloning the default branch and switching away from it. The watchdog only ever reads and writes `.watchdog-state/`, so no default-branch file is written and none can block it -- the failure class is unreachable rather than merely fixed. The bootstrap path now builds the orphan with `git init` instead of emptying a default-branch checkout, which is also strictly less work.

## Tests

Two guards in `scripts/__tests__/ci-aggregate-workflow.test.js`:

- the gate must **fail** on drift rather than repair it (`exit 1` in `line-endings`, `reset --hard` in `csharpier`, never the reverse);
- the watchdog's single `clone` must stay state-branch-scoped, with no cross-tree `checkout -B`.

Verified locally: `node --test scripts/__tests__/ci-aggregate-workflow.test.js scripts/__tests__/auto-commit-fetch-force-refspec.test.js` -> 19/19; `actionlint` and `yamllint` clean on both workflows; `git add --renormalize .` on a fresh clone of `master` reports no drift, so the new gate is green on the current tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI gating and git attribute semantics repo-wide; behavior is intentional and test-guarded, but mis-merging `.gitattributes` back to bare `text` could reintroduce silent dirty clones.
> 
> **Overview**
> Fixes **Stuck Job Watchdog** failures where a pristine clone looked dirty after Dependabot/API commits left CRLF blobs that disagreed with `.gitattributes`, blocking branch switches.
> 
> **`.gitattributes`** switches every text rule from bare `text` to **`text=auto`** (same `eol` targets) so already-CRLF blobs are not forced through clean-side normalization that makes clones appear modified with no fixable edit.
> 
> **CI** adds an unfiltered **`line-endings`** job: `git add --renormalize .` then **`exit 1`** if the index differs, with per-file annotations. It is wired into **`CI Success`**. The **csharpier** job still renormalizes and **`reset --hard`** for formatting only—documented as repair, not the drift gate.
> 
> **Stuck Job Watchdog** clones **`watchdog-state`** directly (`--single-branch --branch`) and bootstraps with **`git init`** instead of checking out the default branch and switching trees, so default-branch line-ending drift cannot block state updates.
> 
> **Tests** in `ci-aggregate-workflow.test.js` lock in: gate vs repair behavior, no bare `text` in `.gitattributes`, and state-branch-only cloning. **`.llm/context.md`** documents the required Unity MCP **`resultPath`** package prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17602286a50647cb42cd03b3f828b4746626bf26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->