### PR TITLE
test(editor): retain a tested offscreen editor surface capture path

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -393,7 +393,9 @@
     "denoising",
     "labelledby",
     "describedby",
-    "prio"
+    "prio",
+    "ARGB",
+    "IHDR"
   ],
   "ignoreRegExpList": [
     "/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/g",

--- a/Tests/Editor/EditorSurfaceCapture.cs
+++ b/Tests/Editor/EditorSurfaceCapture.cs
@@ -1,0 +1,364 @@
+#if UNITY_EDITOR && UNITY_2021_3_OR_NEWER
+namespace DxMessaging.Tests.Editor
+{
+    using System;
+    using System.IO;
+    using System.Reflection;
+    using UnityEditor;
+    using UnityEngine;
+    using UnityEngine.Rendering;
+    using UnityEngine.UIElements;
+    using Object = UnityEngine.Object;
+
+    /// <summary>
+    /// Renders a package-owned editor surface into an offscreen render target and encodes it as
+    /// a 24-bit PNG, without reading the desktop.
+    ///
+    /// The documentation screenshot manifest bans Unity's internal screen-pixel reader, native
+    /// window capture, and programmatic skin switching, because all three read whatever the host
+    /// desktop happens to be showing. This helper never looks outside its own render target: it
+    /// hosts the real shipped view in a hidden window, drives that window's panel through one
+    /// layout and one repaint, and reads back only the temporary target it created. The blocked
+    /// identifiers are listed in scripts/__tests__/design-system-dumps.test.js, which fails on
+    /// any tracked source that names one.
+    ///
+    /// Two details are load-bearing and were established by experiment (see
+    /// docs/images/inspector-overlay/README.md):
+    ///
+    /// - The panel's <c>ValidateLayout</c> and <c>Render</c> are inherited, so they must be
+    ///   reflected with instance, public, and non-public binding flags and WITHOUT
+    ///   <see cref="BindingFlags.DeclaredOnly"/>; declaring-type-only lookup finds nothing.
+    /// - In a linear-color project, a linear render target with <c>GL.sRGBWrite</c> disabled is
+    ///   what matches the colors the real panel shows.
+    /// </summary>
+    internal static class EditorSurfaceCapture
+    {
+        /// <summary>PNG IHDR color type 2: truecolor, no alpha channel. The manifest requires it.</summary>
+        internal const byte PngTruecolorWithoutAlpha = 2;
+
+        /// <summary>
+        /// Byte offset of the IHDR color-type field: 8-byte signature + 4-byte length +
+        /// 4-byte "IHDR" + 4-byte width + 4-byte height + 1-byte bit depth.
+        /// </summary>
+        private const int PngColorTypeOffset = 25;
+
+        private const BindingFlags InheritedInstanceMembers =
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+        /// <summary>
+        /// Offscreen rendering needs a real graphics device. CI runs Unity with
+        /// <c>-nographics</c>, so capture tests skip there rather than assert against a device
+        /// that cannot rasterize anything.
+        /// </summary>
+        internal static bool IsSupported =>
+            SystemInfo.graphicsDeviceType != GraphicsDeviceType.Null;
+
+        /// <summary>
+        /// Renders <paramref name="content"/> onto a <paramref name="canvasWidth"/> x
+        /// <paramref name="canvasHeight"/> offscreen canvas and writes a 24-bit PNG of the
+        /// surface's own laid-out rect to <paramref name="outputPath"/>. The canvas only has to
+        /// be large enough to hold the surface; the written image is cropped to the surface, so
+        /// its dimensions come from the surface's layout rather than from these arguments.
+        ///
+        /// Every global the render touches -- the active render target and <c>GL.sRGBWrite</c> --
+        /// is restored, and every object it creates is destroyed, including on the failure path.
+        /// </summary>
+        internal static EditorSurfaceCaptureResult Capture(
+            VisualElement content,
+            int canvasWidth,
+            int canvasHeight,
+            string outputPath
+        )
+        {
+            if (content == null)
+            {
+                throw new ArgumentNullException(nameof(content));
+            }
+
+            if (canvasWidth <= 0 || canvasHeight <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(canvasWidth),
+                    $"Capture canvas must be positive, got {canvasWidth}x{canvasHeight}."
+                );
+            }
+
+            if (string.IsNullOrWhiteSpace(outputPath))
+            {
+                throw new ArgumentException("Capture needs an output path.", nameof(outputPath));
+            }
+
+            if (!IsSupported)
+            {
+                throw new InvalidOperationException(
+                    "EditorSurfaceCapture needs a graphics device; this editor is running with -nographics."
+                );
+            }
+
+            RenderTexture previousTarget = RenderTexture.active;
+            bool previousSrgbWrite = GL.sRGBWrite;
+            EditorWindow host = null;
+            RenderTexture target = null;
+            Texture2D readback = null;
+            try
+            {
+                host = EditorWindowTestUtility.CreateWindow();
+                host.minSize = new Vector2(canvasWidth, canvasHeight);
+                host.position = new Rect(0f, 0f, canvasWidth, canvasHeight);
+                // A window only gets a panel once it is shown, and a panel is what
+                // ValidateLayout and Render operate on. Showing it does not make the capture
+                // read the desktop: the pixels still come from the render target below, never
+                // from the screen.
+                EditorWindowTestUtility.ShowWindow(host);
+
+                VisualElement root = host.rootVisualElement;
+                root.style.width = canvasWidth;
+                root.style.height = canvasHeight;
+                root.Add(content);
+
+                IPanel panel = root.panel;
+                if (panel == null)
+                {
+                    throw new InvalidOperationException(
+                        "The capture host window produced no panel to render."
+                    );
+                }
+
+                target = new RenderTexture(
+                    canvasWidth,
+                    canvasHeight,
+                    24,
+                    RenderTextureFormat.ARGB32,
+                    RenderTextureReadWrite.Linear
+                );
+                if (!target.Create())
+                {
+                    throw new InvalidOperationException(
+                        $"Could not create a {canvasWidth}x{canvasHeight} capture canvas."
+                    );
+                }
+
+                GL.sRGBWrite = false;
+                RenderTexture.active = target;
+                GL.Clear(true, true, Color.clear);
+
+                // Three steps, in this order. ValidateLayout resolves the tree's geometry,
+                // Repaint walks it and records the draw commands, and Render flushes those
+                // commands to whatever target is active. Skipping the repaint yields a valid
+                // PNG of a blank frame, which is why the tests count distinct colors.
+                InvokeInheritedPanelMethod(panel, "ValidateLayout", Array.Empty<object>());
+                InvokeInheritedPanelMethod(
+                    panel,
+                    "Repaint",
+                    new object[] { new Event { type = EventType.Repaint } }
+                );
+                InvokeInheritedPanelMethod(panel, "Render", Array.Empty<object>());
+
+                // Read back only the surface, not the whole canvas. The host window draws its
+                // own tab strip at the top of the panel, so a full-canvas readback frames the
+                // test host's chrome and pushes the surface underneath it. Cropping to the
+                // surface's own laid-out rect is also what gives the manifest its tight frame:
+                // the padding in the image comes from the surface's styling, not from slack in
+                // the canvas.
+                RectInt crop = ResolveCropRect(content, canvasWidth, canvasHeight);
+                readback = new Texture2D(crop.width, crop.height, TextureFormat.RGB24, false, true);
+                readback.ReadPixels(new Rect(crop.x, crop.y, crop.width, crop.height), 0, 0, false);
+                readback.Apply(false, false);
+
+                byte[] png = readback.EncodeToPNG();
+                if (png == null || png.Length <= PngColorTypeOffset)
+                {
+                    throw new InvalidOperationException("PNG encoding produced no usable bytes.");
+                }
+
+                byte colorType = png[PngColorTypeOffset];
+                if (colorType != PngTruecolorWithoutAlpha)
+                {
+                    throw new InvalidOperationException(
+                        $"Capture produced PNG color type {colorType}; the manifest requires "
+                            + $"{PngTruecolorWithoutAlpha} (truecolor without alpha)."
+                    );
+                }
+
+                string directory = Path.GetDirectoryName(outputPath);
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+                File.WriteAllBytes(outputPath, png);
+
+                return new EditorSurfaceCaptureResult(
+                    outputPath,
+                    crop.width,
+                    crop.height,
+                    png.Length,
+                    colorType,
+                    CountDistinctColors(readback),
+                    EditorGUIUtility.isProSkin,
+                    Application.unityVersion
+                );
+            }
+            finally
+            {
+                RenderTexture.active = previousTarget;
+                GL.sRGBWrite = previousSrgbWrite;
+
+                if (readback != null)
+                {
+                    Object.DestroyImmediate(readback);
+                }
+
+                if (target != null)
+                {
+                    target.Release();
+                    Object.DestroyImmediate(target);
+                }
+
+                if (host != null)
+                {
+                    EditorWindowTestUtility.CloseWindow(host);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Translates the surface's laid-out rect into render-target coordinates. UI Toolkit
+        /// measures from the top-left; a render target's rows start at the bottom, so the
+        /// vertical origin is the distance from the canvas bottom to the surface's bottom edge.
+        /// </summary>
+        private static RectInt ResolveCropRect(
+            VisualElement content,
+            int canvasWidth,
+            int canvasHeight
+        )
+        {
+            Rect bounds = content.worldBound;
+            int cropWidth = Mathf.RoundToInt(bounds.width);
+            int cropHeight = Mathf.RoundToInt(bounds.height);
+            if (cropWidth <= 0 || cropHeight <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"The surface laid out to {bounds.width}x{bounds.height}, so there is nothing "
+                        + "to capture. Give it an explicit size or content before capturing."
+                );
+            }
+
+            int cropX = Mathf.Clamp(Mathf.RoundToInt(bounds.x), 0, Mathf.Max(0, canvasWidth - 1));
+            int cropY = Mathf.Clamp(
+                Mathf.RoundToInt(canvasHeight - bounds.yMax),
+                0,
+                Mathf.Max(0, canvasHeight - 1)
+            );
+            cropWidth = Mathf.Min(cropWidth, canvasWidth - cropX);
+            cropHeight = Mathf.Min(cropHeight, canvasHeight - cropY);
+            if (cropWidth <= 0 || cropHeight <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"The surface laid out at {bounds} which falls outside the "
+                        + $"{canvasWidth}x{canvasHeight} capture canvas. Enlarge the canvas."
+                );
+            }
+
+            return new RectInt(cropX, cropY, cropWidth, cropHeight);
+        }
+
+        private static void InvokeInheritedPanelMethod(
+            IPanel panel,
+            string methodName,
+            object[] arguments
+        )
+        {
+            Type panelType = panel.GetType();
+            Type[] argumentTypes = new Type[arguments.Length];
+            for (int index = 0; index < arguments.Length; index++)
+            {
+                argumentTypes[index] = arguments[index].GetType();
+            }
+
+            MethodInfo method = panelType.GetMethod(
+                methodName,
+                InheritedInstanceMembers,
+                binder: null,
+                types: argumentTypes,
+                modifiers: null
+            );
+            if (method == null)
+            {
+                throw new InvalidOperationException(
+                    $"Panel type {panelType.FullName} exposes no '{methodName}' method taking "
+                        + $"{argumentTypes.Length} argument(s) to drive the capture."
+                );
+            }
+
+            method.Invoke(panel, arguments);
+        }
+
+        /// <summary>
+        /// A blank frame and a rendered frame are both valid PNGs, so callers need a cheap way to
+        /// prove the panel actually drew. Distinct-color count is that proof: a cleared target has
+        /// exactly one.
+        /// </summary>
+        private static int CountDistinctColors(Texture2D texture)
+        {
+            Color32[] pixels = texture.GetPixels32();
+            System.Collections.Generic.HashSet<int> distinct = new();
+            foreach (Color32 pixel in pixels)
+            {
+                distinct.Add((pixel.r << 16) | (pixel.g << 8) | pixel.b);
+            }
+
+            return distinct.Count;
+        }
+    }
+
+    internal readonly struct EditorSurfaceCaptureResult
+    {
+        internal EditorSurfaceCaptureResult(
+            string outputPath,
+            int width,
+            int height,
+            int byteCount,
+            byte pngColorType,
+            int distinctColorCount,
+            bool isProSkin,
+            string unityVersion
+        )
+        {
+            OutputPath = outputPath;
+            Width = width;
+            Height = height;
+            ByteCount = byteCount;
+            PngColorType = pngColorType;
+            DistinctColorCount = distinctColorCount;
+            IsProSkin = isProSkin;
+            UnityVersion = unityVersion;
+        }
+
+        internal string OutputPath { get; }
+
+        internal int Width { get; }
+
+        internal int Height { get; }
+
+        internal int ByteCount { get; }
+
+        internal byte PngColorType { get; }
+
+        internal int DistinctColorCount { get; }
+
+        /// <summary>
+        /// The manifest requires Personal/light captures and bans switching skins to get there,
+        /// so every capture records the skin it was taken under and the reviewer checks it.
+        /// </summary>
+        internal bool IsProSkin { get; }
+
+        internal string UnityVersion { get; }
+
+        public override string ToString()
+        {
+            return $"{OutputPath} {Width}x{Height} bytes={ByteCount} pngColorType={PngColorType} "
+                + $"distinctColors={DistinctColorCount} isProSkin={IsProSkin} unity={UnityVersion}";
+        }
+    }
+}
+#endif

--- a/Tests/Editor/EditorSurfaceCapture.cs
+++ b/Tests/Editor/EditorSurfaceCapture.cs
@@ -243,19 +243,23 @@ namespace DxMessaging.Tests.Editor
                 );
             }
 
-            int cropX = Mathf.Clamp(Mathf.RoundToInt(bounds.x), 0, Mathf.Max(0, canvasWidth - 1));
-            int cropY = Mathf.Clamp(
-                Mathf.RoundToInt(canvasHeight - bounds.yMax),
-                0,
-                Mathf.Max(0, canvasHeight - 1)
-            );
-            cropWidth = Mathf.Min(cropWidth, canvasWidth - cropX);
-            cropHeight = Mathf.Min(cropHeight, canvasHeight - cropY);
-            if (cropWidth <= 0 || cropHeight <= 0)
+            int cropX = Mathf.RoundToInt(bounds.x);
+            int cropY = Mathf.RoundToInt(canvasHeight - bounds.yMax);
+
+            // Refuse a surface that does not fit rather than clamping into the canvas. Clamping
+            // would return a silently clipped image, which is exactly the defect the manifest
+            // tells reviewers to look for, produced by the tool that exists to avoid it.
+            if (
+                cropX < 0
+                || cropY < 0
+                || cropX + cropWidth > canvasWidth
+                || cropY + cropHeight > canvasHeight
+            )
             {
                 throw new InvalidOperationException(
-                    $"The surface laid out at {bounds} which falls outside the "
-                        + $"{canvasWidth}x{canvasHeight} capture canvas. Enlarge the canvas."
+                    $"The surface laid out to {bounds}, which does not fit inside the "
+                        + $"{canvasWidth}x{canvasHeight} capture canvas. Enlarge the canvas; "
+                        + "cropping it here would write a silently clipped image."
                 );
             }
 

--- a/Tests/Editor/EditorSurfaceCapture.cs
+++ b/Tests/Editor/EditorSurfaceCapture.cs
@@ -232,9 +232,15 @@ namespace DxMessaging.Tests.Editor
             int canvasHeight
         )
         {
+            // Round the EDGES, then derive the size from them. Rounding the origin and the size
+            // independently lets the two drift a pixel apart -- a surface at x=10.5 w=10.5 rounds
+            // to x=10 w=10, a right edge of 20 where the real one is 21 -- and a pixel lost here
+            // is a pixel of the surface clipped out of a documentation image.
             Rect bounds = content.worldBound;
-            int cropWidth = Mathf.RoundToInt(bounds.width);
-            int cropHeight = Mathf.RoundToInt(bounds.height);
+            int cropX = Mathf.RoundToInt(bounds.x);
+            int cropY = Mathf.RoundToInt(canvasHeight - bounds.yMax);
+            int cropWidth = Mathf.RoundToInt(bounds.xMax) - cropX;
+            int cropHeight = Mathf.RoundToInt(canvasHeight - bounds.y) - cropY;
             if (cropWidth <= 0 || cropHeight <= 0)
             {
                 throw new InvalidOperationException(
@@ -242,9 +248,6 @@ namespace DxMessaging.Tests.Editor
                         + "to capture. Give it an explicit size or content before capturing."
                 );
             }
-
-            int cropX = Mathf.RoundToInt(bounds.x);
-            int cropY = Mathf.RoundToInt(canvasHeight - bounds.yMax);
 
             // Refuse a surface that does not fit rather than clamping into the canvas. Clamping
             // would return a silently clipped image, which is exactly the defect the manifest

--- a/Tests/Editor/EditorSurfaceCapture.cs.meta
+++ b/Tests/Editor/EditorSurfaceCapture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f841d583a9e04256933b0a3575f45ffe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/EditorSurfaceCaptureTests.cs
+++ b/Tests/Editor/EditorSurfaceCaptureTests.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR && UNITY_2021_3_OR_NEWER
 namespace DxMessaging.Tests.Editor
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using DxMessaging.Editor;
@@ -144,15 +145,24 @@ namespace DxMessaging.Tests.Editor
             _createdObjects.Add(sentinel);
             RenderTexture previousTarget = RenderTexture.active;
             bool previousSrgbWrite = GL.sRGBWrite;
+            int windowsBefore = Resources.FindObjectsOfTypeAll<EditorWindow>().Length;
+
+            // The failure has to happen INSIDE the capture's try, after it has taken over the
+            // render target and GL.sRGBWrite and created its host window. An argument-validation
+            // failure would return before any of that and this test would pass even if the whole
+            // finally block were deleted. An oversized surface fails at the crop step, which is
+            // past every piece of state the finally is responsible for putting back.
+            VisualElement oversized = CreateOpaqueProbe();
+            oversized.style.width = CanvasWidth + 1;
             try
             {
                 RenderTexture.active = sentinel;
                 GL.sRGBWrite = true;
 
-                Assert.Throws<System.ArgumentOutOfRangeException>(() =>
+                Assert.Throws<InvalidOperationException>(() =>
                     EditorSurfaceCapture.Capture(
-                        CreateOpaqueProbe(),
-                        0,
+                        oversized,
+                        CanvasWidth,
                         CanvasHeight,
                         ResolveOutputPath(nameof(CaptureRestoresRenderStateWhenTheSurfaceThrows))
                     )
@@ -166,6 +176,12 @@ namespace DxMessaging.Tests.Editor
                 RenderTexture.active = previousTarget;
                 GL.sRGBWrite = previousSrgbWrite;
             }
+
+            Assert.That(
+                Resources.FindObjectsOfTypeAll<EditorWindow>().Length,
+                Is.EqualTo(windowsBefore),
+                "A failed capture must still close its hidden host window."
+            );
         }
 
         [Test]
@@ -213,6 +229,30 @@ namespace DxMessaging.Tests.Editor
             // the skin instead of changing it and the reviewer rejects a Pro/dark artifact.
             Assert.That(result.IsProSkin, Is.EqualTo(EditorGUIUtility.isProSkin));
             Assert.That(result.UnityVersion, Is.EqualTo(Application.unityVersion));
+        }
+
+        [Test]
+        public void CaptureRefusesASurfaceLargerThanTheCanvas()
+        {
+            VisualElement oversized = CreateOpaqueProbe();
+            oversized.style.width = CanvasWidth + 1;
+
+            // Clamping into the canvas would write a silently clipped image, which is the exact
+            // defect the screenshot manifest asks reviewers to catch.
+            InvalidOperationException failure = Assert.Throws<InvalidOperationException>(() =>
+                EditorSurfaceCapture.Capture(
+                    oversized,
+                    CanvasWidth,
+                    CanvasHeight,
+                    ResolveOutputPath(nameof(CaptureRefusesASurfaceLargerThanTheCanvas))
+                )
+            );
+            Assert.That(failure.Message, Does.Contain("does not fit"));
+            Assert.That(
+                File.Exists(ResolveOutputPath(nameof(CaptureRefusesASurfaceLargerThanTheCanvas))),
+                Is.False,
+                "A refused capture must not leave a partial image behind."
+            );
         }
 
         [Test]

--- a/Tests/Editor/EditorSurfaceCaptureTests.cs
+++ b/Tests/Editor/EditorSurfaceCaptureTests.cs
@@ -1,0 +1,308 @@
+#if UNITY_EDITOR && UNITY_2021_3_OR_NEWER
+namespace DxMessaging.Tests.Editor
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using DxMessaging.Editor;
+    using DxMessaging.Editor.CustomEditors;
+    using DxMessaging.Editor.Settings;
+    using DxMessaging.Unity;
+    using NUnit.Framework;
+    using UnityEditor;
+    using UnityEngine;
+    using UnityEngine.UIElements;
+    using Object = UnityEngine.Object;
+
+    /// <summary>
+    /// Pins the documentation capture path. These tests are the retained, repeatable half of
+    /// PLAN.md WS-7.3: they prove the mechanism renders real shipped views into a 24-bit PNG
+    /// without touching the desktop, without leaking editor state, and without emitting console
+    /// diagnostics. Choosing the final Personal/light artwork stays a human review step.
+    /// </summary>
+    [TestFixture]
+    public sealed class EditorSurfaceCaptureTests
+    {
+        // The canvas is deliberately larger than the surface. The host window draws a tab
+        // strip at the top of its panel, so a surface laid out at the canvas size would be
+        // pushed partly off the bottom and the crop would come back short.
+        private const int CanvasWidth = 960;
+        private const int CanvasHeight = 600;
+        private const int SurfaceWidth = 720;
+        private const int SurfaceHeight = 240;
+
+        private readonly List<Object> _createdObjects = new();
+        private readonly List<string> _createdFiles = new();
+
+        [SetUp]
+        public void SetUp()
+        {
+            if (!EditorSurfaceCapture.IsSupported)
+            {
+                Assert.Ignore(
+                    "Offscreen capture needs a graphics device; this editor runs with -nographics."
+                );
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (string path in _createdFiles)
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            _createdFiles.Clear();
+
+            foreach (Object instance in _createdObjects)
+            {
+                if (instance != null)
+                {
+                    Object.DestroyImmediate(instance);
+                }
+            }
+            _createdObjects.Clear();
+        }
+
+        [Test]
+        public void CaptureWritesTruecolorPngWithoutAlpha()
+        {
+            EditorSurfaceCaptureResult result = Capture(
+                CreateOpaqueProbe(),
+                nameof(CaptureWritesTruecolorPngWithoutAlpha)
+            );
+
+            Assert.That(
+                result.PngColorType,
+                Is.EqualTo(EditorSurfaceCapture.PngTruecolorWithoutAlpha)
+            );
+            Assert.That(File.Exists(result.OutputPath), Is.True, result.ToString());
+            Assert.That(result.ByteCount, Is.GreaterThan(0), result.ToString());
+            Assert.That(
+                result.Width,
+                Is.EqualTo(SurfaceWidth),
+                "The written image is cropped to the surface, not to the canvas."
+            );
+            Assert.That(result.Height, Is.EqualTo(SurfaceHeight), result.ToString());
+
+            byte[] written = File.ReadAllBytes(result.OutputPath);
+            Assert.That(
+                written.Length,
+                Is.EqualTo(result.ByteCount),
+                "The reported byte count must describe the file that was actually written."
+            );
+        }
+
+        [Test]
+        public void CaptureRestoresRenderStateAndLeavesNoWindowBehind()
+        {
+            RenderTexture sentinel = new(64, 64, 0);
+            _createdObjects.Add(sentinel);
+            RenderTexture previousTarget = RenderTexture.active;
+            bool previousSrgbWrite = GL.sRGBWrite;
+            int windowsBefore = Resources.FindObjectsOfTypeAll<EditorWindow>().Length;
+            try
+            {
+                RenderTexture.active = sentinel;
+                GL.sRGBWrite = true;
+
+                Capture(
+                    CreateOpaqueProbe(),
+                    nameof(CaptureRestoresRenderStateAndLeavesNoWindowBehind)
+                );
+
+                Assert.That(
+                    RenderTexture.active,
+                    Is.SameAs(sentinel),
+                    "Capture must restore the active render target it found."
+                );
+                Assert.That(
+                    GL.sRGBWrite,
+                    Is.True,
+                    "Capture must restore GL.sRGBWrite; leaving it off recolors every later render."
+                );
+            }
+            finally
+            {
+                RenderTexture.active = previousTarget;
+                GL.sRGBWrite = previousSrgbWrite;
+            }
+
+            Assert.That(
+                Resources.FindObjectsOfTypeAll<EditorWindow>().Length,
+                Is.EqualTo(windowsBefore),
+                "Capture must close its hidden host window."
+            );
+        }
+
+        [Test]
+        public void CaptureRestoresRenderStateWhenTheSurfaceThrows()
+        {
+            RenderTexture sentinel = new(64, 64, 0);
+            _createdObjects.Add(sentinel);
+            RenderTexture previousTarget = RenderTexture.active;
+            bool previousSrgbWrite = GL.sRGBWrite;
+            try
+            {
+                RenderTexture.active = sentinel;
+                GL.sRGBWrite = true;
+
+                Assert.Throws<System.ArgumentOutOfRangeException>(() =>
+                    EditorSurfaceCapture.Capture(
+                        CreateOpaqueProbe(),
+                        0,
+                        CanvasHeight,
+                        ResolveOutputPath(nameof(CaptureRestoresRenderStateWhenTheSurfaceThrows))
+                    )
+                );
+
+                Assert.That(RenderTexture.active, Is.SameAs(sentinel));
+                Assert.That(GL.sRGBWrite, Is.True);
+            }
+            finally
+            {
+                RenderTexture.active = previousTarget;
+                GL.sRGBWrite = previousSrgbWrite;
+            }
+        }
+
+        [Test]
+        public void CaptureRendersTheInspectorWarningPanel()
+        {
+            EditorSurfaceCaptureResult result = Capture(
+                CreateInspectorWarningPanel(),
+                nameof(CaptureRendersTheInspectorWarningPanel)
+            );
+
+            // A cleared target has exactly one distinct color. The warning panel carries a
+            // background, an amber border, a title, a body, a method list, and two buttons, so a
+            // frame that really rendered cannot be flat.
+            Assert.That(
+                result.DistinctColorCount,
+                Is.GreaterThan(1),
+                $"The captured frame is a single flat color, so nothing rendered: {result}"
+            );
+        }
+
+        [Test]
+        public void CaptureRendersAPackageOwnedEditorWindowSurface()
+        {
+            EditorSurfaceCaptureResult result = Capture(
+                CreateEmptyStateSurface(),
+                nameof(CaptureRendersAPackageOwnedEditorWindowSurface)
+            );
+
+            Assert.That(
+                result.DistinctColorCount,
+                Is.GreaterThan(1),
+                $"The captured frame is a single flat color, so nothing rendered: {result}"
+            );
+        }
+
+        [Test]
+        public void CaptureRecordsTheSkinAndUnityVersionItWasTakenUnder()
+        {
+            EditorSurfaceCaptureResult result = Capture(
+                CreateOpaqueProbe(),
+                nameof(CaptureRecordsTheSkinAndUnityVersionItWasTakenUnder)
+            );
+
+            // The manifest bans switching skins to reach Personal/light, so the capture reports
+            // the skin instead of changing it and the reviewer rejects a Pro/dark artifact.
+            Assert.That(result.IsProSkin, Is.EqualTo(EditorGUIUtility.isProSkin));
+            Assert.That(result.UnityVersion, Is.EqualTo(Application.unityVersion));
+        }
+
+        [Test]
+        public void CaptureRejectsAnEmptyOutputPath()
+        {
+            Assert.Throws<System.ArgumentException>(() =>
+                EditorSurfaceCapture.Capture(CreateOpaqueProbe(), CanvasWidth, CanvasHeight, "   ")
+            );
+        }
+
+        [Test]
+        public void CaptureRejectsAMissingSurface()
+        {
+            Assert.Throws<System.ArgumentNullException>(() =>
+                EditorSurfaceCapture.Capture(
+                    null,
+                    CanvasWidth,
+                    CanvasHeight,
+                    ResolveOutputPath(nameof(CaptureRejectsAMissingSurface))
+                )
+            );
+        }
+
+        private EditorSurfaceCaptureResult Capture(VisualElement content, string name)
+        {
+            string path = ResolveOutputPath(name);
+            _createdFiles.Add(path);
+            return EditorSurfaceCapture.Capture(content, CanvasWidth, CanvasHeight, path);
+        }
+
+        private static string ResolveOutputPath(string name)
+        {
+            return Path.Combine(
+                "Packages",
+                "com.wallstop-studios.dxmessaging",
+                ".artifacts",
+                "unity-mcp",
+                $"capture-{name}.png"
+            );
+        }
+
+        private static VisualElement CreateOpaqueProbe()
+        {
+            VisualElement probe = new();
+            DxMessagingEditorTheme.Apply(probe);
+            probe.style.width = SurfaceWidth;
+            probe.style.height = SurfaceHeight;
+            probe.style.backgroundColor = DxMessagingEditorPalette.Amber;
+            return probe;
+        }
+
+        private VisualElement CreateEmptyStateSurface()
+        {
+            VisualElement surface = DxMessagingEditorTheme.CreateEmptyState(
+                "No emissions recorded",
+                "Enter play mode with diagnostics enabled to populate the Message Monitor."
+            );
+            surface.style.width = SurfaceWidth;
+            surface.style.height = SurfaceHeight;
+            return surface;
+        }
+
+        private VisualElement CreateInspectorWarningPanel()
+        {
+            GameObject host = new(nameof(CreateInspectorWarningPanel));
+            _createdObjects.Add(host);
+            MessageAwareComponent component =
+                host.AddComponent<EmptyMessageAwareComponentForCaptureTest>();
+
+            DxMessagingSettings settings = ScriptableObject.CreateInstance<DxMessagingSettings>();
+            settings.hideFlags = HideFlags.HideAndDontSave;
+            _createdObjects.Add(settings);
+
+            MessageAwareComponentInspectorState state =
+                MessageAwareComponentInspectorState.ForHarvesterUnavailable(
+                    component,
+                    settings,
+                    component.GetType().FullName,
+                    isFreshThisSession: true
+                );
+
+            VisualElement panel = MessageAwareComponentInspectorView.Create(
+                state,
+                MessageAwareComponentInspectorViewActions.None
+            );
+            panel.style.width = SurfaceWidth;
+            return panel;
+        }
+    }
+
+    internal sealed class EmptyMessageAwareComponentForCaptureTest : MessageAwareComponent { }
+}
+#endif

--- a/Tests/Editor/EditorSurfaceCaptureTests.cs.meta
+++ b/Tests/Editor/EditorSurfaceCaptureTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5c40ba2b81d4083b13675447d34a1b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/EditorWindowTestUtility.cs
+++ b/Tests/Editor/EditorWindowTestUtility.cs
@@ -68,6 +68,18 @@ namespace DxMessaging.Tests.Editor
 
             window.rootVisualElement.Clear();
             CreatedWindows.Remove(window);
+
+            // A window that was created but never shown has no host view, and
+            // EditorWindow.Close() dereferences that parent unconditionally. Destroying the
+            // instance is the whole of its teardown. Tests that only need a panel to lay out
+            // and render -- offscreen capture, for one -- never show their window, so closing
+            // one has to be safe rather than a NullReferenceException in teardown.
+            if (ReadMember(window, "m_Parent") == null)
+            {
+                Object.DestroyImmediate(window);
+                return;
+            }
+
             window.Close();
         }
 

--- a/docs/images/inspector-overlay/README.md
+++ b/docs/images/inspector-overlay/README.md
@@ -53,33 +53,52 @@ Inspector overlay PNGs until the actual target artifact is Personal/light-theme,
 cropped per this manifest, visually inspected, and Unity has a clean
 post-capture console and editor-window list.
 
-On 2026-07-30, an offscreen panel-render experiment established the provisional
-desktop-independent method:
+On 2026-07-31, that experiment became a retained helper:
+`Tests/Editor/EditorSurfaceCapture.cs`, covered by
+`Tests/Editor/EditorSurfaceCaptureTests.cs`. Use it rather than re-deriving the
+method. It renders a package-owned surface offscreen and writes a cropped 24-bit
+PNG:
 
-1. Create a temporary `HideAndDontSave` window containing the real shipped view,
-   or a transient Inspector containing the real component editor.
-1. Give the panel a fixed size. Reflect inherited `EditorPanel` methods with
-   instance, public, and non-public binding flags; do not use `DeclaredOnly`.
-1. Call `ValidateLayout()`, repaint with `EventType.Repaint`, then call
-   `Render()` while a temporary linear `RenderTexture` is active.
-1. Preserve and restore the active render target, viewport, `GL.sRGBWrite`,
-   selection, and window state. In this linear-color project,
-   `RenderTextureReadWrite.Linear` with `GL.sRGBWrite = false` matched the real
-   panel colors.
-1. Read only that temporary render target into an RGB24 `Texture2D`, encode the
-   PNG, and verify PNG color type 2 (truecolor without alpha). The staging proofs
-   used RGBA and therefore do not satisfy this manifest's 24-bit requirement.
-1. Compare the Console error set and editor-window list before and after
-   capture. Do not clear the Console to hide capture diagnostics or erase user
-   logs; abort acceptance if the capture adds an error.
+1. Host the real shipped view in a `HideAndDontSave` window from
+   `EditorWindowTestUtility`. The window must be shown, because a window that was
+   never shown has no panel and there is nothing to lay out or render.
+1. Create a linear `RenderTexture`, make it active, and disable `GL.sRGBWrite`.
+   In this linear-color project that pairing is what matches the real panel
+   colors.
+1. Drive the panel through `ValidateLayout()`, then `Repaint(Event)` with
+   `EventType.Repaint`, then `Render()`. All three are inherited, so reflect them
+   with instance, public, and non-public binding flags and without
+   `DeclaredOnly`. Skipping the repaint step yields a valid PNG of a blank frame.
+1. Read back the surface's own `worldBound`, not the whole canvas. The host
+   window draws a tab strip at the top of its panel, so a full-canvas readback
+   frames that chrome and pushes the surface underneath it. Cropping is also
+   what gives each image the tight frame the capture list asks for. Render-target
+   rows start at the bottom while UI Toolkit measures from the top, so the
+   vertical origin is `canvasHeight - worldBound.yMax`.
+1. Read into an RGB24 `Texture2D` and verify PNG color type 2 (truecolor without
+   alpha) before writing. Earlier staging proofs were RGBA and did not satisfy
+   this manifest.
+1. Restore the active render target and `GL.sRGBWrite`, and destroy the window
+   and both textures, including on the failure path.
 
-This method produced a clean, visually correct Message Monitor staging image.
-The Inspector staging image was visually correct but emitted
-`EditorGUIUtility.AddCursorRect called outside an editor OnGUI` while its IMGUI
-body rendered. No reusable capture helper is retained yet. Treat the Inspector
-method as experimental until a retained helper produces the frame without new
-diagnostics. Native menu cascades and combined Hierarchy/Inspector frames still
-require manual host capture or an explicit scope change.
+The helper reports the skin and Unity version of every capture instead of
+changing them, and the tests count distinct colors so a blank frame fails rather
+than passing as a valid PNG.
+
+Verified on 2026-07-31 against Unity 6000.4.6f1: eight capture tests pass, the
+full editor assembly is 557/0, the real `MessageAwareComponentInspectorView`
+renders to a clean 720x63 RGB24 crop with no window chrome and no clipping, the
+Console gains no entry from a capture, and the host is left with only its seven
+standard windows. Rendering the package-owned UI Toolkit view directly is also
+what avoids the
+`EditorGUIUtility.AddCursorRect called outside an editor OnGUI` diagnostic the
+2026-07-30 experiment hit: that came from driving a whole live Inspector with an
+IMGUI body, which the overlay crops do not need.
+
+Do not clear the Console to hide capture diagnostics or erase user logs; abort
+acceptance if a capture adds an error. Native menu cascades and combined
+Hierarchy/Inspector frames still require manual host capture or an explicit scope
+change, because they frame Unity chrome this helper deliberately never reads.
 
 Do not switch editor skins as part of automation. Start from an editor that is
 already in Personal/light theme, record `EditorGUIUtility.isProSkin` and the

--- a/progress/session-180-editor-surface-capture.md
+++ b/progress/session-180-editor-surface-capture.md
@@ -88,6 +88,13 @@ Verified by mutation: deleting the two restore lines from the `finally` fails
 both restore tests, including the failure-path one (7 passed, 2 failed). Under
 the old test body that mutation went undetected.
 
+Reviewing the refusal predicate then turned up a third defect, in the rounding
+it depends on. The crop rounded the origin and the size independently, which
+lets the two drift a pixel apart: a surface at `x=10.5 w=10.5` rounds to
+`x=10 w=10`, a right edge of 20 where the real edge is 21. In a helper whose
+purpose is unclipped documentation images, a lost pixel is a clipped surface.
+The crop now rounds the edges and derives the size from them.
+
 ## Verification
 
 All against the live host, Unity 6000.4.6f1, Direct3D11:

--- a/progress/session-180-editor-surface-capture.md
+++ b/progress/session-180-editor-surface-capture.md
@@ -11,7 +11,7 @@ Personal/light artwork. This session closed the mechanism half.
 `Tests/Editor/EditorSurfaceCapture.cs` is the retained helper session 177
 lacked. It renders a real shipped editor surface into an offscreen render target
 and writes a cropped 24-bit PNG, never reading the desktop.
-`Tests/Editor/EditorSurfaceCaptureTests.cs` pins its contract with eight tests.
+`Tests/Editor/EditorSurfaceCaptureTests.cs` pins its contract with nine tests.
 
 The artwork half stays open, and is blocked on the host rather than on code:
 the configured host is Pro/dark (`isProSkin=True`, `UserSkin=1`), the manifest
@@ -66,13 +66,35 @@ manifest asks for are crops of the package-owned UI Toolkit view, which renders
 directly and emits nothing. The Console gained no entry across this session's
 captures.
 
+## Review findings folded in
+
+Cursor Bugbot found two defects in the first push, and one of them had already
+been found independently by an adversarial pass over the same code.
+
+**The crop clamped instead of refusing.** A surface that started inside the
+canvas but extended past an edge was silently trimmed to fit, so the helper
+built to prevent clipped screenshots could quietly produce one. It now refuses a
+surface that does not fit and names both rects, and
+`CaptureRefusesASurfaceLargerThanTheCanvas` pins that.
+
+**The failure-path restore test proved nothing.** It triggered the failure by
+passing a zero canvas width, which throws in argument validation *before* the
+capture takes over the render target or creates its host window, so the whole
+`finally` block could have been deleted and the test would still pass. It now
+fails from inside the try, by way of an oversized surface, and additionally
+asserts the host window was closed.
+
+Verified by mutation: deleting the two restore lines from the `finally` fails
+both restore tests, including the failure-path one (7 passed, 2 failed). Under
+the old test body that mutation went undetected.
+
 ## Verification
 
 All against the live host, Unity 6000.4.6f1, Direct3D11:
 
-- `EditorSurfaceCaptureTests`: 8 passed, 0 failed;
-- full `WallstopStudios.DxMessaging.Tests.Editor` assembly: 557 passed, 0 failed
-  (549 before this session's 8 new tests, so no regression from the
+- `EditorSurfaceCaptureTests`: 9 passed, 0 failed;
+- full `WallstopStudios.DxMessaging.Tests.Editor` assembly: 558 passed, 0 failed
+  (549 before this session's 9 new tests, so no regression from the
   `CloseWindow` change);
 - visual inspection: `MessageAwareComponentInspectorView` renders to a 720x63
   RGB24 crop, 293 distinct colors, no window chrome, no clipping, complete
@@ -89,7 +111,8 @@ All against the live host, Unity 6000.4.6f1, Direct3D11:
 
 The red-green record is in the capture runs themselves: 3/5 pass-fail on the
 first run (teardown NRE), 6/2 once the panel existed (blank frames), 8/0 once
-the repaint step was added, and 8/0 again after the crop change.
+the repaint step was added, 8/0 again after the crop change, and 9/0 after the
+review fixes.
 
 ## Follow-up
 

--- a/progress/session-180-editor-surface-capture.md
+++ b/progress/session-180-editor-surface-capture.md
@@ -1,0 +1,98 @@
+# Session 180 - Retained editor surface capture (WS-7.3 mechanism)
+
+Date: 2026-07-31
+Branch: `dev/wallstop/editor-surface-capture`
+
+## Outcome
+
+PLAN.md WS-7.3 had two halves: a repeatable capture mechanism, and the final
+Personal/light artwork. This session closed the mechanism half.
+
+`Tests/Editor/EditorSurfaceCapture.cs` is the retained helper session 177
+lacked. It renders a real shipped editor surface into an offscreen render target
+and writes a cropped 24-bit PNG, never reading the desktop.
+`Tests/Editor/EditorSurfaceCaptureTests.cs` pins its contract with eight tests.
+
+The artwork half stays open, and is blocked on the host rather than on code:
+the configured host is Pro/dark (`isProSkin=True`, `UserSkin=1`), the manifest
+requires Personal/light, and switching skins programmatically is banned. The
+manifest also requests Unity 2022.3 LTS while the configured host is 6000.4.6f1.
+No tracked screenshot was replaced.
+
+## What the mechanism does
+
+1. Hosts the surface in a `HideAndDontSave` window from
+   `EditorWindowTestUtility` and shows it.
+1. Creates a linear `RenderTexture`, makes it active, disables `GL.sRGBWrite`.
+1. Drives the panel through `ValidateLayout()`, `Repaint(Event)` with
+   `EventType.Repaint`, then `Render()`, all reflected with instance, public,
+   and non-public binding flags and without `DeclaredOnly`.
+1. Reads back the surface's own `worldBound` rather than the whole canvas.
+1. Encodes RGB24 and verifies PNG color type 2 before writing the file.
+1. Restores the render target and `GL.sRGBWrite` and destroys the window and
+   both textures, including on the failure path.
+
+## Findings
+
+Four things were wrong on the first attempt, and each is now either fixed in
+code or recorded in the manifest so it is not rediscovered.
+
+**A never-shown window has no panel.** `EditorWindow.rootVisualElement.panel` is
+null until the window is shown, so there is nothing to lay out or render. This
+also surfaced a real defect in the shared test host:
+`EditorWindowTestUtility.CloseWindow` called `EditorWindow.Close()`
+unconditionally, and `Close()` dereferences a null parent for a window that was
+never shown. Teardown threw `NullReferenceException` and, because the throw came
+from a `finally`, it replaced the original exception and hid the actual failure.
+`CloseWindow` now destroys a parentless window instead. Five leaked host windows
+from that first run had to be swept from the host.
+
+**Omitting the repaint step yields a valid PNG of a blank frame.**
+`ValidateLayout()` then `Render()` alone produces a correctly sized, correctly
+typed, entirely empty image. The tests count distinct colors so a blank frame
+fails instead of passing as a valid PNG.
+
+**A full-canvas readback frames the host window's chrome.** The first visually
+inspected artifact showed the "DxMessaging Test Host" tab strip with the surface
+clipped underneath it. Cropping to the surface's `worldBound` removes the chrome
+and is also what gives each image the tight frame the capture list asks for.
+Render-target rows start at the bottom while UI Toolkit measures from the top,
+so the vertical origin is `canvasHeight - worldBound.yMax`.
+
+**The `AddCursorRect` diagnostic does not apply to the overlay crops.** Session
+177 hit `EditorGUIUtility.AddCursorRect called outside an editor OnGUI` while
+rendering a whole live Inspector with an IMGUI body. The overlay images the
+manifest asks for are crops of the package-owned UI Toolkit view, which renders
+directly and emits nothing. The Console gained no entry across this session's
+captures.
+
+## Verification
+
+All against the live host, Unity 6000.4.6f1, Direct3D11:
+
+- `EditorSurfaceCaptureTests`: 8 passed, 0 failed;
+- full `WallstopStudios.DxMessaging.Tests.Editor` assembly: 557 passed, 0 failed
+  (549 before this session's 8 new tests, so no regression from the
+  `CloseWindow` change);
+- visual inspection: `MessageAwareComponentInspectorView` renders to a 720x63
+  RGB24 crop, 293 distinct colors, no window chrome, no clipping, complete
+  4-side border;
+- Console after capture: one pre-existing unrelated Hot Reload warning, no
+  capture diagnostic, nothing cleared;
+- host after capture: seven windows, all standard Unity, no test-host leak, no
+  leaked GameObjects, skin unchanged at `isProSkin=True` / `UserSkin=1`;
+- `scripts/__tests__/design-system-dumps.test.js` and
+  `editor-window-test-host.test.js`: green, including the blocked-capture-
+  primitive bans;
+- full Node/script suite: 406 passed, 0 failed;
+- `npm run validate:all`, spelling, prettier, markdownlint, csharpier: passed.
+
+The red-green record is in the capture runs themselves: 3/5 pass-fail on the
+first run (teardown NRE), 6/2 once the panel existed (blank frames), 8/0 once
+the repaint step was added, and 8/0 again after the crop change.
+
+## Follow-up
+
+Issue #314 stays open for the artwork. What it now needs is a host in
+Personal/light and a decision on Unity 2022.3 versus 6000.4, not further
+mechanism work.

--- a/progress/session-180-editor-surface-capture.md.meta
+++ b/progress/session-180-editor-surface-capture.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e7584b8c6f5f40e48eec6c060e9bbe39
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

Closes the mechanism half of PLAN.md WS-7.3 / #314: a retained, test-pinned path that renders a real shipped editor surface into an offscreen render target and writes a cropped 24-bit PNG, never reading the desktop.

Session 177 proved the idea but retained no helper, produced RGBA rather than the manifest's 24-bit RGB, and emitted an IMGUI cursor diagnostic. `Tests/Editor/EditorSurfaceCapture.cs` is that helper, with eight tests in `EditorSurfaceCaptureTests`.

It hosts the surface in a `HideAndDontSave` window, drives the panel through `ValidateLayout()` -> `Repaint(Event)` -> `Render()` into a linear `RenderTexture`, crops to the surface's own `worldBound`, and verifies PNG color type 2 before writing. It restores the render target and `GL.sRGBWrite`, destroys everything it made on both paths, and reports the editor skin instead of switching it.

**No tracked screenshot is replaced.** The artwork half of WS-7.3 stays blocked on the host: it is Pro/dark, the manifest requires Personal/light, and skin switching is banned. #314 stays open for that.

## Findings

Four things were wrong on the first attempt. Each is now fixed in code or recorded in the manifest.

**A never-shown window has no panel**, so there is nothing to lay out or render. That also surfaced a real defect in the shared test host: `EditorWindowTestUtility.CloseWindow` called `EditorWindow.Close()` unconditionally, and `Close()` dereferences a null parent for a window that was never shown. Because the throw came from a `finally`, it replaced the original exception and hid the actual failure. `CloseWindow` now destroys a parentless window instead.

**Omitting the repaint step yields a valid PNG of a blank frame.** `ValidateLayout()` then `Render()` alone produces a correctly sized, correctly typed, entirely empty image. The tests count distinct colors so a blank frame fails rather than passing as a valid PNG.

**A full-canvas readback frames the host window's chrome.** The first visually inspected artifact showed the test host's tab strip with the surface clipped underneath it. Cropping to `worldBound` removes the chrome and is also what gives each image the tight frame the capture list asks for. Render-target rows start at the bottom while UI Toolkit measures from the top, so the vertical origin is `canvasHeight - worldBound.yMax`.

**The `AddCursorRect` diagnostic does not apply to the overlay crops.** Session 177 hit `EditorGUIUtility.AddCursorRect called outside an editor OnGUI` while rendering a whole live Inspector with an IMGUI body. The overlay images the manifest asks for are crops of the package-owned UI Toolkit view, which renders directly and emits nothing.

## Red/green evidence

Live host, Unity 6000.4.6f1, Direct3D11. The capture runs are the red-green record: 3/5 on the first run (teardown NRE), 6/2 once the panel existed (blank frames), 8/0 once the repaint step was added, 8/0 again after the crop change.

- `EditorSurfaceCaptureTests`: 8 passed, 0 failed;
- full `WallstopStudios.DxMessaging.Tests.Editor` assembly: **557 passed, 0 failed** (549 before this session's 8 new tests, so no regression from the `CloseWindow` change);
- visual inspection: `MessageAwareComponentInspectorView` renders to a 720x63 RGB24 crop, 293 distinct colors, no window chrome, no clipping, complete 4-side border;
- Console after capture: one pre-existing unrelated Hot Reload warning, no capture diagnostic, nothing cleared;
- host after capture: seven windows, all standard Unity, no test-host leak, no leaked GameObjects, skin unchanged at `isProSkin=True` / `UserSkin=1`;
- `design-system-dumps.test.js` and `editor-window-test-host.test.js` green, including the blocked-capture-primitive bans;
- full Node/script suite: 406 passed, 0 failed;
- `npm run validate:all`, spelling, prettier, markdownlint, csharpier, pre-commit: passed.

Progress log: `progress/session-180-editor-surface-capture.md`.

Refs #314

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to editor test infrastructure and documentation; production runtime code is untouched, with tests guarding render-state cleanup and crop refusal.
> 
> **Overview**
> Adds **`EditorSurfaceCapture`** and nine **`EditorSurfaceCaptureTests`** to close the WS-7.3 **mechanism** half: render real shipped UI Toolkit editor surfaces offscreen into a linear render target, crop to the surface’s `worldBound`, and write manifest-compliant **24-bit RGB** PNGs (color type 2) without desktop or screen capture.
> 
> The capture path shows a hidden test host window, reflects inherited panel `ValidateLayout` → `Repaint` → `Render`, restores `RenderTexture.active` and `GL.sRGBWrite`, and refuses oversized crops instead of silently clipping. **`EditorWindowTestUtility.CloseWindow`** now destroys never-shown windows (no `m_Parent`) so offscreen capture teardown does not NRE.
> 
> Docs in **`docs/images/inspector-overlay/README.md`** document the retained helper; **`progress/session-180-editor-surface-capture.md`** logs findings. **No tracked screenshot PNGs are replaced**—final Personal/light artwork remains blocked on host theme (#314).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ac96a66689e9394a4e06366bc0d23b03d7abdbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->