### PR TITLE
test(editor): reject imported branding prototypes

### DIFF
--- a/Tests/Editor/DxMessagingEditorThemeTests.cs
+++ b/Tests/Editor/DxMessagingEditorThemeTests.cs
@@ -156,6 +156,52 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
+        public void BrandingPrototypeAssemblyAndWindowsAreNotLoaded()
+        {
+            const string brandingAssemblyName = "WallstopStudios.DxMessaging.Editor.Branding";
+            const string brandingNamespacePrefix = "WallstopStudios.DxMessaging.Editor.Branding.";
+            List<string> loadedPrototypeArtifacts = new();
+
+            foreach (System.Reflection.Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (
+                    string.Equals(
+                        assembly.GetName().Name,
+                        brandingAssemblyName,
+                        StringComparison.Ordinal
+                    )
+                )
+                {
+                    loadedPrototypeArtifacts.Add("assembly: " + assembly.FullName);
+                }
+            }
+
+            foreach (Type windowType in TypeCache.GetTypesDerivedFrom<EditorWindow>())
+            {
+                if (
+                    windowType.FullName != null
+                    && windowType.FullName.StartsWith(
+                        brandingNamespacePrefix,
+                        StringComparison.Ordinal
+                    )
+                )
+                {
+                    loadedPrototypeArtifacts.Add("window: " + windowType.AssemblyQualifiedName);
+                }
+            }
+
+            Assert.That(
+                loadedPrototypeArtifacts,
+                Is.Empty,
+                "The design-system branding prototype is imported into the host project. "
+                    + "Remove its design-system/production/unity-package content so only the "
+                    + "canonical Tools/Wallstop Studios/DxMessaging windows remain. Loaded "
+                    + "prototype artifacts: "
+                    + string.Join(", ", loadedPrototypeArtifacts)
+            );
+        }
+
+        [Test]
         public void CreateEmptyStateBuildsContainerWithTitleAndBody()
         {
             VisualElement empty = DxMessagingEditorTheme.CreateEmptyState(

--- a/docs/guides/mcp-local-setup.md
+++ b/docs/guides/mcp-local-setup.md
@@ -60,6 +60,21 @@ Windows paths need no special quoting, and a quoted one may end in a backslash
 (`UNITY_PROJECT_PATH="D:\Program Files\Proj\"`). A line these commands cannot parse is warned about
 and skipped, so unrelated entries in a shared `.env.local` cannot break them.
 
+## Troubleshooting
+
+### Repeating audio lock assertion
+
+Close the Unity Editor if its Console continually prints
+`Access version should be odd when acquiring lock`. Unity tracks that assertion as
+[UUM-146734](https://issuetracker.unity.com/issues/23329/crash-on-assertimplementation-when-audio-dual-thread-lock-version-is-even-on-acquire)
+in `audio::DualThreadManager::ControlUpdate` and reports that the loop can exhaust editor memory.
+The native assertion is distinct from the MCP probe's endpoint and bearer-token diagnoses. MCP
+activity may still trigger the Unity defect.
+
+Reopen Unity on the latest available patch and follow the Unity issue for fixed-version status. Run
+`npm run unity:mcp:probe` separately after the editor restarts; its `unreachable`, `unauthorized`,
+`http-error`, or `malformed` result identifies an actual bridge connection failure.
+
 ## Notes
 
 - The host and the container must present the same `UNITY_MCP_BEARER_TOKEN`. When they do not share

--- a/progress/session-176-host-prototype-guard-and-unity-audio-rca.md
+++ b/progress/session-176-host-prototype-guard-and-unity-audio-rca.md
@@ -75,8 +75,13 @@ exhausts memory.
   and all nine legs of
   [Unity run 30516059562](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/30516059562)
   successfully.
+- Evidence head `21f01257` independently completed static
+  [CI run 30517212605](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/30517212605)
+  and all nine legs of
+  [Unity run 30517212555](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/30517212555)
+  successfully.
 - Two independent adversarial review passes reached zero remaining findings.
   The final review request also triggered Cursor, Copilot, and the only
-  repository collaborator. Copilot produced no review because its workflow
-  reported an exhausted monthly quota; no actionable GitHub review feedback
-  was outstanding when this evidence update was prepared.
+  repository collaborator. Two Copilot attempts produced no review because both
+  workflows reported an exhausted monthly quota; no actionable GitHub review
+  feedback was outstanding when this evidence update was prepared.

--- a/progress/session-176-host-prototype-guard-and-unity-audio-rca.md
+++ b/progress/session-176-host-prototype-guard-and-unity-audio-rca.md
@@ -1,0 +1,74 @@
+# Session 176 -- host prototype guard and Unity audio RCA
+
+Date: 2026-07-30
+Branch: `dev/wallstop/session-176-plan-ws3-guard`
+PR: pending
+Issues: **#308**, **#314**
+
+## Outcome
+
+Closed PLAN.md WS-3 in the configured host project and converted the cleanup into
+a portable EditMode invariant. The ignored design-system prototype was still
+compiled into the host and registered these duplicate menus:
+
+- `Window/DxMessaging/Message Flow`
+- `Window/DxMessaging/Message Monitor %&m`
+
+The canonical windows remained under `Tools/Wallstop Studios/DxMessaging/`.
+Removing `design-system/production/unity-package` from the host removed both
+prototype entries. `BrandingPrototypeAssemblyAndWindowsAreNotLoaded` rejects the
+branding assembly and every `EditorWindow` in its namespace if another test host
+imports them.
+
+The red-green fixture recorded 14 passes and one expected failure before cleanup,
+then 15 passes and zero failures after cleanup. The namespace check covers
+renamed or additional prototype windows. A live menu refresh now reports one
+Flow and one Monitor entry, both canonical.
+
+## Unity audio assertion
+
+Issue #308 reports a continual
+`Access version should be odd when acquiring lock` loop after MCP activity.
+Unity's UUM-146734 tracker maps that exact assertion to
+`audio::DualThreadManager::ControlUpdate` and reports that the loop can continue
+until the Editor exhausts memory. This identifies the native failure but does not
+rule out MCP activity as a trigger.
+
+The current Unity 6000.4.6f1 host completed MCP discovery, editor-state queries,
+console reads, menu refreshes, dynamic commands, assembly reloads, and both
+focused test runs without reproducing the assertion. The MCP setup guide now
+distinguishes this upstream audio failure from the probe's connection
+classifications and tells users to close the Editor before the assertion loop
+exhausts memory.
+
+## Repository and GitHub audit
+
+- No open, draft, or Dependabot pull requests needed carry-forward work.
+- No open Dependabot security alert was waiting.
+- Existing local branches and worktrees map to merged or superseded work.
+- Master static CI was green at `9b61a612`; its Unity and performance workflows
+  were still running when this session began.
+- Eleven issues remain open after creating #314. #308 was the only concrete
+  user-facing bug; #296 and
+  #297 are the next editor diagnostics improvements. #276 remains an
+  underspecified runtime exploration rather than an implementable requirement.
+- Opened #314 with acceptance criteria for PLAN.md WS-7.3's safe EditorWindow
+  capture and draft screenshot replacement.
+
+## Verification
+
+- Unity MCP endpoint handshake: reachable and authenticated.
+- Focused EditMode red run: **14 passed / 1 failed** (the new guard).
+- Focused EditMode green run: **15 passed / 0 failed**.
+- Full EditMode run across the editor, allocation, and benchmark assemblies:
+  **796 passed / 0 failed / 26 skipped** in 341.2 seconds after the final review
+  fixes.
+- Live menu inventory: one canonical Flow entry and one canonical Monitor entry.
+- Script tests: **404 passed / 0 failed**.
+- `format:check`, Markdown lint, spelling, `validate:all`, and `git diff --check`
+  passed.
+- Master commit `9b61a612` completed all nine Unity matrix legs and Performance
+  Numbers successfully. The follow-up generated performance-doc commit
+  `b4711189` completed its static CI and documentation workflows successfully.
+
+PR review and branch CI results will be added before the session closes.

--- a/progress/session-176-host-prototype-guard-and-unity-audio-rca.md
+++ b/progress/session-176-host-prototype-guard-and-unity-audio-rca.md
@@ -70,5 +70,13 @@ exhausts memory.
 - Master commit `9b61a612` completed all nine Unity matrix legs and Performance
   Numbers successfully. The follow-up generated performance-doc commit
   `b4711189` completed its static CI and documentation workflows successfully.
-
-PR review and branch CI results will be added before the session closes.
+- PR head `0babb1a5` completed static
+  [CI run 30516059468](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/30516059468)
+  and all nine legs of
+  [Unity run 30516059562](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/30516059562)
+  successfully.
+- Two independent adversarial review passes reached zero remaining findings.
+  The final review request also triggered Cursor, Copilot, and the only
+  repository collaborator. Copilot produced no review because its workflow
+  reported an exhausted monthly quota; no actionable GitHub review feedback
+  was outstanding when this evidence update was prepared.

--- a/progress/session-176-host-prototype-guard-and-unity-audio-rca.md
+++ b/progress/session-176-host-prototype-guard-and-unity-audio-rca.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-30
 Branch: `dev/wallstop/session-176-plan-ws3-guard`
-PR: pending
+PR: **#315**
 Issues: **#308**, **#314**
 
 ## Outcome

--- a/progress/session-176-host-prototype-guard-and-unity-audio-rca.md.meta
+++ b/progress/session-176-host-prototype-guard-and-unity-audio-rca.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 078f09a1de1a49e583fcdd118da6e952
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

- reject the discarded design-system branding assembly and every `EditorWindow` in its namespace from Unity test hosts
- remove the prototype package content from the configured host and verify only the canonical DxMessaging menus remain
- document Unity's UUM-146734 native audio-lock assertion separately from MCP endpoint/auth probe failures
- record the session's GitHub/branch audit, red-green evidence, full verification, and WS-7.3 follow-up issue #314

## Why

The configured host still compiled the ignored `design-system/production/unity-package` prototype. Unity therefore registered duplicate `Window/DxMessaging/*` menus alongside the canonical `Tools/Wallstop Studios/DxMessaging/*` tools. Git ignored the source, so the repository was clean while the editor surface was wrong.

Issue #308 also reports the repeating `Access version should be odd when acquiring lock` assertion after MCP activity. Unity tracks that native assertion as UUM-146734 in `audio::DualThreadManager::ControlUpdate` and warns it can loop until editor memory is exhausted. The guide now explains that this native failure is distinct from the bridge probe's classified connection errors without ruling out MCP activity as a trigger.

## Red-green evidence

- before host cleanup: theme fixture **14 passed / 1 failed** on the new prototype guard
- after cleanup: theme fixture **15 passed / 0 failed**
- final live menu inventory: one canonical Flow Graph and one canonical Message Monitor; no `Window/DxMessaging/*` entries
- final full EditMode assemblies: **796 passed / 0 failed / 26 skipped** in 341.2 seconds

## Validation

- `npm test`: **404 passed / 0 failed**
- `npm run format:check`
- `npm run lint:markdown`
- `npm run check:spelling`
- `npm run validate:all`
- targeted `lychee --config .lychee.toml docs/guides/mcp-local-setup.md`
- `git diff --check`
- two adversarial sub-agent passes; final review reported zero remaining issues

Addresses #308. Follow-up screenshot capture work is tracked in #314.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation changes only; no runtime, auth, or data-handling logic modified in shipped editor code within this diff.
> 
> **Overview**
> Adds an EditMode guard **`BrandingPrototypeAssemblyAndWindowsAreNotLoaded`** so test hosts must not load the discarded `WallstopStudios.DxMessaging.Editor.Branding` assembly or any `EditorWindow` in that namespace—preventing duplicate `Window/DxMessaging/*` menus when the design-system prototype is still imported alongside canonical **`Tools/Wallstop Studios/DxMessaging/*`** tools.
> 
> The MCP local setup guide adds a **Troubleshooting** section for Unity’s repeating `Access version should be odd when acquiring lock` assertion ([UUM-146734](https://issuetracker.unity.com/issues/23329/crash-on-assertimplementation-when-audio-dual-thread-lock-version-is-even-on-acquire)), clarifying it is a native audio defect (not the same as probe `unreachable`/`unauthorized` results) and that MCP activity may still trigger it.
> 
> Session progress notes record red/green evidence for the guard, host cleanup outcome, and follow-up issue **#314**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9337cefcc5b3a557e3a6c940ad520eb2706514fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->