### PR TITLE
ci: retry the external link probe before failing the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -972,12 +972,34 @@ jobs:
       - name: Probe external link liveness
         if: ${{ needs.changes.outputs.docs_links != 'false' }}
         run: |
-          lychee \
-            -c .lychee.toml \
-            --scheme https \
-            --scheme http \
-            --accept-timeouts=true \
-            --files-from "${RUNNER_TEMP}/doc-files.txt"
+          # This gate is required, and it asks third-party websites whether they are up.
+          # A single attempt cannot tell a genuinely dead link from a host that was briefly
+          # unreachable, so one blip anywhere on the public internet turns master red on a
+          # commit that changed no links. That happened twice on 2026-07-31, from two
+          # different hosts and two different causes: a cached openupm.com timeout
+          # reclassified as a fatal error (#324), and a shellcheck.net connection failure.
+          #
+          # Two attempts, spaced apart, separate the two cases: a dead link is still dead
+          # 30 seconds later, a blip is not. This is not a flaky test being retried into
+          # green -- the failure being smoothed over is external and outside this
+          # repository, which is the same reasoning that already accepts bot detection,
+          # throttling, and timeouts here.
+          for attempt in 1 2; do
+            if lychee \
+              -c .lychee.toml \
+              --scheme https \
+              --scheme http \
+              --accept-timeouts=true \
+              --files-from "${RUNNER_TEMP}/doc-files.txt"; then
+              exit 0
+            fi
+            if [ "${attempt}" -eq 2 ]; then
+              echo "::error::External link probe failed on both attempts; treating the links as genuinely dead."
+              exit 1
+            fi
+            echo "::notice::External link probe failed on attempt ${attempt}; retrying in 30s to rule out a transient host failure."
+            sleep 30
+          done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -990,6 +1012,10 @@ jobs:
           This job fails for broken internal links or genuinely dead external
           links. Bot-detection, throttling, transient responses, and timeouts are
           accepted by this gate; do not add per-domain excludes for those cases.
+
+          The external probe runs twice, 30s apart, and only fails if both
+          attempts fail. If you are reading this, the link was unreachable on
+          both, so check it by hand before assuming the host was flaky.
           EOF
 
   ci-success:

--- a/progress/session-181-link-gate-retry.md
+++ b/progress/session-181-link-gate-retry.md
@@ -1,0 +1,67 @@
+# Session 181 - External link gate turns master red on third-party outages
+
+Date: 2026-07-31
+Branch: `dev/wallstop/link-gate-retry`
+
+## Outcome
+
+`Lint docs links` is a required check that asks third-party websites whether
+they are up. It ran once and failed the build on the first bad answer, so a blip
+anywhere on the public internet turned a PR or master red on a commit that
+changed no links.
+
+The external probe now runs twice, 30 seconds apart, and fails only if both
+attempts fail.
+
+## Evidence
+
+Two failures in under an hour on 2026-07-31, from two different hosts and two
+different causes, neither related to the commit under test:
+
+| Run | Where | Cause |
+| --- | --- | --- |
+| [30610933921](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/30610933921) | PR #320 | `openupm.com` timed out; a cached result for the same URL was reported as a fatal error despite `--accept-timeouts=true` |
+| [30613636402](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/30613636402) | master | `shellcheck.net`: `Connection failed. Check network connectivity and firewall settings` |
+
+PR #320 changed a PowerShell test and a progress note. Master's commit added
+editor test files. Neither touched a link, a doc page, or `.lychee.toml`.
+
+Both runs' offline pass reported `0 Errors`, so nothing internal was wrong in
+either case. Both were cleared by a manual re-run, which is the tell: the check
+was measuring the weather, not the repository.
+
+## Why a retry rather than a per-host exclude
+
+`.lychee.toml` bans per-domain excludes explicitly, and rightly: an exclude
+would hide the link when it really does die. `accept` takes status codes, so it
+cannot express "the connection failed". The step's own summary already commits
+to accepting bot detection, throttling, transient responses, and timeouts, so
+accepting a transient connection failure is the same policy, not a new one.
+
+A single attempt cannot separate "this link is dead" from "this host was
+unreachable for a moment". Two attempts can: a dead link is still dead 30
+seconds later. The retry costs nothing on a green run, because the second
+attempt only happens after a failure.
+
+This is not a flaky test retried into green. The flakiness being smoothed over
+is in third-party web servers, outside this repository, and the alternative is
+training reviewers to re-run a red required check without reading it, which is
+worse than the flake.
+
+## Scope
+
+`--accept-timeouts=true`, `.lychee.toml`, the pinned lychee version, and the
+offline internal-link pass are all unchanged. The scheduled advisory scan still
+shares `.lychee.toml` without `accept_timeouts`, so it keeps reporting timeouts.
+
+Issue #324 stays open for the narrower upstream defect it documents: lychee
+reclassifies a cached timeout as a generic error, which defeats
+`--accept-timeouts=true` for any URL that appears more than once. The retry
+makes that survivable; it does not make it correct.
+
+## Verification
+
+- `actionlint`, `yamllint`, `prettier --check`: passed;
+- full Node/script suite: 406 passed, 0 failed;
+- `npm run validate:all`: passed;
+- master restored to green by re-running the failed job before this change.

--- a/progress/session-181-link-gate-retry.md.meta
+++ b/progress/session-181-link-gate-retry.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c069773d84304b46abe8e1c2d8f35b71
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

`Lint docs links` is a required check that asks third-party websites whether they are up, and it ran once and failed the build on the first bad answer. A blip anywhere on the public internet turned a PR or master red on a commit that changed no links.

The external probe now runs twice, 30 seconds apart, and fails only if both attempts fail.

## Evidence

Two failures in under an hour on 2026-07-31, from two different hosts and two different causes, neither related to the commit under test:

| Run | Where | Cause |
| --- | --- | --- |
| [30610933921](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/30610933921) | PR #320 | `openupm.com` timed out; a cached result for the same URL was reported as a fatal error despite `--accept-timeouts=true` |
| [30613636402](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/30613636402) | master | `shellcheck.net`: `Connection failed. Check network connectivity and firewall settings` |

PR #320 changed a PowerShell test and a progress note. Master's commit added editor test files. Neither touched a link, a doc page, or `.lychee.toml`. Both runs' offline pass reported `0 Errors`, so nothing internal was wrong in either case, and both were cleared by a manual re-run -- which is the tell: the check was measuring the weather, not the repository.

## Why a retry, and why not the alternatives

- **Per-host exclude:** `.lychee.toml` bans them explicitly, and rightly. An exclude hides the link when it really does die.
- **`accept`:** takes status codes, so it cannot express "the connection failed".
- **Longer timeout / more `max_retries`:** reduces how often a host times out, but does nothing for a refused connection, and nothing for the cached-timeout misclassification in #324.

A single attempt cannot separate "this link is dead" from "this host was unreachable for a moment". Two attempts can: a dead link is still dead 30 seconds later. The retry costs nothing on a green run, because the second attempt only happens after a failure.

This is not a flaky test retried into green. The flakiness being smoothed over is in third-party web servers, outside this repository, and the step's own summary already commits to accepting bot detection, throttling, transient responses, and timeouts for exactly that reason. The alternative is training reviewers to re-run a red required check without reading it, which is worse than the flake.

## Scope

`--accept-timeouts=true`, `.lychee.toml`, the pinned lychee version, and the offline internal-link pass are all unchanged. The scheduled advisory scan still shares `.lychee.toml` without `accept_timeouts`, so it keeps reporting timeouts.

The failure summary now tells the reader the probe already retried, so a red result means the link was unreachable twice and deserves a manual check rather than another re-run.

**#324 stays open** for the narrower upstream defect it documents: lychee reclassifies a cached timeout as a generic error, defeating `--accept-timeouts=true` for any URL appearing more than once. This retry makes that survivable; it does not make it correct.

## Verification

- `actionlint`, `yamllint`, `prettier --check`: passed;
- full Node/script suite: 406 passed, 0 failed;
- `npm run validate:all`, spelling, pre-commit: passed;
- master was restored to green by re-running its failed job before this change.

Refs #324

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to external link probing behavior; no runtime, auth, or application code paths are modified.
> 
> **Overview**
> The **Lint docs links** required check used to fail CI on the first failed external `lychee` probe, so transient third-party outages could turn master red without any link changes in the commit.
> 
> The **Probe external link liveness** step in `ci.yml` now runs the same `lychee` invocation **twice**, with a **30s** pause between attempts, and only fails if **both** attempts fail. Inline comments document the motivation (recent `openupm.com` / `shellcheck.net` flakes and #324). The **Explain link-check failures** step summary tells reviewers that a red result means the link failed twice, not a one-off blip.
> 
> A **progress** note (`session-181-link-gate-retry.md`) records evidence and scope: offline internal checks, `.lychee.toml`, pinned lychee, and `--accept-timeouts=true` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6eaef693fb6e6db18e5cdd9007736adf6a2c294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->