### PR TITLE
ci: validate Unity editors before credentials

### DIFF
--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -236,7 +236,6 @@ jobs:
       # Validate before taking the organization lock.
       - name: Validate installed Unity Editor
         id: validate_editor
-        if: ${{ steps.compute.outputs.is-empty != 'true' }}
         timeout-minutes: 10
         shell: pwsh
         run: |

--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -166,6 +166,15 @@ jobs:
           lfs: true
           persist-credentials: false
 
+      - name: Checkout Unity runner maintenance
+        timeout-minutes: 5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: Ambiguous-Interactive/unity-helpers
+          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
+          path: .ci/unity-helpers
+          persist-credentials: false
+
       - name: Print runner diagnostics
         timeout-minutes: 2
         # Composite action runs PowerShell internally; `shell: bash` on this
@@ -248,7 +257,7 @@ jobs:
           } else {
             'EditorOnly'
           }
-          $editor = ./scripts/unity/ensure-editor.ps1 `
+          $editor = & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
             -UnityVersion '${{ matrix.unity-version }}' `
             -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
             -CiManagedOnly `

--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -215,14 +215,6 @@ jobs:
           include-comparisons: "true"
           target: "${{ matrix.test-mode }}"
 
-      - name: Validate Unity license secrets
-        timeout-minutes: 2
-        uses: ./.github/actions/validate-unity-license
-        env:
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-
       # Capture privacy-safe machine specs for the doc/comment provenance line
       # (CPU/RAM/OS only -- collect-machine-specs.ps1 deliberately emits NO
       # hostname or runner name). Runs BEFORE the org lock so it never holds the
@@ -265,6 +257,14 @@ jobs:
             -DiagnosticsPath $diagnosticsFile `
             -RequireHealthyExisting
           "UNITY_EDITOR_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Validate Unity license secrets
+        timeout-minutes: 2
+        uses: ./.github/actions/validate-unity-license
+        env:
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Acquire organization Unity lock
         id: acquire_lock

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,15 @@ jobs:
           lfs: true
           persist-credentials: false
 
+      - name: Checkout Unity runner maintenance
+        timeout-minutes: 5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: Ambiguous-Interactive/unity-helpers
+          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
+          path: .ci/unity-helpers
+          persist-credentials: false
+
       - name: Print runner diagnostics
         timeout-minutes: 2
         # Composite action runs PowerShell internally; `shell: bash` on this
@@ -240,7 +249,7 @@ jobs:
           $diagnosticsPath = Join-Path $artifactsPath 'editor-validation'
           $diagnosticsFile = Join-Path $diagnosticsPath 'ensure-editor-summary.json'
           New-Item -ItemType Directory -Force -Path $diagnosticsPath | Out-Null
-          $editor = ./scripts/unity/ensure-editor.ps1 `
+          $editor = & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
             -UnityVersion '2022.3.45f1' `
             -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
             -CiManagedOnly `
@@ -444,6 +453,15 @@ jobs:
           lfs: true
           persist-credentials: false
 
+      - name: Checkout Unity runner maintenance
+        timeout-minutes: 5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: Ambiguous-Interactive/unity-helpers
+          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
+          path: .ci/unity-helpers
+          persist-credentials: false
+
       - name: Print runner diagnostics
         timeout-minutes: 2
         # Composite action runs PowerShell internally; never use plain
@@ -467,7 +485,7 @@ jobs:
           $diagnosticsPath = Join-Path $artifactsPath 'editor-validation'
           $diagnosticsFile = Join-Path $diagnosticsPath 'ensure-editor-summary.json'
           New-Item -ItemType Directory -Force -Path $diagnosticsPath | Out-Null
-          $editor = ./scripts/unity/ensure-editor.ps1 `
+          $editor = & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
             -UnityVersion '2022.3.45f1' `
             -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
             -CiManagedOnly `

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,12 +229,10 @@ jobs:
         with:
           target: editmode
 
-      # Skip editor validation and Unity work when no test assembly matched.
-      # Lock acquisition remains structurally unconditional for the analyzer;
-      # the expected-empty signal lets result verification report a typed skip.
+      # Unity work skips when no test assembly matched. Editor validation,
+      # credential validation, and lock acquisition remain unconditional.
       - name: Validate installed Unity Editor
         id: validate_editor
-        if: ${{ steps.compute.outputs.is-empty != 'true' }}
         timeout-minutes: 10
         shell: pwsh
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,14 +229,6 @@ jobs:
         with:
           target: editmode
 
-      - name: Validate Unity license secrets
-        timeout-minutes: 2
-        uses: ./.github/actions/validate-unity-license
-        env:
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-
       # Skip editor validation and Unity work when no test assembly matched.
       # Lock acquisition remains structurally unconditional for the analyzer;
       # the expected-empty signal lets result verification report a typed skip.
@@ -258,6 +250,14 @@ jobs:
             -DiagnosticsPath $diagnosticsFile `
             -RequireHealthyExisting
           "UNITY_EDITOR_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Validate Unity license secrets
+        timeout-minutes: 2
+        uses: ./.github/actions/validate-unity-license
+        env:
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Acquire organization Unity lock
         id: acquire_lock
@@ -460,14 +460,6 @@ jobs:
         with:
           node-version: "22.18.0"
 
-      - name: Validate Unity license secrets
-        timeout-minutes: 2
-        uses: ./.github/actions/validate-unity-license
-        env:
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-
       - name: Validate installed Unity Editor
         id: validate_editor
         timeout-minutes: 10
@@ -485,6 +477,14 @@ jobs:
             -DiagnosticsPath $diagnosticsFile `
             -RequireHealthyExisting
           "UNITY_EDITOR_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Validate Unity license secrets
+        timeout-minutes: 2
+        uses: ./.github/actions/validate-unity-license
+        env:
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Acquire organization Unity lock
         id: acquire_lock

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -119,14 +119,6 @@ jobs:
           include-perf: "true"
           target: "${{ matrix.test-mode }}"
 
-      - name: Validate Unity license secrets
-        timeout-minutes: 2
-        uses: ./.github/actions/validate-unity-license
-        env:
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-
       # Skip editor validation and Unity work when no assembly matched. Lock
       # acquisition remains structurally unconditional for the analyzer. The
       # benchmark list is currently non-empty, so this is defense-in-depth.
@@ -148,6 +140,14 @@ jobs:
             -DiagnosticsPath $diagnosticsFile `
             -RequireHealthyExisting
           "UNITY_EDITOR_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Validate Unity license secrets
+        timeout-minutes: 2
+        uses: ./.github/actions/validate-unity-license
+        env:
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Acquire organization Unity lock
         id: acquire_lock

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -119,12 +119,11 @@ jobs:
           include-perf: "true"
           target: "${{ matrix.test-mode }}"
 
-      # Skip editor validation and Unity work when no assembly matched. Lock
-      # acquisition remains structurally unconditional for the analyzer. The
+      # Unity work skips when no assembly matched. Editor validation,
+      # credential validation, and lock acquisition remain unconditional. The
       # benchmark list is currently non-empty, so this is defense-in-depth.
       - name: Validate installed Unity Editor
         id: validate_editor
-        if: ${{ steps.compute.outputs.is-empty != 'true' }}
         timeout-minutes: 10
         shell: pwsh
         run: |

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -68,6 +68,15 @@ jobs:
           lfs: true
           persist-credentials: false
 
+      - name: Checkout Unity runner maintenance
+        timeout-minutes: 5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: Ambiguous-Interactive/unity-helpers
+          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
+          path: .ci/unity-helpers
+          persist-credentials: false
+
       - name: Print runner diagnostics
         timeout-minutes: 2
         # Composite action runs PowerShell internally; `shell: bash` on this
@@ -131,7 +140,7 @@ jobs:
           $diagnosticsPath = Join-Path $artifactsPath 'editor-validation'
           $diagnosticsFile = Join-Path $diagnosticsPath 'ensure-editor-summary.json'
           New-Item -ItemType Directory -Force -Path $diagnosticsPath | Out-Null
-          $editor = ./scripts/unity/ensure-editor.ps1 `
+          $editor = & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
             -UnityVersion '${{ matrix.unity-version }}' `
             -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
             -CiManagedOnly `

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -157,14 +157,6 @@ jobs:
           target: "${{ matrix.test-mode }}"
           runtime-only: "${{ matrix.test-mode == 'standalone' && 'true' || 'false' }}"
 
-      - name: Validate Unity license secrets
-        timeout-minutes: 2
-        uses: ./.github/actions/validate-unity-license
-        env:
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-
       # Skip editor validation and Unity work when no test assembly matched.
       # Lock acquisition remains structurally unconditional for the analyzer;
       # the expected-empty signal lets result verification report a typed skip.
@@ -193,6 +185,14 @@ jobs:
             -DiagnosticsPath $diagnosticsFile `
             -RequireHealthyExisting
           "UNITY_EDITOR_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Validate Unity license secrets
+        timeout-minutes: 2
+        uses: ./.github/actions/validate-unity-license
+        env:
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Require current PR head before lock acquisition
         if: ${{ steps.compute.outputs.is-empty != 'true' }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -157,14 +157,12 @@ jobs:
           target: "${{ matrix.test-mode }}"
           runtime-only: "${{ matrix.test-mode == 'standalone' && 'true' || 'false' }}"
 
-      # Skip editor validation and Unity work when no test assembly matched.
-      # Lock acquisition remains structurally unconditional for the analyzer;
-      # the expected-empty signal lets result verification report a typed skip.
-      # Editors and modules are installed manually by a runner administrator.
-      # CI only verifies the exact trusted tool-cache install and never repairs it.
+      # Unity work skips when no test assembly matched. Editor validation,
+      # credential validation, and lock acquisition remain unconditional.
+      # Editors and modules are installed manually by a runner administrator;
+      # CI only verifies the exact trusted tool-cache install.
       - name: Validate installed Unity Editor
         id: validate_editor
-        if: ${{ steps.compute.outputs.is-empty != 'true' }}
         timeout-minutes: 10
         shell: pwsh
         run: |

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -107,6 +107,15 @@ jobs:
           lfs: true
           persist-credentials: false
 
+      - name: Checkout Unity runner maintenance
+        timeout-minutes: 5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: Ambiguous-Interactive/unity-helpers
+          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
+          path: .ci/unity-helpers
+          persist-credentials: false
+
       - name: Print runner diagnostics
         timeout-minutes: 2
         # Composite action runs PowerShell internally; `shell: bash` on this
@@ -175,7 +184,7 @@ jobs:
           } else {
             'EditorOnly'
           }
-          $editor = ./scripts/unity/ensure-editor.ps1 `
+          $editor = & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
             -UnityVersion '${{ matrix.unity-version }}' `
             -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
             -CiManagedOnly `

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -480,7 +480,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     ];
     for (const [actual, contract, message] of contracts) assert.match(actual, contract, message);
 
-    assert.doesNotMatch(validationStep, /\b(?:install-modules|uninstall)\b/i, label);
+    assert.doesNotMatch(validationStep, /\n {8}if:|\b(?:install-modules|uninstall)\b/i, label);
     assert.doesNotMatch(returnStep, /continue-on-error:/);
 
     const acquireHolder = /holder-id-suffix: (.+)\n/.exec(acquireStep);

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -476,6 +476,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
       [gateStep, /\n        if: always\(\)\n        timeout-minutes: 2\n/],
       [gateStep, /classification-complete: \$\{\{ steps\.cleanup_classification\.outputs\.classification-complete \}\}/],
       [gateStep, /release-outcome: \$\{\{ steps\.release_unity_lock\.outcome \}\}/],
+      [validationStep, /\.ci\/unity-helpers\/scripts\/unity\/ensure-editor\.ps1/],
       ...(["perf-numbers.yml", "unity-benchmarks.yml", "unity-tests.yml"].includes(file) || jobId === "unity-checks" ? [[workStep, /-UnityInstallRoot \(Join-Path \$env:RUNNER_TOOL_CACHE 'u6-v3'\)/, `${label}: licensed work and central return must use the same trusted editor root`]] : [])
     ];
     for (const [actual, contract, message] of contracts) assert.match(actual, contract, message);

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -444,7 +444,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     }
 
     // prettier-ignore
-    const lifecycleNames = ["Validate installed Unity Editor", "Acquire organization Unity lock", "Require acquired Unity lock", licensedWorkName, "Return Unity license", "Classify Unity cleanup evidence", "Release organization Unity lock", "Require confirmed Unity cleanup"];
+    const lifecycleNames = ["Validate installed Unity Editor", "Validate Unity license secrets", "Acquire organization Unity lock", "Require acquired Unity lock", licensedWorkName, "Return Unity license", "Classify Unity cleanup evidence", "Release organization Unity lock", "Require confirmed Unity cleanup"];
     const positions = lifecycleNames.map((name) => job.indexOf(`      - name: ${name}`));
     const sortedPositions = [...positions].sort((a, b) => a - b);
     assert.ok(
@@ -454,7 +454,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     assert.deepEqual(positions, sortedPositions, `${label} lifecycle order`);
 
     // prettier-ignore
-    const [validationStep, acquireStep, requireStep, workStep, returnStep, classifyStep, releaseStep, gateStep] = lifecycleNames.map((name) => getStepBlock(job, name));
+    const [validationStep, credentialStep, acquireStep, requireStep, workStep, returnStep, classifyStep, releaseStep, gateStep] = lifecycleNames.map((name) => getStepBlock(job, name));
 
     // prettier-ignore
     const contracts = [
@@ -463,6 +463,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
       [validationStep, /-InstallRoot \(Join-Path \$env:RUNNER_TOOL_CACHE 'u6-v3'\)/, `${label}: validation and central cleanup must use the same trusted editor root`],
       [validationStep, /-CiManagedOnly/],
       [validationStep, /-RequireHealthyExisting/],
+      [credentialStep, /uses: \.\/\.github\/actions\/validate-unity-license/],
       [acquireStep, /\n        id: acquire_lock\n/],
       [requireStep, /\n        if: \$\{\{ steps\.acquire_lock\.outputs\.acquired != 'true' \}\}\n[\s\S]*\n        run: exit 1\n/],
       [workStep, new RegExp(`\\n        if: \\$\\{\\{ ${licensedCondition} \\}\\}\\n`), label],

--- a/scripts/unity/export-unitypackage.ps1
+++ b/scripts/unity/export-unitypackage.ps1
@@ -597,7 +597,7 @@ $OutputPath = Resolve-FullPath -Path $OutputPath
 
 if (-not $StageOnly) {
     if ([string]::IsNullOrWhiteSpace($UnityEditorPath)) {
-        Write-CiError 'UnityEditorPath is required (set UNITY_EDITOR_PATH or pass -UnityEditorPath); CI must validate a manually installed editor with ensure-editor.ps1 -RequireHealthyExisting first.'
+        Write-CiError 'UnityEditorPath is required (set UNITY_EDITOR_PATH or pass -UnityEditorPath); CI must validate a manually installed editor before export.'
         exit 1
     }
     if (-not (Test-Path -LiteralPath $UnityEditorPath -PathType Leaf)) {

--- a/scripts/unity/run-ci-tests.ps1
+++ b/scripts/unity/run-ci-tests.ps1
@@ -2891,17 +2891,7 @@ if ($GenerateOnly) {
 }
 
 if (-not $UnityEditorPath -or $UnityEditorPath.Trim().Length -eq 0) {
-    $ensureEditor = Join-Path $PSScriptRoot 'ensure-editor.ps1'
-    $provisioningProfile = if ($TestMode -eq 'standalone') { 'StandaloneWindowsIl2Cpp' } else { 'EditorOnly' }
-    $ensureArgs = @{
-        UnityVersion         = $UnityVersion
-        InstallRoot          = $UnityInstallRoot
-        ProvisioningProfile = $provisioningProfile
-    }
-    if ($env:GITHUB_ACTIONS -eq 'true') {
-        $ensureArgs.RequireHealthyExisting = $true
-    }
-    $UnityEditorPath = (& $ensureEditor @ensureArgs | Select-Object -Last 1)
+    throw 'UnityEditorPath is required. Validate the manually installed editor before running Unity tests.'
 }
 
 if (-not (Test-Path -LiteralPath $UnityEditorPath -PathType Leaf)) {


### PR DESCRIPTION
## Summary

- move each bounded `-CiManagedOnly -RequireHealthyExisting` editor check before Unity credential validation
- keep credential validation before organization lock acquisition
- extend the shared lifecycle-order contract to enforce editor -> credentials -> lock across all five licensed jobs

This closes the remaining DxMessaging finding for Ambiguous-Interactive/ambiguous-organization-build-lock#166. CI still never installs or repairs an editor.

## Red/green evidence

- Before: the exact central enrollment analyzer reported `unity-editor-check-after-credentials` for all five licensed jobs.
- After commit `b1d27ab60e4731ddb22e0bbd6998c8dfdd5c4eff`: the same exact-snapshot audit reports zero DxMessaging findings.
- `node --test scripts/__tests__/ci-aggregate-workflow.test.js`: 17/17 passed.
- `npm test`: 397 passed, 9 expected PowerShell-unavailable skips, 0 failed.
- Actionlint, Prettier, markdownlint, spelling, Unity policy, version, packaging, skill, banner, and issue-template checks passed.
- `validate:all` reached analyzer payload verification; that one .NET-backed check could not run locally because `dotnet` is not installed in this environment. Hosted CI remains authoritative for it.

No organization policy, credential, secret, App, runner, or ruleset setting changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes licensed CI ordering and pins editor validation on an external `unity-helpers` checkout; mis-pin or checkout failure would block all Unity legs, but scope is workflow/scripts only with no credential or policy changes.
> 
> **Overview**
> Licensed Unity jobs now **check the tool-cache editor before Unity license secrets**, then acquire the org lock—matching the organization lock analyzer’s expected lifecycle and closing the `unity-editor-check-after-credentials` finding.
> 
> **Shared `unity-helpers` checkout** (pinned ref into `.ci/unity-helpers`) replaces in-repo `./scripts/unity/ensure-editor.ps1` for CI validation. **Editor validation runs unconditionally** (no `if` on empty test assemblies); only the actual Unity test/export steps still skip when there is no work. **`run-ci-tests.ps1`** no longer invokes `ensure-editor`; workflows must set `UNITY_EDITOR_PATH` after validation.
> 
> The **workflow lifecycle test** now asserts editor → credentials → lock order and the external `ensure-editor` path across all five licensed jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit decb71763386d6448c550ac087afb934242b2307. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->