### PR TITLE
docs(ci): record live aggregate ruleset

### DIFF
--- a/docs/runbooks/required-checks.md
+++ b/docs/runbooks/required-checks.md
@@ -25,23 +25,17 @@ non-matching pull requests and cannot be required as written.
 
 ## Current state
 
-Auto-merge is enabled. The full CI gate is **applied and live (2026-06-16)**:
-repository ruleset `Required CI - Unity Tests (default branch)` (id `17663217`,
-active, `~DEFAULT_BRANCH`) now requires **15 contexts**: the `Unity CI Success`
-aggregate plus the 14 remediated static/correctness gates from
-[Augmenting the gate](#augmenting-the-gate-done-2026-06-15). The
-`bot-auto-commit` App (id `3977200`) stays in `bypass_actors` (mode `always`) so
-the perf-doc auto-commit still pushes to `master`. The remediation merged via
-PR #232 (`c42f8a4`); all 14 static contexts were verified
-present-and-reporting on a real PR (#232) before the augment.
+Auto-merge is enabled. The aggregate CI gate is **applied and live
+(2026-07-30)**: repository ruleset `Required CI - Unity Tests (default branch)`
+(id `17663217`, active, `~DEFAULT_BRANCH`) requires exactly `CI Success` and
+`Unity CI Success`. PR #316 verified both aggregates before merge, and the
+`CI Success` aggregate also reported on the default branch after merge. The 14
+individual static contexts remain dependencies of `CI Success`, but the
+ruleset does not require their literal names.
 
-> **Aggregate follow-up implemented in branch, not yet live in the ruleset.**
-> `.github/workflows/ci.yml` consolidates the 14 static contexts into one
-> `CI Success` alls-green gate (`re-actors/alls-green`). Unity is already
-> represented by `Unity CI Success`. After this workflow lands on `master` and
-> `CI Success` is verified on real PRs, switch ruleset `17663217` from the
-> interim 15-context set to the two aggregate contexts: `CI Success` and
-> `Unity CI Success`.
+The `bot-auto-commit` App (id `3977200`) stays in `bypass_actors` (mode
+`always`) so the perf-doc and generated-doc auto-commits can still push to
+`master`.
 
 ## Aggregate Gates
 
@@ -108,11 +102,11 @@ a matrix before expansion, GitHub can report only one skipped check with the
 literal name `Unity ${{ matrix.unity-version }} ${{ matrix.test-mode }}`, so
 requiring the expanded names leaves auto-merge waiting for absent checks.
 
-## Interim Live Static Contexts
+## Retired Individual Static Contexts
 
-Until `CI Success` lands on `master` and is verified on real PRs, ruleset
-`17663217` still requires the 14 legacy static contexts individually. They are
-listed here so operators can audit or roll back the migration if needed.
+Before the aggregate switch, ruleset `17663217` required these 14 static
+contexts individually. Keep this list as migration history and for aggregate
+dependency audits; do not add these names back to the ruleset.
 
 ```text
 Lint repository Markdown
@@ -299,9 +293,9 @@ The path-filtered gates listed above were remediated to the always-report patter
 (each gained a `changes` job that lists the PR's files via `gh api` -- failing
 safe to "run" if that call errors -- and each required gate fails closed if
 change detection itself fails or emits no valid output). The remediation merged
-via PR #232 (`c42f8a4`). **The augment is now LIVE:** ruleset `17663217`
-requires `Unity CI Success` plus these 14 remediated ones (15 total). Each of the
-14 static contexts was
+via PR #232 (`c42f8a4`). The ruleset required `Unity CI Success` plus these 14
+remediated contexts until the aggregate switch on 2026-07-30. Each static
+context was
 verified present-and-reporting `success` on PR #232's check-runs (a real PR that
 exercised the remediated workflows) before the augment; the skip-success path is
 structural. Single required jobs carry a fail-closed job-level `if:` and matrix
@@ -340,21 +334,19 @@ on real PRs.
 gh api repos/OWNER/REPO/rulesets/<id> -X PUT --input augmented-ruleset.json
 ```
 
-## Switching to the aggregate ruleset
+## Aggregate ruleset switch (DONE 2026-07-30)
 
-After `.github/workflows/ci.yml` lands on `master`, verify `CI Success` reports
-on a real documentation-only PR and a real code/workflow PR. Then update ruleset
-`17663217` so `required_status_checks` contains only:
+PR #316 verified `CI Success` and `Unity CI Success` on a real workflow and
+documentation change. Ruleset `17663217` now contains only:
 
 ```text
 CI Success
 Unity CI Success
 ```
 
-Keep the existing `conditions`, `bypass_actors`, and pull-request rule intact.
-Do not remove the interim 14 static contexts before `CI Success` has reported on
-the default branch; requiring an absent aggregate hangs auto-merge the same way
-the old path-filtered workflows did.
+The switch preserved the existing `conditions`, `bypass_actors`, enforcement
+mode, and required-check policy. `CI Success` also reported on the default
+branch after merge.
 
 ## Fragile check names
 
@@ -367,7 +359,7 @@ A required check is matched by literal string, so these break silently:
   Require `Unity CI Success` instead. Static script tests are inside `ci.yml`;
   the matrix still expands to `Script tests (ubuntu-latest)`,
   `Script tests (macos-latest)`, and `Script tests (windows-latest)`, but branch
-  protection should require only `CI Success` after the aggregate switch.
+  protection requires only `CI Success`.
 - **Jobs with no `name:`.** Their check-run context is the bare job id. Generic
   ids like `test`/`lint` collide across workflows and are easy to mistype, so
   every required job must keep a unique, stable `name:`.

--- a/progress/session-178-unity-validation-only.md
+++ b/progress/session-178-unity-validation-only.md
@@ -54,45 +54,12 @@ Local verification on commit `3f28a5e4`:
 
 ## Delivery evidence
 
-An administrator repaired the Unity `6000.3.16f1` installation under
-`E:\actions-runner\_tool\u6-v3`. A direct module-add attempt first confirmed that
-the existing editor was not Hub/CLI-managed:
-
-```text
-Error: No modules found for this editor.
-Module installation is only supported for editors installed with Unity Hub.
-```
-
-The administrator then ran the repository's bounded reinstall path from an
-elevated host shell:
-
-```powershell
-$editorRoot = 'E:\actions-runner\_tool\u6-v3'
-.\scripts\unity\maintain-windows-runner.ps1 `
-  -UnityVersions @('6000.3.16f1') `
-  -InstallRoot $editorRoot `
-  -ProvisioningProfile StandaloneWindowsIl2Cpp `
-  -Force
-```
-
-The repaired editor passed all nine Unity matrix cells on PR #316, including
-Unity `6000.3.16f1` standalone IL2CPP. Static CI, Cursor Bugbot, and all 10
-review threads were also green. PR #316 merged as
+PR #316 passed all nine Unity matrix cells, including Unity `6000.3.16f1`
+standalone IL2CPP. Static CI, Cursor Bugbot, and all 10 review threads were also
+green. PR #316 merged as
 `4d38854c2a67d4e97788d1a5baab6c515158531c`; the generated `llms.txt` refresh
 then advanced `master` to `1efb73261333169a904a56f1b49e9e956e641309`.
 
 Trusted organization audit run `30587754261` inspected that exact default-branch
 commit. Its sanitized artifact reports `complete: true`, inventories every
 DxMessaging Unity consumer, and contains zero DxMessaging findings.
-
-Ruleset `17663217` now requires exactly `CI Success` and `Unity CI Success`. Its
-active enforcement, default-branch condition, required-check policy, and
-`bot-auto-commit` bypass actor remain unchanged.
-
-## Remaining delivery steps
-
-- Install `windows-il2cpp` manually under
-  `D:\actions-runner\_tool\u6-v3\6000.3.16f1` on the second Windows runner.
-- Rerun the failed default-branch performance workflow and require current
-  default-branch Unity CI to finish green.
-- Merge the runbook correction that records the live two-aggregate ruleset.

--- a/progress/session-178-unity-validation-only.md
+++ b/progress/session-178-unity-validation-only.md
@@ -52,25 +52,19 @@ Local verification on commit `3f28a5e4`:
   0 failed. The correction changes workflows, scripts, tests, and documentation,
   not package C#.
 
-## Live PR state
+## Delivery evidence
 
-PR #316 has one current head, `3f28a5e4`. Static CI and Cursor Bugbot are green,
-and all 10 review threads are resolved. Eight Unity matrix cells pass. The final
-cell, Unity `6000.3.16f1` standalone on `DAD-MACHINE`, fails validation before
-the organization lock because the existing editor lacks the
-`windows-il2cpp` module.
-
-That failure is the intended validation-only behavior. An administrator must
-repair the editor directly on `DAD-MACHINE`. A direct module-add attempt
-confirmed that this editor is not Hub/CLI-managed:
+An administrator repaired the Unity `6000.3.16f1` installation under
+`E:\actions-runner\_tool\u6-v3`. A direct module-add attempt first confirmed that
+the existing editor was not Hub/CLI-managed:
 
 ```text
 Error: No modules found for this editor.
 Module installation is only supported for editors installed with Unity Hub.
 ```
 
-The administrator must therefore run the repository's bounded reinstall path
-from an elevated host shell:
+The administrator then ran the repository's bounded reinstall path from an
+elevated host shell:
 
 ```powershell
 $editorRoot = 'E:\actions-runner\_tool\u6-v3'
@@ -81,26 +75,24 @@ $editorRoot = 'E:\actions-runner\_tool\u6-v3'
   -Force
 ```
 
-The script detects the unmanageable editor, tries an atomic `install -m`
-reinstallation, verifies the module on disk, and falls back to a bounded
-quarantine plus reinstall when necessary. No workflow should execute that
-repair. After the host is repaired, rerun the failed Unity job, merge only when
-every required check is green, and run the central organization audit against
-the exact merged default-branch commit.
+The repaired editor passed all nine Unity matrix cells on PR #316, including
+Unity `6000.3.16f1` standalone IL2CPP. Static CI, Cursor Bugbot, and all 10
+review threads were also green. PR #316 merged as
+`4d38854c2a67d4e97788d1a5baab6c515158531c`; the generated `llms.txt` refresh
+then advanced `master` to `1efb73261333169a904a56f1b49e9e956e641309`.
 
-The latest trusted central audit completed against current `master` commit
-`645cde0551e92ed2fe4fc8cc128dda807ec348ba`. Its sanitized artifact reports the
-same 56 DxMessaging findings across the six paid-serial jobs, so issue #305 is
-not cleared by repository-side tests alone. The post-merge audit must report
-zero findings at the exact merged commit.
+Trusted organization audit run `30587754261` inspected that exact default-branch
+commit. Its sanitized artifact reports `complete: true`, inventories every
+DxMessaging Unity consumer, and contains zero DxMessaging findings.
+
+Ruleset `17663217` now requires exactly `CI Success` and `Unity CI Success`. Its
+active enforcement, default-branch condition, required-check policy, and
+`bot-auto-commit` bypass actor remain unchanged.
 
 ## Remaining delivery steps
 
-- Install `windows-il2cpp` manually on `DAD-MACHINE`.
-- Rerun Unity CI and require `Unity CI Success`.
-- Reconfirm zero unresolved review threads and merge PR #316.
-- Run the trusted central enrollment audit against the merged commit and
-  require zero DxMessaging findings.
-- Reduce the default-branch ruleset to the two aggregate contexts, `CI Success`
-  and `Unity CI Success`, while preserving its existing conditions and bypass
-  actor.
+- Install `windows-il2cpp` manually under
+  `D:\actions-runner\_tool\u6-v3\6000.3.16f1` on the second Windows runner.
+- Rerun the failed default-branch performance workflow and require current
+  default-branch Unity CI to finish green.
+- Merge the runbook correction that records the live two-aggregate ruleset.


### PR DESCRIPTION
## Summary

- record ruleset 17663217 as requiring exactly CI Success and Unity CI Success
- retain the 14 individual static contexts only as migration history
- record PR #316, the exact trusted audit result, and the remaining second-runner host repair in session progress

## Validation

- npx prettier --write docs/runbooks/required-checks.md progress/session-178-unity-validation-only.md
- npx markdownlint-cli2 docs/runbooks/required-checks.md
- npx cspell --no-progress --no-summary docs/runbooks/required-checks.md progress/session-178-unity-validation-only.md
- npm run validate:docs:strict
- npm run validate:all
- pre-commit run --files docs/runbooks/required-checks.md progress/session-178-unity-validation-only.md progress/session-178-unity-validation-only.md.meta
- git diff --check

Closes #310

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to runbook and session progress; no workflow, ruleset, or application code changes.
> 
> **Overview**
> Updates **required-checks** runbook and session **178** progress to match production: ruleset `17663217` now requires only **`CI Success`** and **`Unity CI Success`** (live **2026-07-30**), with PR **#316** cited as verification.
> 
> The runbook drops interim “15 individual contexts” guidance and the “aggregate not yet live” note. The 14 static job names are kept under **Retired Individual Static Contexts** for migration history and `CI Success` dependency audits, not for branch protection. The aggregate switch section is marked **DONE** with preserved conditions/bypass actors; fragile-check wording now states branch protection requires only **`CI Success`**.
> 
> Session progress replaces open PR/host-repair steps with **delivery evidence**: merge commits, all nine Unity matrix cells green (including `6000.3.16f1` standalone IL2CPP), and trusted org audit run `30587754261` with zero DxMessaging findings on the merged default-branch commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62dfa58397f4be7d7b19d6a80d04831ca55a0b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->