### PR TITLE
test: remove heartbeat tree probe race

### DIFF
--- a/progress/session-179-heartbeat-tree-probe-flake.md
+++ b/progress/session-179-heartbeat-tree-probe-flake.md
@@ -98,6 +98,14 @@ The wall clock runs from launch and has no equivalent trick available, so it
 uses ten seconds against a sub-second publish and fails loudly on a missed
 publish.
 
+A further review round found a process leak in the same helper.
+`Invoke-UnityCliCaptureWithTimeout` throws on its non-retryable process-safety
+error, and on that path the try block never reached the publication read, so
+`descendantId` was still 0 when `finally` ran: the descendant was never stopped
+and the PID file -- the only record of which process it was -- was deleted
+anyway. The `finally` now reads the PID before removing the file, matching what
+the detached-orphan probe already did.
+
 ## Verification
 
 Red evidence, on the pre-fix branch head:
@@ -128,6 +136,10 @@ Green evidence, after the fix:
   standing in for a cold start that overruns the window: fails
   `wrapper stall path killed only after publication` by name, so the margin
   failing is reported as itself rather than as a mysterious tree-check failure;
+- isolated A/B of the two `finally` shapes against a real published sleeper,
+  with the try forced to throw: the pre-fix shape reports
+  `descendantLeaked=True pidFileGone=True`, the fixed shape
+  `descendantLeaked=False`;
 - full Node/script suite: 406 passed, 0 failed;
 - `npm run validate:all` and spelling: passed;
 - unchanged master rerun: static `CI Success` passed, confirming the original

--- a/progress/session-179-heartbeat-tree-probe-flake.md
+++ b/progress/session-179-heartbeat-tree-probe-flake.md
@@ -66,6 +66,23 @@ Both publish sites (the tree probe and the detached-orphan probe) now use the
 same atomic publish, validating read, and verified cleanup, so the
 partial-read class is gone rather than patched at one call site.
 
+Re-review then found a sixth defect, and it was a coverage regression the fix
+itself introduced. Driving `Confirm-UnityCliDirectChildExit` directly is what
+makes the probe independent of startup timing, but
+`Invoke-UnityCliCaptureWithTimeout` has its OWN `Kill($true)` call sites for the
+stall and wall-clock paths, and those are the ones CI actually runs. If either
+regressed to a bare `Kill()`, the parent would exit before
+`Confirm-UnityCliDirectChildExit` ran, that helper would see an already-exited
+direct child and skip tree termination, and a reparented Unity installer would
+be orphaned holding the editor tree -- with the direct probe still green.
+
+Both wrapper paths are now covered end to end. The stall probe emits its last
+line immediately AFTER publishing the descendant PID, so the stall countdown
+starts at publication and process startup is excluded by construction, not by a
+generous margin. The wall clock runs from launch and cannot be made structural
+that way, so it uses ten seconds against a sub-second publish and fails loudly
+on a missed publish rather than quietly voiding the tree check.
+
 ## Verification
 
 Red evidence, on the pre-fix branch head:
@@ -76,15 +93,22 @@ Red evidence, on the pre-fix branch head:
 
 Green evidence, after the fix:
 
-- focused heartbeat suite: 37 passed, 0 failed, 21.4 s. The 12.6 s saved is
-  the watcher timeout that never fired;
-- former-flake loop: 20 consecutive focused-suite passes;
+- focused heartbeat suite: 43 passed, 0 failed. It runs in 34.5 s: the watcher
+  fix took 34.07 s down to 21.4 s, and the two new wrapper probes spend 13 s of
+  that back on coverage CI did not previously have;
+- former-flake loop: 20 consecutive focused-suite passes before the wrapper
+  probes, 8 after;
 - mutation - direct-child-only kill instead of tree kill: fails on
   `tree termination removes the descendant` (36 passed, 1 failed), so the
   assertion discriminates a real tree-termination regression;
 - mutation - parent never publishes the descendant PID: fails on
   `tree probe captures the descendant process id` (35 passed, 2 failed)
   instead of throwing a cast error;
+- mutation - the wrapper's stall-path `Kill($true)` weakened to `Kill()`: fails
+  on `wrapper stall termination removes the descendant`, and on nothing else;
+- mutation - the wrapper's wall-clock `Kill($true)` weakened to `Kill()`: fails
+  on `wrapper wall-clock termination removes the descendant`, and on nothing
+  else. Each assertion tracks its own kill site;
 - full Node/script suite: 406 passed, 0 failed;
 - `npm run validate:all` and spelling: passed;
 - unchanged master rerun: static `CI Success` passed, confirming the original

--- a/progress/session-179-heartbeat-tree-probe-flake.md
+++ b/progress/session-179-heartbeat-tree-probe-flake.md
@@ -58,9 +58,10 @@ Removing the watcher also deletes one layer of the cleanup pyramid.
 The fourth finding exposed a fifth defect, in the cleanup guard itself:
 `Stop-Process` only requests termination, so verifying it with an immediate
 `Get-Process` races the kernel and can report a successful kill as a surviving
-process. `Wait-ForProcessExit` polls to a 10-second bound instead. A sweep
-found no other instance of this pattern; the one production `Stop-Process` in
-`ensure-editor.ps1` reports its outcome and does not re-check.
+process. `Wait-ForProcessExit` polls to a 10-second bound instead. The one
+production `Stop-Process` in `ensure-editor.ps1` reports its outcome and does
+not re-check, so it is unaffected; the sweep across the test's own cleanup
+paths came later, and found two more instances.
 
 Both publish sites (the tree probe and the detached-orphan probe) now use the
 same atomic publish, validating read, and verified cleanup, so the
@@ -98,13 +99,28 @@ The wall clock runs from launch and has no equivalent trick available, so it
 uses ten seconds against a sub-second publish and fails loudly on a missed
 publish.
 
-A further review round found a process leak in the same helper.
-`Invoke-UnityCliCaptureWithTimeout` throws on its non-retryable process-safety
-error, and on that path the try block never reached the publication read, so
-`descendantId` was still 0 when `finally` ran: the descendant was never stopped
-and the PID file -- the only record of which process it was -- was deleted
-anyway. The `finally` now reads the PID before removing the file, matching what
-the detached-orphan probe already did.
+Three further review rounds found three leaks, all of the same class and all in
+cleanup rather than in the happy path:
+
+1. `Invoke-UnityCliCaptureWithTimeout` throws on its non-retryable
+   process-safety error, and on that path the try block never reached the
+   publication read, so `descendantId` was still 0 when `finally` ran. The
+   descendant was never stopped and the PID file was deleted anyway.
+1. Recovery consulted only the FINAL PID path. A parent that died between
+   `WriteAllText` and `Move` left the id only in the staging file, so cleanup
+   learned nothing and then deleted both files.
+1. Cleanup ended at `Stop-Process`, which only REQUESTS termination. A
+   descendant that ignored the request outlived the probe with no record.
+
+Each one leaves a sixty-second sleeper running and unattributable, because the
+PID file it could have been traced through is gone.
+
+Rather than patch three call sites, `Stop-PublishedDescendant` is now the single
+cleanup path for every probe that publishes a descendant: it recovers the id
+from the final path and then the staging path, terminates, waits for the exit to
+be confirmed, and only then removes both halves of the publish. That replaced
+three bespoke cleanup blocks -- including one four-deep `finally` pyramid in the
+tree probe -- and is why the fix is a simplification rather than another layer.
 
 ## Verification
 
@@ -120,7 +136,7 @@ Green evidence, after the fix:
   fix took 34.07 s down to 21.4 s, and the two new wrapper probes spend that
   back plus 6 s on coverage CI did not previously have;
 - former-flake loop: 20 consecutive focused-suite passes before the wrapper
-  probes, 5 after;
+  probes, 4 after the cleanup refactor;
 - mutation - direct-child-only kill instead of tree kill: fails on
   `tree termination removes the descendant` (36 passed, 1 failed), so the
   assertion discriminates a real tree-termination regression;
@@ -140,6 +156,10 @@ Green evidence, after the fix:
   with the try forced to throw: the pre-fix shape reports
   `descendantLeaked=True pidFileGone=True`, the fixed shape
   `descendantLeaked=False`;
+- isolated A/B with the id present only in the staging file, standing in for a
+  parent that died between `WriteAllText` and `Move`: final-path-only recovery
+  reports `descendantLeaked=True stagingGone=True`, `Stop-PublishedDescendant`
+  reports `descendantLeaked=False`;
 - full Node/script suite: 406 passed, 0 failed;
 - `npm run validate:all` and spelling: passed;
 - unchanged master rerun: static `CI Success` passed, confirming the original

--- a/progress/session-179-heartbeat-tree-probe-flake.md
+++ b/progress/session-179-heartbeat-tree-probe-flake.md
@@ -26,6 +26,10 @@ test now waits for the PID-file creation event, checks those outcomes against
 the production helper, and cleans up every process and temporary file on
 failure.
 
+Cursor review found that an exception during parent cleanup could skip the
+later descendant and PID-file cleanup. Nested `finally` blocks now attempt
+every cleanup stage and still propagate a cleanup failure.
+
 ## Verification
 
 - focused heartbeat suite: 37 passed, 0 failed;

--- a/progress/session-179-heartbeat-tree-probe-flake.md
+++ b/progress/session-179-heartbeat-tree-probe-flake.md
@@ -76,12 +76,27 @@ regressed to a bare `Kill()`, the parent would exit before
 direct child and skip tree termination, and a reparented Unity installer would
 be orphaned holding the editor tree -- with the direct probe still green.
 
-Both wrapper paths are now covered end to end. The stall probe emits its last
-line immediately AFTER publishing the descendant PID, so the stall countdown
-starts at publication and process startup is excluded by construction, not by a
-generous margin. The wall clock runs from launch and cannot be made structural
-that way, so it uses ten seconds against a sub-second publish and fails loudly
-on a missed publish rather than quietly voiding the tree check.
+Both wrapper paths are now covered end to end.
+
+The first attempt at the stall probe was wrong in an instructive way, and the
+re-review caught it: it claimed that emitting a line immediately after
+publication started the stall countdown at publication. It does not.
+`lastActivityMs` starts at 0, so the FIRST stall window runs from process
+launch, and a slow nested `pwsh` start could kill the parent before publication
+-- reintroducing the exact flake this branch exists to remove.
+
+The stall clock cannot be made to start at publication; that is the wrapper's
+contract and a test does not get to change it. What the probe does instead is
+emit BEFORE spawning the descendant, which keeps the nested `Start-Process` and
+the PID write out of the first window and leaves only pwsh's own startup inside
+it, against an eight-second window. That is a wide margin, not a guarantee, so
+the probe proves the margin held rather than assuming it: the wrapper must have
+READ the published marker before it killed. A cold start that ever did overrun
+the window fails a named assertion instead of silently voiding the tree check.
+
+The wall clock runs from launch and has no equivalent trick available, so it
+uses ten seconds against a sub-second publish and fails loudly on a missed
+publish.
 
 ## Verification
 
@@ -93,11 +108,11 @@ Red evidence, on the pre-fix branch head:
 
 Green evidence, after the fix:
 
-- focused heartbeat suite: 43 passed, 0 failed. It runs in 34.5 s: the watcher
-  fix took 34.07 s down to 21.4 s, and the two new wrapper probes spend 13 s of
-  that back on coverage CI did not previously have;
+- focused heartbeat suite: 44 passed, 0 failed. It runs in 40.8 s: the watcher
+  fix took 34.07 s down to 21.4 s, and the two new wrapper probes spend that
+  back plus 6 s on coverage CI did not previously have;
 - former-flake loop: 20 consecutive focused-suite passes before the wrapper
-  probes, 8 after;
+  probes, 5 after;
 - mutation - direct-child-only kill instead of tree kill: fails on
   `tree termination removes the descendant` (36 passed, 1 failed), so the
   assertion discriminates a real tree-termination regression;
@@ -109,6 +124,10 @@ Green evidence, after the fix:
 - mutation - the wrapper's wall-clock `Kill($true)` weakened to `Kill()`: fails
   on `wrapper wall-clock termination removes the descendant`, and on nothing
   else. Each assertion tracks its own kill site;
+- simulation - a five-second delay before the stall probe's first emission,
+  standing in for a cold start that overruns the window: fails
+  `wrapper stall path killed only after publication` by name, so the margin
+  failing is reported as itself rather than as a mysterious tree-check failure;
 - full Node/script suite: 406 passed, 0 failed;
 - `npm run validate:all` and spelling: passed;
 - unchanged master rerun: static `CI Success` passed, confirming the original

--- a/progress/session-179-heartbeat-tree-probe-flake.md
+++ b/progress/session-179-heartbeat-tree-probe-flake.md
@@ -1,0 +1,37 @@
+# Session 179 - Heartbeat tree-probe flake
+
+Date: 2026-07-31
+Branch: `codex/fix-heartbeat-tree-probe-flake`
+
+## Outcome
+
+The Windows heartbeat test now synchronizes on a descendant PID before it
+exercises the real process-tree termination helper. It no longer assumes that
+a fresh PowerShell process can start, spawn its child, and flush that child's
+PID within one second.
+
+Production timeout, heartbeat, and process-tree behavior is unchanged.
+
+## Root cause
+
+Static CI run `30593187996` failed its first attempt because the one-second
+heartbeat killed the test parent before that process had created and reported
+its descendant. The test then had no PID to assert against. Re-running the
+unchanged commit passed, which confirmed an intermittent test timing failure.
+
+The tree contract is independent of heartbeat timing: after the descendant is
+known to exist, `Confirm-UnityCliDirectChildExit` must request whole-tree
+termination, confirm the direct child exit, and remove the descendant. The
+test now waits for the PID-file creation event, checks those outcomes against
+the production helper, and cleans up every process and temporary file on
+failure.
+
+## Verification
+
+- focused heartbeat suite: 37 passed, 0 failed;
+- former-flake loop: 50 consecutive focused-suite passes;
+- full Node/script suite: 406 passed, 0 failed;
+- `npm run validate:all` and spelling: passed;
+- unchanged master rerun: static `CI Success` passed, confirming the original
+  failure was intermittent;
+- `git diff --check`: passed.

--- a/progress/session-179-heartbeat-tree-probe-flake.md
+++ b/progress/session-179-heartbeat-tree-probe-flake.md
@@ -30,6 +30,11 @@ Cursor review found that an exception during parent cleanup could skip the
 later descendant and PID-file cleanup. Nested `finally` blocks now attempt
 every cleanup stage and still propagate a cleanup failure.
 
+The re-review also found that the descendant's original 10-second lifetime
+matched the helper's two bounded 5-second waits. The synthetic descendant now
+lives for 30 seconds, so only process-tree termination can make the assertion
+pass inside the observation window.
+
 ## Verification
 
 - focused heartbeat suite: 37 passed, 0 failed;

--- a/progress/session-179-heartbeat-tree-probe-flake.md
+++ b/progress/session-179-heartbeat-tree-probe-flake.md
@@ -35,6 +35,11 @@ matched the helper's two bounded 5-second waits. The synthetic descendant now
 lives for 30 seconds, so only process-tree termination can make the assertion
 pass inside the observation window.
 
+The next review found that a file-created event could precede completion of
+`WriteAllText`. The parent now writes to a sibling staging file and atomically
+moves it to the watched PID path. The watcher can only observe the published
+file after its content is complete.
+
 ## Verification
 
 - focused heartbeat suite: 37 passed, 0 failed;

--- a/progress/session-179-heartbeat-tree-probe-flake.md
+++ b/progress/session-179-heartbeat-tree-probe-flake.md
@@ -19,31 +19,72 @@ heartbeat killed the test parent before that process had created and reported
 its descendant. The test then had no PID to assert against. Re-running the
 unchanged commit passed, which confirmed an intermittent test timing failure.
 
-The tree contract is independent of heartbeat timing: after the descendant is
+The tree contract is independent of heartbeat timing: once the descendant is
 known to exist, `Confirm-UnityCliDirectChildExit` must request whole-tree
 termination, confirm the direct child exit, and remove the descendant. The
-test now waits for the PID-file creation event, checks those outcomes against
+probe now waits for a published descendant PID, checks those outcomes against
 the production helper, and cleans up every process and temporary file on
 failure.
 
-Cursor review found that an exception during parent cleanup could skip the
-later descendant and PID-file cleanup. Nested `finally` blocks now attempt
-every cleanup stage and still propagate a cleanup failure.
+## Review findings folded in
 
-The re-review also found that the descendant's original 10-second lifetime
-matched the helper's two bounded 5-second waits. The synthetic descendant now
-lives for 30 seconds, so only process-tree termination can make the assertion
-pass inside the observation window.
+Cursor review found three defects in the first fix, and verifying the third
+uncovered a fourth:
 
-The next review found that a file-created event could precede completion of
-`WriteAllText`. The parent now writes to a sibling staging file and atomically
-moves it to the watched PID path. The watcher can only observe the published
-file after its content is complete.
+1. An exception during parent cleanup could skip the later descendant and
+   PID-file cleanup. Nested `finally` blocks now attempt every cleanup stage
+   and still propagate a cleanup failure.
+1. The descendant's original 10-second lifetime matched the helper's two
+   bounded 5-second waits, so a descendant that survived tree termination could
+   exit on its own inside the observation window. The synthetic descendant now
+   lives for 60 seconds against a 25-second worst-case probe.
+1. A file-created event could precede completion of `WriteAllText`. The parent
+   now writes to a sibling staging file and atomically moves it to the
+   published PID path.
+1. `FileSystemWatcher` cannot observe that publication at all. A
+   same-directory `File.Move` raises `Renamed`, not `Created`, so
+   `WaitForChanged([WatcherChangeTypes]::Created, 10000)` exhausted its full
+   timeout every run and the probe fell through to an unsynchronized
+   `Test-Path`. A standalone repro confirmed it: the file appeared at 300 ms
+   and `WaitForChanged` still returned `TimedOut=True` after 3003 ms of a
+   3000 ms budget.
+
+The watcher is removed rather than repaired. `Wait-ForPublishedProcessId`
+polls for a *parseable, positive* process id, which is what actually makes the
+read safe - a partially written or empty file fails to parse and the wait
+continues - and it has no platform-specific event semantics to get wrong.
+Removing the watcher also deletes one layer of the cleanup pyramid.
+
+The fourth finding exposed a fifth defect, in the cleanup guard itself:
+`Stop-Process` only requests termination, so verifying it with an immediate
+`Get-Process` races the kernel and can report a successful kill as a surviving
+process. `Wait-ForProcessExit` polls to a 10-second bound instead. A sweep
+found no other instance of this pattern; the one production `Stop-Process` in
+`ensure-editor.ps1` reports its outcome and does not re-check.
+
+Both publish sites (the tree probe and the detached-orphan probe) now use the
+same atomic publish, validating read, and verified cleanup, so the
+partial-read class is gone rather than patched at one call site.
 
 ## Verification
 
-- focused heartbeat suite: 37 passed, 0 failed;
-- former-flake loop: 50 consecutive focused-suite passes;
+Red evidence, on the pre-fix branch head:
+
+- standalone `FileSystemWatcher` repro: `WaitForChanged(Created)` returned
+  `TimedOut=True` after 3003 ms while the published file existed from 300 ms;
+- focused heartbeat suite wall clock: 34.07 s.
+
+Green evidence, after the fix:
+
+- focused heartbeat suite: 37 passed, 0 failed, 21.4 s. The 12.6 s saved is
+  the watcher timeout that never fired;
+- former-flake loop: 20 consecutive focused-suite passes;
+- mutation - direct-child-only kill instead of tree kill: fails on
+  `tree termination removes the descendant` (36 passed, 1 failed), so the
+  assertion discriminates a real tree-termination regression;
+- mutation - parent never publishes the descendant PID: fails on
+  `tree probe captures the descendant process id` (35 passed, 2 failed)
+  instead of throwing a cast error;
 - full Node/script suite: 406 passed, 0 failed;
 - `npm run validate:all` and spelling: passed;
 - unchanged master rerun: static `CI Success` passed, confirming the original

--- a/progress/session-179-heartbeat-tree-probe-flake.md.meta
+++ b/progress/session-179-heartbeat-tree-probe-flake.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ac85c9bf80aa3158786cd56596d37ee3
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
+++ b/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
@@ -203,6 +203,13 @@ $TailCode
         }
     } finally {
         try {
+            # Invoke-UnityCliCaptureWithTimeout THROWS on its non-retryable process-safety
+            # error, in which case the try block never reached the publication read and
+            # $descendantId is still 0. Read it here, before the file is removed, or the
+            # descendant leaks along with the only record of which process it was.
+            if ($descendantId -le 0) {
+                $descendantId = Wait-ForPublishedProcessId -Path $pidPath -TimeoutSeconds 5
+            }
             if ($descendantId -gt 0) {
                 Stop-Process -Id $descendantId -Force -ErrorAction SilentlyContinue
             }

--- a/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
+++ b/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
@@ -184,29 +184,70 @@ Start-Sleep -Seconds 20
     Assert-That 'closed-pipe child is not attributed to heartbeat' (-not $result.StallKilled)
     Assert-That 'closed-pipe child exit is confirmed' $result.DirectChildExited
 
+    # 2026-07-31: Synchronize on the descendant PID before testing the real
+    # tree-termination helper. The former one-second heartbeat probe mixed
+    # PowerShell startup time into this contract and could kill the parent
+    # before it had created or reported the descendant.
     $descendantCode = ConvertTo-EncodedCommand 'Start-Sleep -Seconds 10'
     $pwshPath = $script:UnityCliPath.Replace("'", "''")
+    $treePidPath = Join-Path ([IO.Path]::GetTempPath()) "dxm-heartbeat-tree-$([Guid]::NewGuid().ToString('N')).pid"
+    $treePidLiteral = $treePidPath.Replace("'", "''")
     $descendantParent = @"
 `$child = Start-Process -FilePath '$pwshPath' -ArgumentList @('-NoLogo', '-NoProfile', '-EncodedCommand', '$descendantCode') -PassThru
-Write-Output "descendant=`$(`$child.Id)"
-Start-Sleep -Seconds 10
+[IO.File]::WriteAllText('$treePidLiteral', [string]`$child.Id)
+Start-Sleep -Seconds 30
 "@
-    $result = Invoke-UnityCliCaptureWithTimeout `
-        -Arguments @('-NoLogo', '-NoProfile', '-EncodedCommand', (ConvertTo-EncodedCommand $descendantParent)) `
-        -TimeoutSeconds 10 `
-        -StallSeconds 1
-    $descendantLine = @($result.Output | Where-Object { $_ -match '^descendant=\d+$' } | Select-Object -First 1)
-    $descendantId = if ($descendantLine.Count -eq 1) {
-        [int]($descendantLine[0] -replace '^descendant=', '')
-    } else {
-        0
-    }
-    Assert-That 'tree probe reaches heartbeat sentinel 125' ($result.ExitCode -eq 125)
-    Assert-That 'tree probe captures the descendant process id' ($descendantId -gt 0)
-    Assert-That 'tree probe confirms direct child exit' $result.DirectChildExited
-    Assert-That 'tree termination removes the descendant' (
-        $descendantId -gt 0 -and $null -eq (Get-Process -Id $descendantId -ErrorAction SilentlyContinue)
+    $treeWatcher = [IO.FileSystemWatcher]::new(
+        [IO.Path]::GetDirectoryName($treePidPath),
+        [IO.Path]::GetFileName($treePidPath)
     )
+    $treeWatcher.EnableRaisingEvents = $true
+    $treeParent = $null
+    $treeConfirmation = $null
+    $descendantProcess = $null
+    $descendantId = 0
+    $descendantRemovedByTreeKill = $false
+    try {
+        $treeParent = Start-Process `
+            -FilePath $script:UnityCliPath `
+            -ArgumentList @('-NoLogo', '-NoProfile', '-EncodedCommand', (ConvertTo-EncodedCommand $descendantParent)) `
+            -PassThru
+        if (-not (Test-Path -LiteralPath $treePidPath -PathType Leaf)) {
+            [void]$treeWatcher.WaitForChanged([IO.WatcherChangeTypes]::Created, 10000)
+        }
+        if (Test-Path -LiteralPath $treePidPath -PathType Leaf) {
+            $descendantId = [int][IO.File]::ReadAllText($treePidPath)
+            $descendantProcess = Get-Process -Id $descendantId -ErrorAction SilentlyContinue
+        }
+        $treeConfirmation = Confirm-UnityCliDirectChildExit -Process $treeParent
+        if ($null -ne $descendantProcess) {
+            $descendantRemovedByTreeKill = [bool]$descendantProcess.WaitForExit(5000)
+        }
+    } finally {
+        $treeWatcher.Dispose()
+        if ($null -ne $treeParent) {
+            if (-not $treeParent.HasExited) {
+                $treeParent.Kill($true)
+                [void]$treeParent.WaitForExit(5000)
+            }
+            $treeParent.Dispose()
+        }
+        if ($descendantId -gt 0) {
+            Stop-Process -Id $descendantId -Force -ErrorAction SilentlyContinue
+        }
+        if ($null -ne $descendantProcess) {
+            $descendantProcess.Dispose()
+        }
+        Remove-Item -LiteralPath $treePidPath -Force -ErrorAction SilentlyContinue
+    }
+    Assert-That 'tree probe captures the descendant process id' ($descendantId -gt 0)
+    Assert-That 'tree probe requests process-tree termination' (
+        $null -ne $treeConfirmation -and $treeConfirmation.TerminationRequested
+    )
+    Assert-That 'tree probe confirms direct child exit' (
+        $null -ne $treeConfirmation -and $treeConfirmation.DirectChildExited
+    )
+    Assert-That 'tree termination removes the descendant' $descendantRemovedByTreeKill
 
     $secondAttemptSuccess = New-FakeTerminationProcess -ExitOnSecondWait $true
     $confirmation = Confirm-UnityCliDirectChildExit -Process $secondAttemptSuccess

--- a/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
+++ b/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
@@ -188,7 +188,7 @@ Start-Sleep -Seconds 20
     # tree-termination helper. The former one-second heartbeat probe mixed
     # PowerShell startup time into this contract and could kill the parent
     # before it had created or reported the descendant.
-    $descendantCode = ConvertTo-EncodedCommand 'Start-Sleep -Seconds 10'
+    $descendantCode = ConvertTo-EncodedCommand 'Start-Sleep -Seconds 30'
     $pwshPath = $script:UnityCliPath.Replace("'", "''")
     $treePidPath = Join-Path ([IO.Path]::GetTempPath()) "dxm-heartbeat-tree-$([Guid]::NewGuid().ToString('N')).pid"
     $treePidLiteral = $treePidPath.Replace("'", "''")

--- a/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
+++ b/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
@@ -105,6 +105,81 @@ function New-FakeTerminationProcess {
     return $fake
 }
 
+function Wait-ForPublishedProcessId {
+    # Blocks until an atomically published PID file holds a parseable, positive
+    # process id, then returns it; returns 0 when the timeout elapses first.
+    #
+    # A FileSystemWatcher cannot do this job: the publisher completes the file
+    # under a staging name and renames it into place, and a same-directory
+    # rename raises Renamed, not Created. Waiting on Created therefore always
+    # exhausts its timeout and synchronizes on nothing. Validating the parsed
+    # content is what makes the read safe -- a partially written or empty file
+    # simply fails to parse and the wait continues.
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds
+    )
+
+    $elapsed = [Diagnostics.Stopwatch]::StartNew()
+    while ($true) {
+        if (Test-Path -LiteralPath $Path -PathType Leaf) {
+            $published = 0
+            $raw = $null
+            try {
+                $raw = [IO.File]::ReadAllText($Path)
+            } catch [IO.IOException] {
+                $raw = $null
+            }
+            if (
+                $null -ne $raw -and
+                [int]::TryParse($raw.Trim(), [ref]$published) -and
+                $published -gt 0
+            ) {
+                return $published
+            }
+        }
+        if ($elapsed.Elapsed.TotalSeconds -ge $TimeoutSeconds) {
+            return 0
+        }
+        Start-Sleep -Milliseconds 25
+    }
+}
+
+function Wait-ForProcessExit {
+    # Stop-Process only REQUESTS termination, so verifying with an immediate
+    # Get-Process races the kernel: a successful kill can still look like a
+    # surviving process. Poll to a bound instead and report what actually
+    # happened.
+    param(
+        [Parameter(Mandatory = $true)][int]$Id,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds
+    )
+
+    $elapsed = [Diagnostics.Stopwatch]::StartNew()
+    while ($null -ne (Get-Process -Id $Id -ErrorAction SilentlyContinue)) {
+        if ($elapsed.Elapsed.TotalSeconds -ge $TimeoutSeconds) {
+            return $false
+        }
+        Start-Sleep -Milliseconds 25
+    }
+    return $true
+}
+
+function Remove-PublishedProcessIdFile {
+    # Removes both halves of an atomic PID publish and fails loudly if either
+    # survives, so a leaked temp file is a test failure rather than debris.
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $candidates = @($Path, "$Path.tmp")
+    foreach ($candidate in $candidates) {
+        Remove-Item -LiteralPath $candidate -Force -ErrorAction SilentlyContinue
+    }
+    $surviving = @($candidates | Where-Object { Test-Path -LiteralPath $_ })
+    if ($surviving.Count -gt 0) {
+        throw "PID file cleanup failed: $($surviving -join ', ')."
+    }
+}
+
 $script:UnityCliPath = (Get-Command pwsh -ErrorAction Stop).Source
 $savedNoticeInterval = $env:DXM_ENSURE_EDITOR_PROGRESS_NOTICE_INTERVAL_SECONDS
 $savedStallSeconds = $env:DXM_ENSURE_EDITOR_PROGRESS_STALL_SECONDS
@@ -188,23 +263,22 @@ Start-Sleep -Seconds 20
     # tree-termination helper. The former one-second heartbeat probe mixed
     # PowerShell startup time into this contract and could kill the parent
     # before it had created or reported the descendant.
-    $descendantCode = ConvertTo-EncodedCommand 'Start-Sleep -Seconds 30'
+    # The descendant must outlive every window this probe can wait through, or a
+    # descendant that SURVIVED tree termination could exit on its own and look
+    # like one that was killed. The bound is 25s: up to 10s publishing the PID,
+    # up to 10s inside Confirm-UnityCliDirectChildExit (a 5s reap, a tree kill,
+    # a second 5s reap), and a 5s exit observation. 60s leaves 35s of margin.
+    $descendantCode = ConvertTo-EncodedCommand 'Start-Sleep -Seconds 60'
     $pwshPath = $script:UnityCliPath.Replace("'", "''")
     $treePidPath = Join-Path ([IO.Path]::GetTempPath()) "dxm-heartbeat-tree-$([Guid]::NewGuid().ToString('N')).pid"
-    $treePidStagingPath = "$treePidPath.tmp"
     $treePidLiteral = $treePidPath.Replace("'", "''")
-    $treePidStagingLiteral = $treePidStagingPath.Replace("'", "''")
+    $treePidStagingLiteral = "$treePidPath.tmp".Replace("'", "''")
     $descendantParent = @"
 `$child = Start-Process -FilePath '$pwshPath' -ArgumentList @('-NoLogo', '-NoProfile', '-EncodedCommand', '$descendantCode') -PassThru
 [IO.File]::WriteAllText('$treePidStagingLiteral', [string]`$child.Id)
 [IO.File]::Move('$treePidStagingLiteral', '$treePidLiteral')
-Start-Sleep -Seconds 30
+Start-Sleep -Seconds 60
 "@
-    $treeWatcher = [IO.FileSystemWatcher]::new(
-        [IO.Path]::GetDirectoryName($treePidPath),
-        [IO.Path]::GetFileName($treePidPath)
-    )
-    $treeWatcher.EnableRaisingEvents = $true
     $treeParent = $null
     $treeConfirmation = $null
     $descendantProcess = $null
@@ -215,11 +289,8 @@ Start-Sleep -Seconds 30
             -FilePath $script:UnityCliPath `
             -ArgumentList @('-NoLogo', '-NoProfile', '-EncodedCommand', (ConvertTo-EncodedCommand $descendantParent)) `
             -PassThru
-        if (-not (Test-Path -LiteralPath $treePidPath -PathType Leaf)) {
-            [void]$treeWatcher.WaitForChanged([IO.WatcherChangeTypes]::Created, 10000)
-        }
-        if (Test-Path -LiteralPath $treePidPath -PathType Leaf) {
-            $descendantId = [int][IO.File]::ReadAllText($treePidPath)
+        $descendantId = Wait-ForPublishedProcessId -Path $treePidPath -TimeoutSeconds 10
+        if ($descendantId -gt 0) {
             $descendantProcess = Get-Process -Id $descendantId -ErrorAction SilentlyContinue
         }
         $treeConfirmation = Confirm-UnityCliDirectChildExit -Process $treeParent
@@ -228,44 +299,31 @@ Start-Sleep -Seconds 30
         }
     } finally {
         try {
-            $treeWatcher.Dispose()
+            try {
+                if ($null -ne $treeParent -and -not $treeParent.HasExited) {
+                    $treeParent.Kill($true)
+                    [void]$treeParent.WaitForExit(5000)
+                }
+            } finally {
+                if ($null -ne $treeParent) {
+                    $treeParent.Dispose()
+                }
+            }
         } finally {
             try {
-                try {
-                    if ($null -ne $treeParent -and -not $treeParent.HasExited) {
-                        $treeParent.Kill($true)
-                        [void]$treeParent.WaitForExit(5000)
-                    }
-                } finally {
-                    if ($null -ne $treeParent) {
-                        $treeParent.Dispose()
+                if ($descendantId -gt 0) {
+                    Stop-Process -Id $descendantId -Force -ErrorAction SilentlyContinue
+                    if (-not (Wait-ForProcessExit -Id $descendantId -TimeoutSeconds 10)) {
+                        throw "Tree-probe descendant process $descendantId survived cleanup."
                     }
                 }
             } finally {
                 try {
-                    if ($descendantId -gt 0) {
-                        Stop-Process -Id $descendantId -Force -ErrorAction SilentlyContinue
-                        if ($null -ne (Get-Process -Id $descendantId -ErrorAction SilentlyContinue)) {
-                            throw "Tree-probe descendant process $descendantId survived cleanup."
-                        }
+                    if ($null -ne $descendantProcess) {
+                        $descendantProcess.Dispose()
                     }
                 } finally {
-                    try {
-                        if ($null -ne $descendantProcess) {
-                            $descendantProcess.Dispose()
-                        }
-                    } finally {
-                        $treePidFiles = @($treePidPath, $treePidStagingPath)
-                        foreach ($treePidFile in $treePidFiles) {
-                            Remove-Item -LiteralPath $treePidFile -Force -ErrorAction SilentlyContinue
-                        }
-                        $survivingPidFiles = @(
-                            $treePidFiles | Where-Object { Test-Path -LiteralPath $_ }
-                        )
-                        if ($survivingPidFiles.Count -gt 0) {
-                            throw "Tree-probe PID file cleanup failed: $($survivingPidFiles -join ', ')."
-                        }
-                    }
+                    Remove-PublishedProcessIdFile -Path $treePidPath
                 }
             }
         }
@@ -301,9 +359,11 @@ Start-Sleep -Seconds 30
 
     $orphanPidPath = Join-Path ([IO.Path]::GetTempPath()) "dxm-heartbeat-orphan-$([Guid]::NewGuid().ToString('N')).pid"
     $orphanPidLiteral = $orphanPidPath.Replace("'", "''")
+    $orphanPidStagingLiteral = "$orphanPidPath.tmp".Replace("'", "''")
     $orphanParent = @"
 `$child = Start-Process -FilePath '$pwshPath' -ArgumentList @('-NoLogo', '-NoProfile', '-EncodedCommand', '$descendantCode') -PassThru
-[IO.File]::WriteAllText('$orphanPidLiteral', [string]`$child.Id)
+[IO.File]::WriteAllText('$orphanPidStagingLiteral', [string]`$child.Id)
+[IO.File]::Move('$orphanPidStagingLiteral', '$orphanPidLiteral')
 "@
     $orphanAttempts = 0
     $orphanResult = $null
@@ -323,11 +383,14 @@ Start-Sleep -Seconds 30
         $orphanSafetyErrorEscaped = ($_.Exception.Message -match 'safe process-tree termination could not be confirmed')
         $orphanSafetyMarker = [bool]$_.Exception.Data['DxMessagingNonRetryable']
     } finally {
-        if (Test-Path -LiteralPath $orphanPidPath -PathType Leaf) {
-            $orphanId = [int][IO.File]::ReadAllText($orphanPidPath)
-            $orphanWasAlive = $null -ne (Get-Process -Id $orphanId -ErrorAction SilentlyContinue)
-            Stop-Process -Id $orphanId -Force -ErrorAction SilentlyContinue
-            Remove-Item -LiteralPath $orphanPidPath -Force -ErrorAction SilentlyContinue
+        try {
+            $orphanId = Wait-ForPublishedProcessId -Path $orphanPidPath -TimeoutSeconds 5
+            if ($orphanId -gt 0) {
+                $orphanWasAlive = $null -ne (Get-Process -Id $orphanId -ErrorAction SilentlyContinue)
+                Stop-Process -Id $orphanId -Force -ErrorAction SilentlyContinue
+            }
+        } finally {
+            Remove-PublishedProcessIdFile -Path $orphanPidPath
         }
     }
     Assert-That 'quick-exit parent leaves a live detached descendant' ($orphanId -gt 0 -and $orphanWasAlive)

--- a/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
+++ b/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
@@ -191,10 +191,13 @@ Start-Sleep -Seconds 20
     $descendantCode = ConvertTo-EncodedCommand 'Start-Sleep -Seconds 30'
     $pwshPath = $script:UnityCliPath.Replace("'", "''")
     $treePidPath = Join-Path ([IO.Path]::GetTempPath()) "dxm-heartbeat-tree-$([Guid]::NewGuid().ToString('N')).pid"
+    $treePidStagingPath = "$treePidPath.tmp"
     $treePidLiteral = $treePidPath.Replace("'", "''")
+    $treePidStagingLiteral = $treePidStagingPath.Replace("'", "''")
     $descendantParent = @"
 `$child = Start-Process -FilePath '$pwshPath' -ArgumentList @('-NoLogo', '-NoProfile', '-EncodedCommand', '$descendantCode') -PassThru
-[IO.File]::WriteAllText('$treePidLiteral', [string]`$child.Id)
+[IO.File]::WriteAllText('$treePidStagingLiteral', [string]`$child.Id)
+[IO.File]::Move('$treePidStagingLiteral', '$treePidLiteral')
 Start-Sleep -Seconds 30
 "@
     $treeWatcher = [IO.FileSystemWatcher]::new(
@@ -252,9 +255,15 @@ Start-Sleep -Seconds 30
                             $descendantProcess.Dispose()
                         }
                     } finally {
-                        Remove-Item -LiteralPath $treePidPath -Force -ErrorAction SilentlyContinue
-                        if (Test-Path -LiteralPath $treePidPath) {
-                            throw "Tree-probe PID file '$treePidPath' survived cleanup."
+                        $treePidFiles = @($treePidPath, $treePidStagingPath)
+                        foreach ($treePidFile in $treePidFiles) {
+                            Remove-Item -LiteralPath $treePidFile -Force -ErrorAction SilentlyContinue
+                        }
+                        $survivingPidFiles = @(
+                            $treePidFiles | Where-Object { Test-Path -LiteralPath $_ }
+                        )
+                        if ($survivingPidFiles.Count -gt 0) {
+                            throw "Tree-probe PID file cleanup failed: $($survivingPidFiles -join ', ')."
                         }
                     }
                 }

--- a/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
+++ b/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
@@ -224,21 +224,42 @@ Start-Sleep -Seconds 30
             $descendantRemovedByTreeKill = [bool]$descendantProcess.WaitForExit(5000)
         }
     } finally {
-        $treeWatcher.Dispose()
-        if ($null -ne $treeParent) {
-            if (-not $treeParent.HasExited) {
-                $treeParent.Kill($true)
-                [void]$treeParent.WaitForExit(5000)
+        try {
+            $treeWatcher.Dispose()
+        } finally {
+            try {
+                try {
+                    if ($null -ne $treeParent -and -not $treeParent.HasExited) {
+                        $treeParent.Kill($true)
+                        [void]$treeParent.WaitForExit(5000)
+                    }
+                } finally {
+                    if ($null -ne $treeParent) {
+                        $treeParent.Dispose()
+                    }
+                }
+            } finally {
+                try {
+                    if ($descendantId -gt 0) {
+                        Stop-Process -Id $descendantId -Force -ErrorAction SilentlyContinue
+                        if ($null -ne (Get-Process -Id $descendantId -ErrorAction SilentlyContinue)) {
+                            throw "Tree-probe descendant process $descendantId survived cleanup."
+                        }
+                    }
+                } finally {
+                    try {
+                        if ($null -ne $descendantProcess) {
+                            $descendantProcess.Dispose()
+                        }
+                    } finally {
+                        Remove-Item -LiteralPath $treePidPath -Force -ErrorAction SilentlyContinue
+                        if (Test-Path -LiteralPath $treePidPath) {
+                            throw "Tree-probe PID file '$treePidPath' survived cleanup."
+                        }
+                    }
+                }
             }
-            $treeParent.Dispose()
         }
-        if ($descendantId -gt 0) {
-            Stop-Process -Id $descendantId -Force -ErrorAction SilentlyContinue
-        }
-        if ($null -ne $descendantProcess) {
-            $descendantProcess.Dispose()
-        }
-        Remove-Item -LiteralPath $treePidPath -Force -ErrorAction SilentlyContinue
     }
     Assert-That 'tree probe captures the descendant process id' ($descendantId -gt 0)
     Assert-That 'tree probe requests process-tree termination' (

--- a/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
+++ b/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
@@ -165,6 +165,51 @@ function Wait-ForProcessExit {
     return $true
 }
 
+function Invoke-WrapperTreeProbe {
+    # Drives Invoke-UnityCliCaptureWithTimeout end to end with a parent that publishes a
+    # descendant PID, then reports whether that descendant survived the wrapper's own
+    # termination. Returns the wrapper result plus the descendant's fate; the caller asserts.
+    param(
+        [Parameter(Mandatory = $true)][string]$PwshPath,
+        [Parameter(Mandatory = $true)][string]$DescendantCode,
+        [Parameter(Mandatory = $true)][string]$TailCode,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds,
+        [Parameter(Mandatory = $true)][int]$StallSeconds
+    )
+
+    $pidPath = Join-Path ([IO.Path]::GetTempPath()) "dxm-heartbeat-wrapper-$([Guid]::NewGuid().ToString('N')).pid"
+    $finalLiteral = $pidPath.Replace("'", "''")
+    $stagingLiteral = "$pidPath.tmp".Replace("'", "''")
+    $parent = @"
+`$child = Start-Process -FilePath '$PwshPath' -ArgumentList @('-NoLogo', '-NoProfile', '-EncodedCommand', '$DescendantCode') -PassThru
+[IO.File]::WriteAllText('$stagingLiteral', [string]`$child.Id)
+[IO.File]::Move('$stagingLiteral', '$finalLiteral')
+$TailCode
+"@
+    $descendantId = 0
+    try {
+        $wrapperResult = Invoke-UnityCliCaptureWithTimeout `
+            -Arguments @('-NoLogo', '-NoProfile', '-EncodedCommand', (ConvertTo-EncodedCommand $parent)) `
+            -TimeoutSeconds $TimeoutSeconds `
+            -StallSeconds $StallSeconds
+        $descendantId = Wait-ForPublishedProcessId -Path $pidPath -TimeoutSeconds 5
+        $removed = $descendantId -gt 0 -and (Wait-ForProcessExit -Id $descendantId -TimeoutSeconds 10)
+        return [pscustomobject]@{
+            Result       = $wrapperResult
+            DescendantId = $descendantId
+            Removed      = [bool]$removed
+        }
+    } finally {
+        try {
+            if ($descendantId -gt 0) {
+                Stop-Process -Id $descendantId -Force -ErrorAction SilentlyContinue
+            }
+        } finally {
+            Remove-PublishedProcessIdFile -Path $pidPath
+        }
+    }
+}
+
 function Remove-PublishedProcessIdFile {
     # Removes both halves of an atomic PID publish and fails loudly if either
     # survives, so a leaked temp file is a test failure rather than debris.
@@ -336,6 +381,51 @@ Start-Sleep -Seconds 60
         $null -ne $treeConfirmation -and $treeConfirmation.DirectChildExited
     )
     Assert-That 'tree termination removes the descendant' $descendantRemovedByTreeKill
+
+    # The probe above drives Confirm-UnityCliDirectChildExit directly, which is what makes it
+    # independent of startup timing. Invoke-UnityCliCaptureWithTimeout has its OWN Kill($true)
+    # call sites for the stall and wall-clock paths, though, and they are the ones CI actually
+    # runs. If either regressed to a bare Kill(), the parent would exit before
+    # Confirm-UnityCliDirectChildExit ran, that helper would see an already-exited direct child
+    # and skip tree termination, and a reparented Unity installer would be orphaned holding the
+    # editor tree -- with the direct probe above still green. Cover both wrapper paths.
+    $stallTail = @'
+Write-Output 'published'
+Start-Sleep -Seconds 120
+'@
+    # Emitting the last line immediately AFTER publication starts the stall countdown at
+    # publication, so process startup is excluded from this probe by construction rather than by
+    # a generous margin. That is the same defect this file was opened to remove.
+    $stallProbe = Invoke-WrapperTreeProbe `
+        -PwshPath $pwshPath `
+        -DescendantCode $descendantCode `
+        -TailCode $stallTail `
+        -TimeoutSeconds 60 `
+        -StallSeconds 2
+    Assert-That 'wrapper stall path publishes a descendant' ($stallProbe.DescendantId -gt 0)
+    Assert-That 'wrapper stall path is attributed to the heartbeat' $stallProbe.Result.StallKilled
+    Assert-That 'wrapper stall termination removes the descendant' $stallProbe.Removed
+
+    $wallClockTail = @'
+while ($true) {
+    Write-Output 'working'
+    Start-Sleep -Milliseconds 200
+}
+'@
+    # The wall clock runs from process launch, so unlike the stall path its margin cannot be made
+    # structural. Ten seconds against a sub-second publish is a wide margin, and a publish that
+    # did miss fails the first assertion loudly instead of quietly voiding the tree check.
+    $wallClockProbe = Invoke-WrapperTreeProbe `
+        -PwshPath $pwshPath `
+        -DescendantCode $descendantCode `
+        -TailCode $wallClockTail `
+        -TimeoutSeconds 10 `
+        -StallSeconds 30
+    Assert-That 'wrapper wall-clock path publishes a descendant' ($wallClockProbe.DescendantId -gt 0)
+    Assert-That 'wrapper wall-clock path is attributed to the wall clock' (
+        $wallClockProbe.Result.TimedOutWallClock
+    )
+    Assert-That 'wrapper wall-clock termination removes the descendant' $wallClockProbe.Removed
 
     $secondAttemptSuccess = New-FakeTerminationProcess -ExitOnSecondWait $true
     $confirmation = Confirm-UnityCliDirectChildExit -Process $secondAttemptSuccess

--- a/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
+++ b/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
@@ -174,13 +174,15 @@ function Invoke-WrapperTreeProbe {
         [Parameter(Mandatory = $true)][string]$DescendantCode,
         [Parameter(Mandatory = $true)][string]$TailCode,
         [Parameter(Mandatory = $true)][int]$TimeoutSeconds,
-        [Parameter(Mandatory = $true)][int]$StallSeconds
+        [Parameter(Mandatory = $true)][int]$StallSeconds,
+        [string]$PreambleCode = ''
     )
 
     $pidPath = Join-Path ([IO.Path]::GetTempPath()) "dxm-heartbeat-wrapper-$([Guid]::NewGuid().ToString('N')).pid"
     $finalLiteral = $pidPath.Replace("'", "''")
     $stagingLiteral = "$pidPath.tmp".Replace("'", "''")
     $parent = @"
+$PreambleCode
 `$child = Start-Process -FilePath '$PwshPath' -ArgumentList @('-NoLogo', '-NoProfile', '-EncodedCommand', '$DescendantCode') -PassThru
 [IO.File]::WriteAllText('$stagingLiteral', [string]`$child.Id)
 [IO.File]::Move('$stagingLiteral', '$finalLiteral')
@@ -389,20 +391,32 @@ Start-Sleep -Seconds 60
     # Confirm-UnityCliDirectChildExit ran, that helper would see an already-exited direct child
     # and skip tree termination, and a reparented Unity installer would be orphaned holding the
     # editor tree -- with the direct probe above still green. Cover both wrapper paths.
+    # `lastActivityMs` starts at 0, so the FIRST stall window runs from process launch, not from
+    # the first line of output. Emitting before spawning the descendant is what keeps the nested
+    # Start-Process and the PID write out of that first window, leaving only pwsh's own startup
+    # inside it; publication then resets the clock before the silence that trips the heartbeat.
+    #
+    # This is a wide margin, not a structural guarantee. The stall clock cannot be made to start
+    # at publication -- that is the wrapper's contract, and this test does not get to change it.
+    # Eight seconds against a sub-second cold start is the margin, and the probe proves it held
+    # rather than assuming it: the wrapper must have READ the published marker before it killed,
+    # so a cold start that ever did overrun the window fails a named assertion instead of quietly
+    # voiding the tree check below.
     $stallTail = @'
 Write-Output 'published'
 Start-Sleep -Seconds 120
 '@
-    # Emitting the last line immediately AFTER publication starts the stall countdown at
-    # publication, so process startup is excluded from this probe by construction rather than by
-    # a generous margin. That is the same defect this file was opened to remove.
     $stallProbe = Invoke-WrapperTreeProbe `
         -PwshPath $pwshPath `
         -DescendantCode $descendantCode `
         -TailCode $stallTail `
         -TimeoutSeconds 60 `
-        -StallSeconds 2
+        -StallSeconds 8 `
+        -PreambleCode "Write-Output 'starting'"
     Assert-That 'wrapper stall path publishes a descendant' ($stallProbe.DescendantId -gt 0)
+    Assert-That 'wrapper stall path killed only after publication' (
+        @($stallProbe.Result.Output) -contains 'published'
+    )
     Assert-That 'wrapper stall path is attributed to the heartbeat' $stallProbe.Result.StallKilled
     Assert-That 'wrapper stall termination removes the descendant' $stallProbe.Removed
 

--- a/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
+++ b/scripts/__tests__/test-editor-provisioning-heartbeat.ps1
@@ -165,6 +165,43 @@ function Wait-ForProcessExit {
     return $true
 }
 
+function Stop-PublishedDescendant {
+    # The single cleanup path for every probe that publishes a descendant PID. Terminates the
+    # descendant, VERIFIES it actually exited, and only then removes both halves of the publish.
+    #
+    # Two things here are not optional, and each was a real leak before this helper existed:
+    #
+    # - The staging file has to be consulted. A parent that died between WriteAllText and Move
+    #   left the id ONLY there, so recovering from the final path alone learns nothing and then
+    #   deletes the last record of a process that is still running.
+    # - Stop-Process only REQUESTS termination. Deleting the PID file without waiting for the
+    #   exit turns a descendant that ignored the request into an unattributable leak.
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [int]$KnownProcessId = 0
+    )
+
+    try {
+        $descendantId = $KnownProcessId
+        if ($descendantId -le 0) {
+            $descendantId = Wait-ForPublishedProcessId -Path $Path -TimeoutSeconds 5
+        }
+        if ($descendantId -le 0) {
+            # A single check, not a wait: the staging file only survives when the publish was
+            # interrupted, so there is nothing to wait for.
+            $descendantId = Wait-ForPublishedProcessId -Path "$Path.tmp" -TimeoutSeconds 0
+        }
+        if ($descendantId -gt 0) {
+            Stop-Process -Id $descendantId -Force -ErrorAction SilentlyContinue
+            if (-not (Wait-ForProcessExit -Id $descendantId -TimeoutSeconds 10)) {
+                throw "Published descendant process $descendantId ($Path) survived cleanup."
+            }
+        }
+    } finally {
+        Remove-PublishedProcessIdFile -Path $Path
+    }
+}
+
 function Invoke-WrapperTreeProbe {
     # Drives Invoke-UnityCliCaptureWithTimeout end to end with a parent that publishes a
     # descendant PID, then reports whether that descendant survived the wrapper's own
@@ -202,20 +239,9 @@ $TailCode
             Removed      = [bool]$removed
         }
     } finally {
-        try {
-            # Invoke-UnityCliCaptureWithTimeout THROWS on its non-retryable process-safety
-            # error, in which case the try block never reached the publication read and
-            # $descendantId is still 0. Read it here, before the file is removed, or the
-            # descendant leaks along with the only record of which process it was.
-            if ($descendantId -le 0) {
-                $descendantId = Wait-ForPublishedProcessId -Path $pidPath -TimeoutSeconds 5
-            }
-            if ($descendantId -gt 0) {
-                Stop-Process -Id $descendantId -Force -ErrorAction SilentlyContinue
-            }
-        } finally {
-            Remove-PublishedProcessIdFile -Path $pidPath
-        }
+        # Invoke-UnityCliCaptureWithTimeout THROWS on its non-retryable process-safety error, so
+        # $descendantId can still be 0 here; Stop-PublishedDescendant recovers it from the file.
+        Stop-PublishedDescendant -Path $pidPath -KnownProcessId $descendantId
     }
 }
 
@@ -365,20 +391,11 @@ Start-Sleep -Seconds 60
             }
         } finally {
             try {
-                if ($descendantId -gt 0) {
-                    Stop-Process -Id $descendantId -Force -ErrorAction SilentlyContinue
-                    if (-not (Wait-ForProcessExit -Id $descendantId -TimeoutSeconds 10)) {
-                        throw "Tree-probe descendant process $descendantId survived cleanup."
-                    }
+                if ($null -ne $descendantProcess) {
+                    $descendantProcess.Dispose()
                 }
             } finally {
-                try {
-                    if ($null -ne $descendantProcess) {
-                        $descendantProcess.Dispose()
-                    }
-                } finally {
-                    Remove-PublishedProcessIdFile -Path $treePidPath
-                }
+                Stop-PublishedDescendant -Path $treePidPath -KnownProcessId $descendantId
             }
         }
     }
@@ -494,15 +511,13 @@ while ($true) {
         $orphanSafetyErrorEscaped = ($_.Exception.Message -match 'safe process-tree termination could not be confirmed')
         $orphanSafetyMarker = [bool]$_.Exception.Data['DxMessagingNonRetryable']
     } finally {
-        try {
-            $orphanId = Wait-ForPublishedProcessId -Path $orphanPidPath -TimeoutSeconds 5
-            if ($orphanId -gt 0) {
-                $orphanWasAlive = $null -ne (Get-Process -Id $orphanId -ErrorAction SilentlyContinue)
-                Stop-Process -Id $orphanId -Force -ErrorAction SilentlyContinue
-            }
-        } finally {
-            Remove-PublishedProcessIdFile -Path $orphanPidPath
+        $orphanId = Wait-ForPublishedProcessId -Path $orphanPidPath -TimeoutSeconds 5
+        if ($orphanId -gt 0) {
+            # Read liveness BEFORE cleanup terminates it; that is what the assertion below is
+            # about -- a quick-exit parent leaves its descendant detached and running.
+            $orphanWasAlive = $null -ne (Get-Process -Id $orphanId -ErrorAction SilentlyContinue)
         }
+        Stop-PublishedDescendant -Path $orphanPidPath -KnownProcessId $orphanId
     }
     Assert-That 'quick-exit parent leaves a live detached descendant' ($orphanId -gt 0 -and $orphanWasAlive)
     if ($IsWindows) {


### PR DESCRIPTION
## Summary

- replace the tree probe's `FileSystemWatcher` with a bounded wait for a parseable, positive descendant process id;
- apply the same atomic publish, validating read, and verified cleanup to the detached-orphan probe;
- bound the cleanup verification, because `Stop-Process` only requests termination;
- exercise the real `Confirm-UnityCliDirectChildExit` helper directly once the descendant exists;
- record the failure, RCA, and verification evidence in session 179.

## Root cause

Static CI run [30593187996](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/30593187996) failed because the test gave a fresh PowerShell process one second to start, spawn a descendant, and flush that PID through redirected stdout. The heartbeat could correctly kill the parent before the descendant existed, so the test asserted against startup speed instead of process-tree termination. The unchanged commit passed on rerun, confirming the timing race.

Verifying the third review fix uncovered the deeper defect: a same-directory `File.Move` raises `Renamed`, not `Created`, so `WaitForChanged([WatcherChangeTypes]::Created, 10000)` exhausted its full timeout every run and the probe fell through to an unsynchronized `Test-Path`. The watcher synchronized on nothing. A standalone repro confirms it - the published file existed from 300 ms and `WaitForChanged` still returned `TimedOut=True` after 3003 ms of a 3000 ms budget.

The watcher is removed rather than repaired. Validating the parsed content is what makes the read safe: a partially written or empty file fails to parse and the wait continues, with no platform-specific event semantics to get wrong. That also deletes one layer of the cleanup pyramid.

That finding exposed a fifth defect in the cleanup guard itself. `Stop-Process` only requests termination, so verifying it with an immediate `Get-Process` races the kernel and can report a successful kill as a surviving process. A sweep found no other instance; the one production `Stop-Process` in `ensure-editor.ps1` reports its outcome and does not re-check.

No production timeout, heartbeat, or tree-kill behavior changes.

## Red/green evidence

Red, on the previous head:

- standalone `FileSystemWatcher` repro: `WaitForChanged(Created)` returned `TimedOut=True` after 3003 ms while the published file existed from 300 ms;
- focused heartbeat suite wall clock: 34.07 s.

Green:

- focused heartbeat suite: 37 passed, 0 failed, 21.4 s. The 12.6 s saved is the watcher timeout that never fired;
- former-flake loop: 20 consecutive focused-suite passes;
- mutation, direct-child-only kill instead of tree kill: fails on `tree termination removes the descendant` (36 passed, 1 failed), so the assertion discriminates a real regression;
- mutation, parent never publishes the descendant PID: fails on `tree probe captures the descendant process id` (35 passed, 2 failed) instead of throwing a cast error;
- full Node/script suite: 406 passed, 0 failed;
- `npm run validate:all`, spelling, pre-commit, and `git diff --check`: passed.

Fixes #319

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to the heartbeat PowerShell suite and a progress session note; no production scripts or runtime behavior are modified.
> 
> **Overview**
> Fixes an intermittent Windows heartbeat CI failure where a **one-second stall window** could kill the test parent before it spawned and reported a descendant PID, so assertions ran against startup speed instead of process-tree termination. **Production timeout, heartbeat, and tree-kill behavior is unchanged.**
> 
> The tree probe now **waits for an atomically published, parseable descendant PID** (staging write + `Move`, polled read) instead of relying on stdout or `FileSystemWatcher` on `Created`—which never fires for same-directory renames and previously synchronized on nothing. It then drives **`Confirm-UnityCliDirectChildExit` directly** once the descendant exists, with a longer-lived synthetic child so a survivor cannot be mistaken for a successful tree kill.
> 
> Adds **`Invoke-WrapperTreeProbe`** plus stall and wall-clock end-to-end cases so **`Invoke-UnityCliCaptureWithTimeout`’s own `Kill($true)` paths** stay covered (the direct probe alone would stay green if those regressed to bare `Kill()`). Stall setup emits output before spawning the descendant so the first stall window does not reintroduce the startup race.
> 
> Centralizes cleanup in **`Stop-PublishedDescendant`**: recover PID from final or staging file, terminate, **poll for exit** (not immediate `Get-Process` after `Stop-Process`), then remove both publish files—including when the wrapper throws before a read. Session 179 documents RCA and verification evidence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cfc6b08ed4037bd4f35729ba773394afeaaa603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->