### PR TITLE
ci: bind Unity editor gate provenance and retire superseded Unity runs

### DIFF
--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Checkout trusted Unity editor validator
         timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         env:
           GIT_CONFIG_COUNT: 1
           GIT_CONFIG_KEY_0: core.hooksPath

--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -219,7 +219,10 @@ jobs:
           }
           $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
           $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'))
-          $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
+          # A summary written by a failed gate can record no editor at all, and
+          # GetFullPath('') throws an ArgumentException instead of saying so.
+          $recorded = [string]$summary.editorPath
+          $actual = if ($recorded) { [IO.Path]::GetFullPath($recorded) } else { '(none recorded)' }
           if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
             throw "Validated editor '$actual' did not match the canonical editor '$expected'."
           }

--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -150,6 +150,78 @@ jobs:
           - standalone
           - playmode
     steps:
+      - name: Remove stale Unity editor validator
+        timeout-minutes: 2
+        shell: pwsh -NoProfile -Command ". '{0}'"
+        run: |
+          $workspace = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE).TrimEnd('\', '/')
+          $parent = [IO.Path]::GetFullPath((Join-Path $workspace '.ci'))
+          $target = [IO.Path]::GetFullPath((Join-Path $parent 'unity-helpers'))
+          if (-not $target.StartsWith("$workspace\", [StringComparison]::OrdinalIgnoreCase)) {
+            throw 'Validator checkout path escaped the workspace.'
+          }
+          if (Test-Path -LiteralPath $parent) {
+            $parentItem = Get-Item -LiteralPath $parent -Force
+            if (($parentItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+              throw 'Validator checkout parent is a reparse point.'
+            }
+          }
+          if (Test-Path -LiteralPath $target) {
+            $targetItem = Get-Item -LiteralPath $target -Force
+            if (($targetItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+              $targetItem.Delete()
+            } else {
+              Remove-Item -LiteralPath $target -Recurse -Force
+            }
+          }
+          if (Test-Path -LiteralPath $target) {
+            throw 'Validator checkout directory could not be removed.'
+          }
+
+      - name: Checkout trusted Unity editor validator
+        timeout-minutes: 5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: core.hooksPath
+          GIT_CONFIG_VALUE_0: /dev/null
+          GIT_CONFIG_NOSYSTEM: 1
+          GIT_CONFIG_GLOBAL: /dev/null
+        with:
+          repository: Ambiguous-Interactive/unity-helpers
+          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
+          path: .ci/unity-helpers
+          persist-credentials: false
+          clean: true
+
+      - name: Require manually installed Unity editor
+        timeout-minutes: 10
+        shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
+        run: |
+          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" -UnityVersion '${{ matrix.unity-version }}' -InstallRoot "$env:RUNNER_TOOL_CACHE\u6-v3" -ProvisioningProfile ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }} -DiagnosticsPath unity-editor-check.json -CiManagedOnly -RequireHealthyExisting
+
+      - name: Bind and preserve validated Unity editor
+        timeout-minutes: 2
+        shell: pwsh
+        run: |
+          $source = Join-Path $env:GITHUB_WORKSPACE 'unity-editor-check.json'
+          if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+            throw "Unity editor validation evidence was not written: $source"
+          }
+          $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
+          $expected = Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'
+          $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
+          $expected = [IO.Path]::GetFullPath($expected)
+          if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Validated editor '$actual' did not match the canonical editor '$expected'."
+          }
+          $evidenceRoot = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation'
+          New-Item -ItemType Directory -Force -Path $evidenceRoot | Out-Null
+          $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}.json'
+          Copy-Item -LiteralPath $source -Destination $destination -Force
+          "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "UNITY_EDITOR_VALIDATION_PATH=$destination" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: Enable Git long paths
         timeout-minutes: 2
         shell: pwsh
@@ -164,15 +236,6 @@ jobs:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/dxm-gitconfig
         with:
           lfs: true
-          persist-credentials: false
-
-      - name: Checkout Unity runner maintenance
-        timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: Ambiguous-Interactive/unity-helpers
-          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
-          path: .ci/unity-helpers
           persist-credentials: false
 
       - name: Print runner diagnostics
@@ -241,31 +304,6 @@ jobs:
             -OutputJson (Join-Path $artifactsPath 'machine-specs.json') `
             -OutputSummary (Join-Path $artifactsPath 'machine-specs.txt')
 
-      # Editors and modules are installed manually by a runner administrator.
-      # Validate before taking the organization lock.
-      - name: Validate installed Unity Editor
-        id: validate_editor
-        timeout-minutes: 10
-        shell: pwsh
-        run: |
-          $artifactsPath = '.artifacts/unity/perf/${{ matrix.unity-version }}-${{ matrix.test-mode }}'
-          $diagnosticsPath = Join-Path $artifactsPath 'editor-validation'
-          $diagnosticsFile = Join-Path $diagnosticsPath 'ensure-editor-summary.json'
-          New-Item -ItemType Directory -Force -Path $diagnosticsPath | Out-Null
-          $provisioningProfile = if ('${{ matrix.test-mode }}' -eq 'standalone') {
-            'StandaloneWindowsIl2Cpp'
-          } else {
-            'EditorOnly'
-          }
-          $editor = & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
-            -UnityVersion '${{ matrix.unity-version }}' `
-            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
-            -CiManagedOnly `
-            -ProvisioningProfile $provisioningProfile `
-            -DiagnosticsPath $diagnosticsFile `
-            -RequireHealthyExisting
-          "UNITY_EDITOR_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append
-
       - name: Validate Unity license secrets
         timeout-minutes: 2
         uses: ./.github/actions/validate-unity-license
@@ -299,13 +337,13 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: perf-editor-validation-${{ matrix.unity-version }}-${{ matrix.test-mode }}
-          path: .artifacts/unity/perf/${{ matrix.unity-version }}-${{ matrix.test-mode }}/editor-validation
+          path: ${{ env.UNITY_EDITOR_VALIDATION_PATH }}
           if-no-files-found: warn
           retention-days: 14
 
       - name: Run Unity Test Runner
         id: run_tests
-        if: ${{ steps.compute.outputs.is-empty != 'true' && steps.validate_editor.outcome == 'success' && steps.acquire_lock.outputs.acquired == 'true' }}
+        if: ${{ steps.compute.outputs.is-empty != 'true' && steps.acquire_lock.outputs.acquired == 'true' }}
         # 180 (not 120): the Standalone leg builds a COLD IL2CPP player, which is
         # far slower than a Mono build. The PlayMode leg runs IN-EDITOR (Mono) with
         # no player build and is faster, so 180 is generous for it too. Stays

--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -198,7 +198,13 @@ jobs:
         timeout-minutes: 10
         shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
         run: |
-          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" -UnityVersion '${{ matrix.unity-version }}' -InstallRoot "$env:RUNNER_TOOL_CACHE\u6-v3" -ProvisioningProfile ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }} -DiagnosticsPath unity-editor-check.json -CiManagedOnly -RequireHealthyExisting
+          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
+            -UnityVersion '${{ matrix.unity-version }}' `
+            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
+            -ProvisioningProfile ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }} `
+            -DiagnosticsPath unity-editor-check.json `
+            -CiManagedOnly `
+            -RequireHealthyExisting
 
       - name: Bind and preserve validated Unity editor
         timeout-minutes: 2
@@ -220,7 +226,6 @@ jobs:
           $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}.json'
           Copy-Item -LiteralPath $source -Destination $destination -Force
           "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "UNITY_EDITOR_VALIDATION_PATH=$destination" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Enable Git long paths
         timeout-minutes: 2
@@ -337,7 +342,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: perf-editor-validation-${{ matrix.unity-version }}-${{ matrix.test-mode }}
-          path: ${{ env.UNITY_EDITOR_VALIDATION_PATH }}
+          path: ${{ runner.temp }}/dx-unity-editor-validation
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -202,29 +202,27 @@ jobs:
             -UnityVersion '${{ matrix.unity-version }}' `
             -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
             -ProvisioningProfile ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }} `
-            -DiagnosticsPath unity-editor-check.json `
+            -DiagnosticsPath (Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation') `
             -CiManagedOnly `
             -RequireHealthyExisting
 
-      - name: Bind and preserve validated Unity editor
+      - name: Bind validated Unity editor
         timeout-minutes: 2
         shell: pwsh
         run: |
-          $source = Join-Path $env:GITHUB_WORKSPACE 'unity-editor-check.json'
+          # ensure-editor writes this summary from a finally block, so the evidence
+          # exists for a failed gate too, and writing it under RUNNER_TEMP keeps it
+          # out of reach of the repository checkout that follows.
+          $source = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation\ensure-editor-summary.json'
           if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
             throw "Unity editor validation evidence was not written: $source"
           }
           $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
-          $expected = Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'
+          $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'))
           $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
-          $expected = [IO.Path]::GetFullPath($expected)
           if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
             throw "Validated editor '$actual' did not match the canonical editor '$expected'."
           }
-          $evidenceRoot = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation'
-          New-Item -ItemType Directory -Force -Path $evidenceRoot | Out-Null
-          $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}.json'
-          Copy-Item -LiteralPath $source -Destination $destination -Force
           "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Enable Git long paths

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Checkout trusted Unity editor validator
         timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         env:
           GIT_CONFIG_COUNT: 1
           GIT_CONFIG_KEY_0: core.hooksPath
@@ -304,8 +304,9 @@ jobs:
         with:
           target: editmode
 
-      # Unity work skips when no test assembly matched. Editor validation,
-      # credential validation, and lock acquisition remain unconditional.
+      # Unity work skips when no test assembly matched. Credential validation
+      # and lock acquisition remain unconditional. The editor gate ran before
+      # the repository checkout, so a failure there has already failed the job.
       - name: Validate Unity license secrets
         timeout-minutes: 2
         uses: ./.github/actions/validate-unity-license
@@ -515,7 +516,7 @@ jobs:
 
       - name: Checkout trusted Unity editor validator
         timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         env:
           GIT_CONFIG_COUNT: 1
           GIT_CONFIG_KEY_0: core.hooksPath

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,7 +256,10 @@ jobs:
           }
           $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
           $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\2022.3.45f1\Editor\Unity.exe'))
-          $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
+          # A summary written by a failed gate can record no editor at all, and
+          # GetFullPath('') throws an ArgumentException instead of saying so.
+          $recorded = [string]$summary.editorPath
+          $actual = if ($recorded) { [IO.Path]::GetFullPath($recorded) } else { '(none recorded)' }
           if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
             throw "Validated editor '$actual' did not match the canonical editor '$expected'."
           }
@@ -555,7 +558,10 @@ jobs:
           }
           $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
           $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\2022.3.45f1\Editor\Unity.exe'))
-          $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
+          # A summary written by a failed gate can record no editor at all, and
+          # GetFullPath('') throws an ArgumentException instead of saying so.
+          $recorded = [string]$summary.editorPath
+          $actual = if ($recorded) { [IO.Path]::GetFullPath($recorded) } else { '(none recorded)' }
           if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
             throw "Validated editor '$actual' did not match the canonical editor '$expected'."
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,29 +239,27 @@ jobs:
             -UnityVersion '2022.3.45f1' `
             -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
             -ProvisioningProfile EditorOnly `
-            -DiagnosticsPath unity-editor-check.json `
+            -DiagnosticsPath (Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation') `
             -CiManagedOnly `
             -RequireHealthyExisting
 
-      - name: Bind and preserve validated Unity editor
+      - name: Bind validated Unity editor
         timeout-minutes: 2
         shell: pwsh
         run: |
-          $source = Join-Path $env:GITHUB_WORKSPACE 'unity-editor-check.json'
+          # ensure-editor writes this summary from a finally block, so the evidence
+          # exists for a failed gate too, and writing it under RUNNER_TEMP keeps it
+          # out of reach of the repository checkout that follows.
+          $source = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation\ensure-editor-summary.json'
           if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
             throw "Unity editor validation evidence was not written: $source"
           }
           $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
-          $expected = Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\2022.3.45f1\Editor\Unity.exe'
+          $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\2022.3.45f1\Editor\Unity.exe'))
           $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
-          $expected = [IO.Path]::GetFullPath($expected)
           if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
             throw "Validated editor '$actual' did not match the canonical editor '$expected'."
           }
-          $evidenceRoot = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation'
-          New-Item -ItemType Directory -Force -Path $evidenceRoot | Out-Null
-          $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}.json'
-          Copy-Item -LiteralPath $source -Destination $destination -Force
           "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Enable Git long paths
@@ -539,29 +537,27 @@ jobs:
             -UnityVersion '2022.3.45f1' `
             -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
             -ProvisioningProfile EditorOnly `
-            -DiagnosticsPath unity-editor-check.json `
+            -DiagnosticsPath (Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation') `
             -CiManagedOnly `
             -RequireHealthyExisting
 
-      - name: Bind and preserve validated Unity editor
+      - name: Bind validated Unity editor
         timeout-minutes: 2
         shell: pwsh
         run: |
-          $source = Join-Path $env:GITHUB_WORKSPACE 'unity-editor-check.json'
+          # ensure-editor writes this summary from a finally block, so the evidence
+          # exists for a failed gate too, and writing it under RUNNER_TEMP keeps it
+          # out of reach of the repository checkout that follows.
+          $source = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation\ensure-editor-summary.json'
           if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
             throw "Unity editor validation evidence was not written: $source"
           }
           $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
-          $expected = Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\2022.3.45f1\Editor\Unity.exe'
+          $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\2022.3.45f1\Editor\Unity.exe'))
           $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
-          $expected = [IO.Path]::GetFullPath($expected)
           if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
             throw "Validated editor '$actual' did not match the canonical editor '$expected'."
           }
-          $evidenceRoot = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation'
-          New-Item -ItemType Directory -Force -Path $evidenceRoot | Out-Null
-          $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}.json'
-          Copy-Item -LiteralPath $source -Destination $destination -Force
           "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Enable Git long paths

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,13 @@ jobs:
         timeout-minutes: 10
         shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
         run: |
-          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" -UnityVersion '2022.3.45f1' -InstallRoot "$env:RUNNER_TOOL_CACHE\u6-v3" -ProvisioningProfile EditorOnly -DiagnosticsPath unity-editor-check.json -CiManagedOnly -RequireHealthyExisting
+          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
+            -UnityVersion '2022.3.45f1' `
+            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
+            -ProvisioningProfile EditorOnly `
+            -DiagnosticsPath unity-editor-check.json `
+            -CiManagedOnly `
+            -RequireHealthyExisting
 
       - name: Bind and preserve validated Unity editor
         timeout-minutes: 2
@@ -257,7 +263,6 @@ jobs:
           $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}.json'
           Copy-Item -LiteralPath $source -Destination $destination -Force
           "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "UNITY_EDITOR_VALIDATION_PATH=$destination" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Enable Git long paths
         timeout-minutes: 2
@@ -336,7 +341,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: unity-release-editor-validation-editmode
-          path: ${{ env.UNITY_EDITOR_VALIDATION_PATH }}
+          path: ${{ runner.temp }}/dx-unity-editor-validation
           if-no-files-found: warn
           retention-days: 14
 
@@ -530,7 +535,13 @@ jobs:
         timeout-minutes: 10
         shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
         run: |
-          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" -UnityVersion '2022.3.45f1' -InstallRoot "$env:RUNNER_TOOL_CACHE\u6-v3" -ProvisioningProfile EditorOnly -DiagnosticsPath unity-editor-check.json -CiManagedOnly -RequireHealthyExisting
+          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
+            -UnityVersion '2022.3.45f1' `
+            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
+            -ProvisioningProfile EditorOnly `
+            -DiagnosticsPath unity-editor-check.json `
+            -CiManagedOnly `
+            -RequireHealthyExisting
 
       - name: Bind and preserve validated Unity editor
         timeout-minutes: 2
@@ -552,7 +563,6 @@ jobs:
           $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}.json'
           Copy-Item -LiteralPath $source -Destination $destination -Force
           "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "UNITY_EDITOR_VALIDATION_PATH=$destination" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Enable Git long paths
         timeout-minutes: 2
@@ -617,7 +627,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: unity-release-editor-validation-unitypackage
-          path: ${{ env.UNITY_EDITOR_VALIDATION_PATH }}
+          path: ${{ runner.temp }}/dx-unity-editor-validation
           if-no-files-found: warn
           retention-days: 14
           # The documented recovery for a failed export is re-running this

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,78 @@ jobs:
       checks: write
     timeout-minutes: 900
     steps:
+      - name: Remove stale Unity editor validator
+        timeout-minutes: 2
+        shell: pwsh -NoProfile -Command ". '{0}'"
+        run: |
+          $workspace = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE).TrimEnd('\', '/')
+          $parent = [IO.Path]::GetFullPath((Join-Path $workspace '.ci'))
+          $target = [IO.Path]::GetFullPath((Join-Path $parent 'unity-helpers'))
+          if (-not $target.StartsWith("$workspace\", [StringComparison]::OrdinalIgnoreCase)) {
+            throw 'Validator checkout path escaped the workspace.'
+          }
+          if (Test-Path -LiteralPath $parent) {
+            $parentItem = Get-Item -LiteralPath $parent -Force
+            if (($parentItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+              throw 'Validator checkout parent is a reparse point.'
+            }
+          }
+          if (Test-Path -LiteralPath $target) {
+            $targetItem = Get-Item -LiteralPath $target -Force
+            if (($targetItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+              $targetItem.Delete()
+            } else {
+              Remove-Item -LiteralPath $target -Recurse -Force
+            }
+          }
+          if (Test-Path -LiteralPath $target) {
+            throw 'Validator checkout directory could not be removed.'
+          }
+
+      - name: Checkout trusted Unity editor validator
+        timeout-minutes: 5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: core.hooksPath
+          GIT_CONFIG_VALUE_0: /dev/null
+          GIT_CONFIG_NOSYSTEM: 1
+          GIT_CONFIG_GLOBAL: /dev/null
+        with:
+          repository: Ambiguous-Interactive/unity-helpers
+          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
+          path: .ci/unity-helpers
+          persist-credentials: false
+          clean: true
+
+      - name: Require manually installed Unity editor
+        timeout-minutes: 10
+        shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
+        run: |
+          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" -UnityVersion '2022.3.45f1' -InstallRoot "$env:RUNNER_TOOL_CACHE\u6-v3" -ProvisioningProfile EditorOnly -DiagnosticsPath unity-editor-check.json -CiManagedOnly -RequireHealthyExisting
+
+      - name: Bind and preserve validated Unity editor
+        timeout-minutes: 2
+        shell: pwsh
+        run: |
+          $source = Join-Path $env:GITHUB_WORKSPACE 'unity-editor-check.json'
+          if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+            throw "Unity editor validation evidence was not written: $source"
+          }
+          $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
+          $expected = Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\2022.3.45f1\Editor\Unity.exe'
+          $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
+          $expected = [IO.Path]::GetFullPath($expected)
+          if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Validated editor '$actual' did not match the canonical editor '$expected'."
+          }
+          $evidenceRoot = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation'
+          New-Item -ItemType Directory -Force -Path $evidenceRoot | Out-Null
+          $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}.json'
+          Copy-Item -LiteralPath $source -Destination $destination -Force
+          "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "UNITY_EDITOR_VALIDATION_PATH=$destination" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: Enable Git long paths
         timeout-minutes: 2
         shell: pwsh
@@ -201,15 +273,6 @@ jobs:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/dxm-gitconfig
         with:
           lfs: true
-          persist-credentials: false
-
-      - name: Checkout Unity runner maintenance
-        timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: Ambiguous-Interactive/unity-helpers
-          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
-          path: .ci/unity-helpers
           persist-credentials: false
 
       - name: Print runner diagnostics
@@ -240,24 +303,6 @@ jobs:
 
       # Unity work skips when no test assembly matched. Editor validation,
       # credential validation, and lock acquisition remain unconditional.
-      - name: Validate installed Unity Editor
-        id: validate_editor
-        timeout-minutes: 10
-        shell: pwsh
-        run: |
-          $artifactsPath = '.artifacts/unity/release-editmode'
-          $diagnosticsPath = Join-Path $artifactsPath 'editor-validation'
-          $diagnosticsFile = Join-Path $diagnosticsPath 'ensure-editor-summary.json'
-          New-Item -ItemType Directory -Force -Path $diagnosticsPath | Out-Null
-          $editor = & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
-            -UnityVersion '2022.3.45f1' `
-            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
-            -CiManagedOnly `
-            -ProvisioningProfile EditorOnly `
-            -DiagnosticsPath $diagnosticsFile `
-            -RequireHealthyExisting
-          "UNITY_EDITOR_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append
-
       - name: Validate Unity license secrets
         timeout-minutes: 2
         uses: ./.github/actions/validate-unity-license
@@ -291,13 +336,13 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: unity-release-editor-validation-editmode
-          path: .artifacts/unity/release-editmode/editor-validation
+          path: ${{ env.UNITY_EDITOR_VALIDATION_PATH }}
           if-no-files-found: warn
           retention-days: 14
 
       - name: Run Unity Test Runner
         id: run_tests
-        if: ${{ steps.compute.outputs.is-empty != 'true' && steps.validate_editor.outcome == 'success' && steps.acquire_lock.outputs.acquired == 'true' }}
+        if: ${{ steps.compute.outputs.is-empty != 'true' && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 120
         shell: pwsh
         env:
@@ -437,6 +482,78 @@ jobs:
       contents: read
     timeout-minutes: 900
     steps:
+      - name: Remove stale Unity editor validator
+        timeout-minutes: 2
+        shell: pwsh -NoProfile -Command ". '{0}'"
+        run: |
+          $workspace = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE).TrimEnd('\', '/')
+          $parent = [IO.Path]::GetFullPath((Join-Path $workspace '.ci'))
+          $target = [IO.Path]::GetFullPath((Join-Path $parent 'unity-helpers'))
+          if (-not $target.StartsWith("$workspace\", [StringComparison]::OrdinalIgnoreCase)) {
+            throw 'Validator checkout path escaped the workspace.'
+          }
+          if (Test-Path -LiteralPath $parent) {
+            $parentItem = Get-Item -LiteralPath $parent -Force
+            if (($parentItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+              throw 'Validator checkout parent is a reparse point.'
+            }
+          }
+          if (Test-Path -LiteralPath $target) {
+            $targetItem = Get-Item -LiteralPath $target -Force
+            if (($targetItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+              $targetItem.Delete()
+            } else {
+              Remove-Item -LiteralPath $target -Recurse -Force
+            }
+          }
+          if (Test-Path -LiteralPath $target) {
+            throw 'Validator checkout directory could not be removed.'
+          }
+
+      - name: Checkout trusted Unity editor validator
+        timeout-minutes: 5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: core.hooksPath
+          GIT_CONFIG_VALUE_0: /dev/null
+          GIT_CONFIG_NOSYSTEM: 1
+          GIT_CONFIG_GLOBAL: /dev/null
+        with:
+          repository: Ambiguous-Interactive/unity-helpers
+          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
+          path: .ci/unity-helpers
+          persist-credentials: false
+          clean: true
+
+      - name: Require manually installed Unity editor
+        timeout-minutes: 10
+        shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
+        run: |
+          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" -UnityVersion '2022.3.45f1' -InstallRoot "$env:RUNNER_TOOL_CACHE\u6-v3" -ProvisioningProfile EditorOnly -DiagnosticsPath unity-editor-check.json -CiManagedOnly -RequireHealthyExisting
+
+      - name: Bind and preserve validated Unity editor
+        timeout-minutes: 2
+        shell: pwsh
+        run: |
+          $source = Join-Path $env:GITHUB_WORKSPACE 'unity-editor-check.json'
+          if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+            throw "Unity editor validation evidence was not written: $source"
+          }
+          $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
+          $expected = Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\2022.3.45f1\Editor\Unity.exe'
+          $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
+          $expected = [IO.Path]::GetFullPath($expected)
+          if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Validated editor '$actual' did not match the canonical editor '$expected'."
+          }
+          $evidenceRoot = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation'
+          New-Item -ItemType Directory -Force -Path $evidenceRoot | Out-Null
+          $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}.json'
+          Copy-Item -LiteralPath $source -Destination $destination -Force
+          "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "UNITY_EDITOR_VALIDATION_PATH=$destination" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: Enable Git long paths
         timeout-minutes: 2
         shell: pwsh
@@ -453,15 +570,6 @@ jobs:
           lfs: true
           persist-credentials: false
 
-      - name: Checkout Unity runner maintenance
-        timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: Ambiguous-Interactive/unity-helpers
-          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
-          path: .ci/unity-helpers
-          persist-credentials: false
-
       - name: Print runner diagnostics
         timeout-minutes: 2
         # Composite action runs PowerShell internally; never use plain
@@ -475,24 +583,6 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.18.0"
-
-      - name: Validate installed Unity Editor
-        id: validate_editor
-        timeout-minutes: 10
-        shell: pwsh
-        run: |
-          $artifactsPath = '.artifacts/unity/release-unitypackage'
-          $diagnosticsPath = Join-Path $artifactsPath 'editor-validation'
-          $diagnosticsFile = Join-Path $diagnosticsPath 'ensure-editor-summary.json'
-          New-Item -ItemType Directory -Force -Path $diagnosticsPath | Out-Null
-          $editor = & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
-            -UnityVersion '2022.3.45f1' `
-            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
-            -CiManagedOnly `
-            -ProvisioningProfile EditorOnly `
-            -DiagnosticsPath $diagnosticsFile `
-            -RequireHealthyExisting
-          "UNITY_EDITOR_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Validate Unity license secrets
         timeout-minutes: 2
@@ -527,7 +617,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: unity-release-editor-validation-unitypackage
-          path: .artifacts/unity/release-unitypackage/editor-validation
+          path: ${{ env.UNITY_EDITOR_VALIDATION_PATH }}
           if-no-files-found: warn
           retention-days: 14
           # The documented recovery for a failed export is re-running this
@@ -537,7 +627,7 @@ jobs:
 
       - name: Export the .unitypackage
         id: export_unitypackage
-        if: ${{ steps.validate_editor.outcome == 'success' && steps.acquire_lock.outputs.acquired == 'true' }}
+        if: ${{ steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 120
         shell: pwsh
         env:

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -104,29 +104,27 @@ jobs:
             -UnityVersion '${{ matrix.unity-version }}' `
             -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
             -ProvisioningProfile ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }} `
-            -DiagnosticsPath unity-editor-check.json `
+            -DiagnosticsPath (Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation') `
             -CiManagedOnly `
             -RequireHealthyExisting
 
-      - name: Bind and preserve validated Unity editor
+      - name: Bind validated Unity editor
         timeout-minutes: 2
         shell: pwsh
         run: |
-          $source = Join-Path $env:GITHUB_WORKSPACE 'unity-editor-check.json'
+          # ensure-editor writes this summary from a finally block, so the evidence
+          # exists for a failed gate too, and writing it under RUNNER_TEMP keeps it
+          # out of reach of the repository checkout that follows.
+          $source = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation\ensure-editor-summary.json'
           if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
             throw "Unity editor validation evidence was not written: $source"
           }
           $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
-          $expected = Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'
+          $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'))
           $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
-          $expected = [IO.Path]::GetFullPath($expected)
           if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
             throw "Validated editor '$actual' did not match the canonical editor '$expected'."
           }
-          $evidenceRoot = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation'
-          New-Item -ItemType Directory -Force -Path $evidenceRoot | Out-Null
-          $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}.json'
-          Copy-Item -LiteralPath $source -Destination $destination -Force
           "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Enable Git long paths

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Checkout trusted Unity editor validator
         timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         env:
           GIT_CONFIG_COUNT: 1
           GIT_CONFIG_KEY_0: core.hooksPath
@@ -194,8 +194,9 @@ jobs:
           include-perf: "true"
           target: "${{ matrix.test-mode }}"
 
-      # Unity work skips when no assembly matched. Editor validation,
-      # credential validation, and lock acquisition remain unconditional. The
+      # Unity work skips when no assembly matched. Credential validation and
+      # lock acquisition remain unconditional. The editor gate ran before the
+      # repository checkout, so a failure there has already failed the job. The
       # benchmark list is currently non-empty, so this is defense-in-depth.
       - name: Validate Unity license secrets
         timeout-minutes: 2

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -121,7 +121,10 @@ jobs:
           }
           $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
           $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'))
-          $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
+          # A summary written by a failed gate can record no editor at all, and
+          # GetFullPath('') throws an ArgumentException instead of saying so.
+          $recorded = [string]$summary.editorPath
+          $actual = if ($recorded) { [IO.Path]::GetFullPath($recorded) } else { '(none recorded)' }
           if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
             throw "Validated editor '$actual' did not match the canonical editor '$expected'."
           }

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -100,7 +100,13 @@ jobs:
         timeout-minutes: 10
         shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
         run: |
-          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" -UnityVersion '${{ matrix.unity-version }}' -InstallRoot "$env:RUNNER_TOOL_CACHE\u6-v3" -ProvisioningProfile ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }} -DiagnosticsPath unity-editor-check.json -CiManagedOnly -RequireHealthyExisting
+          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
+            -UnityVersion '${{ matrix.unity-version }}' `
+            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
+            -ProvisioningProfile ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }} `
+            -DiagnosticsPath unity-editor-check.json `
+            -CiManagedOnly `
+            -RequireHealthyExisting
 
       - name: Bind and preserve validated Unity editor
         timeout-minutes: 2
@@ -122,7 +128,6 @@ jobs:
           $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}.json'
           Copy-Item -LiteralPath $source -Destination $destination -Force
           "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "UNITY_EDITOR_VALIDATION_PATH=$destination" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Enable Git long paths
         timeout-minutes: 2
@@ -227,7 +232,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: unity-benchmark-editor-validation-${{ matrix.unity-version }}-${{ matrix.test-mode }}
-          path: ${{ env.UNITY_EDITOR_VALIDATION_PATH }}
+          path: ${{ runner.temp }}/dx-unity-editor-validation
           if-no-files-found: warn
           retention-days: 90
 

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -52,6 +52,78 @@ jobs:
           - editmode
           - playmode
     steps:
+      - name: Remove stale Unity editor validator
+        timeout-minutes: 2
+        shell: pwsh -NoProfile -Command ". '{0}'"
+        run: |
+          $workspace = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE).TrimEnd('\', '/')
+          $parent = [IO.Path]::GetFullPath((Join-Path $workspace '.ci'))
+          $target = [IO.Path]::GetFullPath((Join-Path $parent 'unity-helpers'))
+          if (-not $target.StartsWith("$workspace\", [StringComparison]::OrdinalIgnoreCase)) {
+            throw 'Validator checkout path escaped the workspace.'
+          }
+          if (Test-Path -LiteralPath $parent) {
+            $parentItem = Get-Item -LiteralPath $parent -Force
+            if (($parentItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+              throw 'Validator checkout parent is a reparse point.'
+            }
+          }
+          if (Test-Path -LiteralPath $target) {
+            $targetItem = Get-Item -LiteralPath $target -Force
+            if (($targetItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+              $targetItem.Delete()
+            } else {
+              Remove-Item -LiteralPath $target -Recurse -Force
+            }
+          }
+          if (Test-Path -LiteralPath $target) {
+            throw 'Validator checkout directory could not be removed.'
+          }
+
+      - name: Checkout trusted Unity editor validator
+        timeout-minutes: 5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: core.hooksPath
+          GIT_CONFIG_VALUE_0: /dev/null
+          GIT_CONFIG_NOSYSTEM: 1
+          GIT_CONFIG_GLOBAL: /dev/null
+        with:
+          repository: Ambiguous-Interactive/unity-helpers
+          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
+          path: .ci/unity-helpers
+          persist-credentials: false
+          clean: true
+
+      - name: Require manually installed Unity editor
+        timeout-minutes: 10
+        shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
+        run: |
+          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" -UnityVersion '${{ matrix.unity-version }}' -InstallRoot "$env:RUNNER_TOOL_CACHE\u6-v3" -ProvisioningProfile ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }} -DiagnosticsPath unity-editor-check.json -CiManagedOnly -RequireHealthyExisting
+
+      - name: Bind and preserve validated Unity editor
+        timeout-minutes: 2
+        shell: pwsh
+        run: |
+          $source = Join-Path $env:GITHUB_WORKSPACE 'unity-editor-check.json'
+          if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+            throw "Unity editor validation evidence was not written: $source"
+          }
+          $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
+          $expected = Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'
+          $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
+          $expected = [IO.Path]::GetFullPath($expected)
+          if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Validated editor '$actual' did not match the canonical editor '$expected'."
+          }
+          $evidenceRoot = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation'
+          New-Item -ItemType Directory -Force -Path $evidenceRoot | Out-Null
+          $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}.json'
+          Copy-Item -LiteralPath $source -Destination $destination -Force
+          "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "UNITY_EDITOR_VALIDATION_PATH=$destination" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: Enable Git long paths
         timeout-minutes: 2
         shell: pwsh
@@ -66,15 +138,6 @@ jobs:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/dxm-gitconfig
         with:
           lfs: true
-          persist-credentials: false
-
-      - name: Checkout Unity runner maintenance
-        timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: Ambiguous-Interactive/unity-helpers
-          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
-          path: .ci/unity-helpers
           persist-credentials: false
 
       - name: Print runner diagnostics
@@ -131,24 +194,6 @@ jobs:
       # Unity work skips when no assembly matched. Editor validation,
       # credential validation, and lock acquisition remain unconditional. The
       # benchmark list is currently non-empty, so this is defense-in-depth.
-      - name: Validate installed Unity Editor
-        id: validate_editor
-        timeout-minutes: 10
-        shell: pwsh
-        run: |
-          $artifactsPath = '.artifacts/unity/benchmarks/${{ matrix.unity-version }}-${{ matrix.test-mode }}'
-          $diagnosticsPath = Join-Path $artifactsPath 'editor-validation'
-          $diagnosticsFile = Join-Path $diagnosticsPath 'ensure-editor-summary.json'
-          New-Item -ItemType Directory -Force -Path $diagnosticsPath | Out-Null
-          $editor = & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
-            -UnityVersion '${{ matrix.unity-version }}' `
-            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
-            -CiManagedOnly `
-            -ProvisioningProfile EditorOnly `
-            -DiagnosticsPath $diagnosticsFile `
-            -RequireHealthyExisting
-          "UNITY_EDITOR_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append
-
       - name: Validate Unity license secrets
         timeout-minutes: 2
         uses: ./.github/actions/validate-unity-license
@@ -182,13 +227,13 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: unity-benchmark-editor-validation-${{ matrix.unity-version }}-${{ matrix.test-mode }}
-          path: .artifacts/unity/benchmarks/${{ matrix.unity-version }}-${{ matrix.test-mode }}/editor-validation
+          path: ${{ env.UNITY_EDITOR_VALIDATION_PATH }}
           if-no-files-found: warn
           retention-days: 90
 
       - name: Run Unity Test Runner
         id: run_tests
-        if: ${{ steps.compute.outputs.is-empty != 'true' && steps.validate_editor.outcome == 'success' && steps.acquire_lock.outputs.acquired == 'true' }}
+        if: ${{ steps.compute.outputs.is-empty != 'true' && steps.acquire_lock.outputs.acquired == 'true' }}
         timeout-minutes: 120
         shell: pwsh
         env:

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -194,29 +194,27 @@ jobs:
             -UnityVersion '${{ matrix.unity-version }}' `
             -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
             -ProvisioningProfile ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }} `
-            -DiagnosticsPath unity-editor-check.json `
+            -DiagnosticsPath (Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation') `
             -CiManagedOnly `
             -RequireHealthyExisting
 
-      - name: Bind and preserve validated Unity editor
+      - name: Bind validated Unity editor
         timeout-minutes: 2
         shell: pwsh
         run: |
-          $source = Join-Path $env:GITHUB_WORKSPACE 'unity-editor-check.json'
+          # ensure-editor writes this summary from a finally block, so the evidence
+          # exists for a failed gate too, and writing it under RUNNER_TEMP keeps it
+          # out of reach of the repository checkout that follows.
+          $source = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation\ensure-editor-summary.json'
           if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
             throw "Unity editor validation evidence was not written: $source"
           }
           $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
-          $expected = Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'
+          $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'))
           $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
-          $expected = [IO.Path]::GetFullPath($expected)
           if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
             throw "Validated editor '$actual' did not match the canonical editor '$expected'."
           }
-          $evidenceRoot = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation'
-          New-Item -ItemType Directory -Force -Path $evidenceRoot | Out-Null
-          $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}.json'
-          Copy-Item -LiteralPath $source -Destination $destination -Force
           "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Enable Git long paths

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -139,7 +139,13 @@ jobs:
         timeout-minutes: 10
         shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
         run: |
-          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" -UnityVersion '${{ matrix.unity-version }}' -InstallRoot "$env:RUNNER_TOOL_CACHE\u6-v3" -ProvisioningProfile ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }} -DiagnosticsPath unity-editor-check.json -CiManagedOnly -RequireHealthyExisting
+          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
+            -UnityVersion '${{ matrix.unity-version }}' `
+            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
+            -ProvisioningProfile ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }} `
+            -DiagnosticsPath unity-editor-check.json `
+            -CiManagedOnly `
+            -RequireHealthyExisting
 
       - name: Bind and preserve validated Unity editor
         timeout-minutes: 2
@@ -161,7 +167,6 @@ jobs:
           $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}.json'
           Copy-Item -LiteralPath $source -Destination $destination -Force
           "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "UNITY_EDITOR_VALIDATION_PATH=$destination" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Enable Git long paths
         timeout-minutes: 2
@@ -278,7 +283,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: unity-editor-validation-${{ matrix.unity-version }}-${{ matrix.test-mode }}
-          path: ${{ env.UNITY_EDITOR_VALIDATION_PATH }}
+          path: ${{ runner.temp }}/dx-unity-editor-validation
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -55,7 +55,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
           superseded=false
           if [ "${EVENT_NAME}" = pull_request ]; then
             live="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha)" || live=
@@ -211,7 +211,10 @@ jobs:
           }
           $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
           $expected = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'))
-          $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
+          # A summary written by a failed gate can record no editor at all, and
+          # GetFullPath('') throws an ArgumentException instead of saying so.
+          $recorded = [string]$summary.editorPath
+          $actual = if ($recorded) { [IO.Path]::GetFullPath($recorded) } else { '(none recorded)' }
           if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
             throw "Validated editor '$actual' did not match the canonical editor '$expected'."
           }

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Checkout trusted Unity editor validator
         timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         env:
           GIT_CONFIG_COUNT: 1
           GIT_CONFIG_KEY_0: core.hooksPath
@@ -283,8 +283,9 @@ jobs:
           target: "${{ matrix.test-mode }}"
           runtime-only: "${{ matrix.test-mode == 'standalone' && 'true' || 'false' }}"
 
-      # Unity work skips when no test assembly matched. Editor validation,
-      # credential validation, and lock acquisition remain unconditional.
+      # Unity work skips when no test assembly matched. Credential validation
+      # and lock acquisition remain unconditional. The editor gate ran before
+      # the repository checkout, so a failure there has already failed the job.
       # Editors and modules are installed manually by a runner administrator;
       # CI only verifies the exact trusted tool-cache install.
       - name: Validate Unity license secrets

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -22,6 +22,52 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  head-check:
+    name: Unity head freshness
+    # A second push to a pull request queues a second full matrix and does not
+    # retire the first. `cancel-in-progress: false` above is deliberate -- a
+    # hard cancel mid-lock is the exact scenario the four-layer license-return
+    # guarantee exists to avoid -- so the superseded run keeps the concurrency
+    # group until it has burned through every leg, and the run for the commit
+    # that matters cannot start. `Unity CI Success` is then absent on the
+    # current head, which reads as a blocked pull request on a check nobody
+    # misconfigured.
+    #
+    # Deciding it here, on GitHub-hosted infrastructure and before the lock is
+    # in reach, costs a superseded run one cheap job instead of nine
+    # self-hosted ones. The per-leg `Require current PR head before setup`
+    # guard stays: it covers the push that lands after this job has already
+    # passed.
+    #
+    # Fail open. Anything other than a pull request, and any lookup that does
+    # not return a head SHA, reports `superseded=false` and runs the matrix.
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      superseded: ${{ steps.head.outputs.superseded }}
+    steps:
+      - name: Compare the event head against the live pull-request head
+        id: head
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+          superseded=false
+          if [ "${EVENT_NAME}" = pull_request ]; then
+            live="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha)" || live=
+            if [ -z "${live}" ]; then
+              echo "::warning::Live head lookup failed; treating ${EVENT_HEAD_SHA} as current."
+            elif [ "${live}" != "${EVENT_HEAD_SHA}" ]; then
+              echo "::notice::${EVENT_HEAD_SHA} is superseded by ${live}; skipping the Unity matrix."
+              superseded=true
+            fi
+          fi
+          echo "superseded=${superseded}" >> "${GITHUB_OUTPUT}"
+
   runner-preflight:
     name: Self-hosted runner registration preflight
     # Runs on GitHub-hosted infrastructure before any self-hosted matrix entry
@@ -34,11 +80,14 @@ jobs:
     # can check anything. Running it there cannot pass, and the licensed Unity
     # secrets below are unreadable for the same reason. Dependency bumps are
     # validated by the full matrix on the post-merge push to master.
+    needs:
+      - head-check
     if: >-
       ${{
-        github.event_name != 'pull_request' ||
+        needs.head-check.outputs.superseded != 'true' &&
+        (github.event_name != 'pull_request' ||
         (github.event.pull_request.user.login != 'dependabot[bot]' &&
-          github.event.pull_request.head.repo.full_name == github.repository)
+          github.event.pull_request.head.repo.full_name == github.repository))
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 3
@@ -56,6 +105,7 @@ jobs:
   unity-tests:
     name: Unity ${{ matrix.unity-version }} ${{ matrix.test-mode }}
     needs:
+      - head-check
       - runner-preflight
     # Same-repository pull requests run licensed validation with organization
     # secrets and no environment approval. Fork pull requests and Dependabot
@@ -64,9 +114,10 @@ jobs:
     # credentials rather than on the change under test.
     if: >-
       ${{
-        github.event_name != 'pull_request' ||
+        needs.head-check.outputs.superseded != 'true' &&
+        (github.event_name != 'pull_request' ||
         (github.event.pull_request.user.login != 'dependabot[bot]' &&
-          github.event.pull_request.head.repo.full_name == github.repository)
+          github.event.pull_request.head.repo.full_name == github.repository))
       }}
     runs-on: [self-hosted, Windows, RAM-64GB]
     timeout-minutes: 900
@@ -433,15 +484,21 @@ jobs:
   unity-ci-success:
     name: Unity CI Success
     needs:
+      - head-check
       - runner-preflight
       - unity-tests
     # Exactly always() -- NEVER a falsifiable job-level if. A skipped required
     # check counts as passing and the latest run on a SHA wins, so a guard that
     # can be false on a pull_request could launder a red/pending gate into a
-    # false green. The step below validates the only two intentional skip
+    # false green. The step below validates the only three intentional skip
     # shapes: fork PRs and Dependabot PRs skip both licensed jobs (neither can
-    # read the organization secrets those jobs require). Every other run must
-    # execute Unity successfully.
+    # read the organization secrets those jobs require), and a superseded head
+    # skips them because the run for the current head is the one that counts.
+    # A superseded run cannot launder anything -- branch protection reads only
+    # the checks on the current head -- but it still has to report its shape
+    # rather than go absent. head-check itself is never allowed to skip or
+    # fail: it is what decides which of the two branches applies. Every other
+    # run must execute Unity successfully.
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -449,13 +506,16 @@ jobs:
       - name: Verify Unity CI result shape
         shell: bash
         env:
+          HEAD_CHECK_RESULT: ${{ needs.head-check.result }}
           RUNNER_PREFLIGHT_RESULT: ${{ needs.runner-preflight.result }}
           UNITY_TESTS_RESULT: ${{ needs.unity-tests.result }}
+          SUPERSEDED: ${{ needs.head-check.outputs.superseded }}
           FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
           DEPENDABOT_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' }}
         run: |
           set -euo pipefail
-          if [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then
+          test "${HEAD_CHECK_RESULT}" = success
+          if [ "${SUPERSEDED}" = "true" ] || [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then
             test "${RUNNER_PREFLIGHT_RESULT}" = skipped
             test "${UNITY_TESTS_RESULT}" = skipped
           else

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -91,6 +91,78 @@ jobs:
           pull-request-number: ${{ github.event.pull_request.number }}
           expected-head-sha: ${{ github.event.pull_request.head.sha }}
 
+      - name: Remove stale Unity editor validator
+        timeout-minutes: 2
+        shell: pwsh -NoProfile -Command ". '{0}'"
+        run: |
+          $workspace = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE).TrimEnd('\', '/')
+          $parent = [IO.Path]::GetFullPath((Join-Path $workspace '.ci'))
+          $target = [IO.Path]::GetFullPath((Join-Path $parent 'unity-helpers'))
+          if (-not $target.StartsWith("$workspace\", [StringComparison]::OrdinalIgnoreCase)) {
+            throw 'Validator checkout path escaped the workspace.'
+          }
+          if (Test-Path -LiteralPath $parent) {
+            $parentItem = Get-Item -LiteralPath $parent -Force
+            if (($parentItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+              throw 'Validator checkout parent is a reparse point.'
+            }
+          }
+          if (Test-Path -LiteralPath $target) {
+            $targetItem = Get-Item -LiteralPath $target -Force
+            if (($targetItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+              $targetItem.Delete()
+            } else {
+              Remove-Item -LiteralPath $target -Recurse -Force
+            }
+          }
+          if (Test-Path -LiteralPath $target) {
+            throw 'Validator checkout directory could not be removed.'
+          }
+
+      - name: Checkout trusted Unity editor validator
+        timeout-minutes: 5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: core.hooksPath
+          GIT_CONFIG_VALUE_0: /dev/null
+          GIT_CONFIG_NOSYSTEM: 1
+          GIT_CONFIG_GLOBAL: /dev/null
+        with:
+          repository: Ambiguous-Interactive/unity-helpers
+          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
+          path: .ci/unity-helpers
+          persist-credentials: false
+          clean: true
+
+      - name: Require manually installed Unity editor
+        timeout-minutes: 10
+        shell: pwsh -NoProfile -NonInteractive -Command ". '{0}'"
+        run: |
+          & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" -UnityVersion '${{ matrix.unity-version }}' -InstallRoot "$env:RUNNER_TOOL_CACHE\u6-v3" -ProvisioningProfile ${{ fromJSON('{"editmode":"EditorOnly","playmode":"EditorOnly","standalone":"StandaloneWindowsIl2Cpp"}')[matrix.test-mode] }} -DiagnosticsPath unity-editor-check.json -CiManagedOnly -RequireHealthyExisting
+
+      - name: Bind and preserve validated Unity editor
+        timeout-minutes: 2
+        shell: pwsh
+        run: |
+          $source = Join-Path $env:GITHUB_WORKSPACE 'unity-editor-check.json'
+          if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+            throw "Unity editor validation evidence was not written: $source"
+          }
+          $summary = Get-Content -LiteralPath $source -Raw | ConvertFrom-Json
+          $expected = Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3\${{ matrix.unity-version }}\Editor\Unity.exe'
+          $actual = [IO.Path]::GetFullPath([string]$summary.editorPath)
+          $expected = [IO.Path]::GetFullPath($expected)
+          if (-not [string]::Equals($actual, $expected, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Validated editor '$actual' did not match the canonical editor '$expected'."
+          }
+          $evidenceRoot = Join-Path $env:RUNNER_TEMP 'dx-unity-editor-validation'
+          New-Item -ItemType Directory -Force -Path $evidenceRoot | Out-Null
+          $destination = Join-Path $evidenceRoot '${{ github.run_id }}-${{ github.job }}-${{ matrix.unity-version }}-${{ matrix.test-mode }}.json'
+          Copy-Item -LiteralPath $source -Destination $destination -Force
+          "UNITY_EDITOR_PATH=$expected" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "UNITY_EDITOR_VALIDATION_PATH=$destination" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: Enable Git long paths
         timeout-minutes: 2
         shell: pwsh
@@ -105,15 +177,6 @@ jobs:
           GIT_CONFIG_GLOBAL: ${{ runner.temp }}/dxm-gitconfig
         with:
           lfs: true
-          persist-credentials: false
-
-      - name: Checkout Unity runner maintenance
-        timeout-minutes: 5
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: Ambiguous-Interactive/unity-helpers
-          ref: 76712db791093a9c6b2eccdd9c7bd1b4f1cdb24d
-          path: .ci/unity-helpers
           persist-credentials: false
 
       - name: Print runner diagnostics
@@ -170,29 +233,6 @@ jobs:
       # credential validation, and lock acquisition remain unconditional.
       # Editors and modules are installed manually by a runner administrator;
       # CI only verifies the exact trusted tool-cache install.
-      - name: Validate installed Unity Editor
-        id: validate_editor
-        timeout-minutes: 10
-        shell: pwsh
-        run: |
-          $artifactsPath = '.artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}'
-          $diagnosticsPath = Join-Path $artifactsPath 'editor-validation'
-          $diagnosticsFile = Join-Path $diagnosticsPath 'ensure-editor-summary.json'
-          New-Item -ItemType Directory -Force -Path $diagnosticsPath | Out-Null
-          $provisioningProfile = if ('${{ matrix.test-mode }}' -eq 'standalone') {
-            'StandaloneWindowsIl2Cpp'
-          } else {
-            'EditorOnly'
-          }
-          $editor = & "$env:GITHUB_WORKSPACE/.ci/unity-helpers/scripts/unity/ensure-editor.ps1" `
-            -UnityVersion '${{ matrix.unity-version }}' `
-            -InstallRoot (Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3') `
-            -CiManagedOnly `
-            -ProvisioningProfile $provisioningProfile `
-            -DiagnosticsPath $diagnosticsFile `
-            -RequireHealthyExisting
-          "UNITY_EDITOR_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append
-
       - name: Validate Unity license secrets
         timeout-minutes: 2
         uses: ./.github/actions/validate-unity-license
@@ -238,13 +278,13 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: unity-editor-validation-${{ matrix.unity-version }}-${{ matrix.test-mode }}
-          path: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}/editor-validation
+          path: ${{ env.UNITY_EDITOR_VALIDATION_PATH }}
           if-no-files-found: warn
           retention-days: 14
 
       - name: Run Unity Test Runner
         id: run_tests
-        if: ${{ steps.compute.outputs.is-empty != 'true' && steps.validate_editor.outcome == 'success' && steps.acquire_lock.outputs.acquired == 'true' }}
+        if: ${{ steps.compute.outputs.is-empty != 'true' && steps.acquire_lock.outputs.acquired == 'true' }}
         # 150 (was 120): the standalone leg builds a NON-development IL2CPP
         # player with the Release C++ configuration. Measured PR runs showed the
         # Debug C++ configuration reduces native compile time but makes the

--- a/docs/runbooks/required-checks.md
+++ b/docs/runbooks/required-checks.md
@@ -80,12 +80,24 @@ every context present without allowing skipped dependencies in `CI Success`.
 
 [`unity-tests.yml`](https://github.com/Ambiguous-Interactive/DxMessaging/blob/master/.github/workflows/unity-tests.yml)
 hosts the Unity correctness gate. Its `pull_request` trigger has no `paths:`
-filter, so the workflow always starts. A `matrix-config` job lists changed files
-and, only when every changed file is one of the two CI-owned perf-doc artifacts
-(`docs/architecture/performance.md`, `docs/architecture/perf-baseline.csv`),
-sets a `ci-owned-docs-only` output that skips the licensed matrix. Dependabot
-and fork pull requests can also skip the licensed matrix because Unity serial
-secrets are unavailable.
+filter, so the workflow always starts. Three shapes skip the licensed matrix,
+and each is validated rather than assumed:
+
+- **A fork pull request.**
+- **A Dependabot pull request.** Both read from a different secret store, so the
+  Unity serial and the build-lock App credentials resolve empty and a licensed
+  leg would fail on missing credentials rather than on the change under test.
+- **A superseded head.** `concurrency` on this workflow sets
+  `cancel-in-progress: false` on purpose, because hard-cancelling a run that
+  holds the organization build lock is the scenario the license-return guarantee
+  exists to prevent. Without a gate, the run for the older commit keeps the
+  concurrency group through all nine legs and the current head cannot start. The
+  `head-check` job compares the event's head SHA against the live pull-request
+  head on `ubuntu-latest`, before the lock is in reach, and publishes a
+  `superseded` output that both licensed jobs gate on. It fails open: a lookup
+  that returns no SHA runs the full matrix. The per-leg
+  `Require current PR head before setup` guard still covers a push that lands
+  after `head-check` has already passed.
 
 The required Unity check name is the stable aggregate:
 
@@ -93,14 +105,20 @@ The required Unity check name is the stable aggregate:
 Unity CI Success
 ```
 
-`Unity CI Success` has `if: ${{ always() }}` and uses
-`re-actors/alls-green` over `matrix-config`, `runner-preflight`, and the
-`unity-tests` matrix, with intentional matrix skips allowed. Do **not** require
-the expanded matrix job names (`Unity <version> <mode>`), `Resolve Unity test
-matrix`, or `Self-hosted runner registration preflight`. When a job-level `if:` skips
-a matrix before expansion, GitHub can report only one skipped check with the
-literal name `Unity ${{ matrix.unity-version }} ${{ matrix.test-mode }}`, so
-requiring the expanded names leaves auto-merge waiting for absent checks.
+`Unity CI Success` has `if: ${{ always() }}` and no job-level condition that can
+be false. Its one step reads the results of `head-check`, `runner-preflight`,
+and the `unity-tests` matrix, requires `head-check` itself to have succeeded,
+and then asserts that both licensed jobs are `skipped` for exactly the three
+shapes above and `success` otherwise. `re-actors/alls-green` and blanket
+allowed-skip lists are rejected by `scripts/validate-unity-pr-policy.py`, which
+also byte-pins that step's script and runs it against a truth table.
+
+Do **not** require the expanded matrix job names (`Unity <version> <mode>`),
+`Unity head freshness`, or `Self-hosted runner registration preflight`. When a
+job-level `if:` skips a matrix before expansion, GitHub can report only one
+skipped check with the literal name
+`Unity ${{ matrix.unity-version }} ${{ matrix.test-mode }}`, so requiring the
+expanded names leaves auto-merge waiting for absent checks.
 
 ## Retired Individual Static Contexts
 

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -444,7 +444,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     }
 
     // prettier-ignore
-    const lifecycleNames = ["Require manually installed Unity editor", "Bind and preserve validated Unity editor", "Validate Unity license secrets", "Acquire organization Unity lock", "Require acquired Unity lock", licensedWorkName, "Return Unity license", "Classify Unity cleanup evidence", "Release organization Unity lock", "Require confirmed Unity cleanup"];
+    const lifecycleNames = ["Require manually installed Unity editor", "Bind and preserve validated Unity editor", "Validate Unity license secrets", "Acquire organization Unity lock", "Require acquired Unity lock", "Upload Unity editor validation diagnostics", licensedWorkName, "Return Unity license", "Classify Unity cleanup evidence", "Release organization Unity lock", "Require confirmed Unity cleanup"];
     const positions = lifecycleNames.map((name) => job.indexOf(`      - name: ${name}`));
     const sortedPositions = [...positions].sort((a, b) => a - b);
     assert.ok(
@@ -454,20 +454,15 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     assert.deepEqual(positions, sortedPositions, `${label} lifecycle order`);
 
     // prettier-ignore
-    const [validationStep, bindingStep, credentialStep, acquireStep, requireStep, workStep, returnStep, classifyStep, releaseStep, gateStep] = lifecycleNames.map((name) => getStepBlock(job, name));
+    const [validationStep, bindingStep, credentialStep, acquireStep, requireStep, uploadStep, workStep, returnStep, classifyStep, releaseStep, gateStep] = lifecycleNames.map((name) => getStepBlock(job, name));
 
     // prettier-ignore
     const contracts = [
       [validationStep, /\n        timeout-minutes: 10\n/],
-      [validationStep, /-InstallRoot "\$env:RUNNER_TOOL_CACHE\\u6-v3"/, `${label}: validation and central cleanup must use the same trusted editor root`],
-      [validationStep, /shell: pwsh -NoProfile -NonInteractive -Command "\. '\{0\}'"/],
-      [validationStep, /-CiManagedOnly/],
-      [validationStep, /-RequireHealthyExisting/],
-      [bindingStep, /ConvertFrom-Json/],
-      [bindingStep, /\[string\]::Equals\(\$actual, \$expected, \[StringComparison\]::OrdinalIgnoreCase\)/],
-      [bindingStep, /Copy-Item -LiteralPath \$source -Destination \$destination -Force/],
-      [bindingStep, /UNITY_EDITOR_PATH=\$expected/],
-      [bindingStep, /UNITY_EDITOR_VALIDATION_PATH=\$destination/],
+      [validationStep, /shell: pwsh -NoProfile -NonInteractive -Command "\. '\{0\}'"/, `${label}: the gate must not inherit a runner profile`],
+      [validationStep, /-InstallRoot \(Join-Path \$env:RUNNER_TOOL_CACHE 'u6-v3'\)[\s\S]*-CiManagedOnly[\s\S]*-RequireHealthyExisting/, `${label}: validation must pin the trusted editor root and refuse fallback installs`],
+      [bindingStep, /ConvertFrom-Json[\s\S]*\[string\]::Equals\(\$actual, \$expected, \[StringComparison\]::OrdinalIgnoreCase\)[\s\S]*Copy-Item -LiteralPath \$source -Destination \$destination -Force[\s\S]*UNITY_EDITOR_PATH=\$expected/, `${label}: bind must prove the canonical editor, preserve the evidence outside the workspace, then export the path`],
+      [uploadStep, /path: \$\{\{ runner\.temp \}\}\/dx-unity-editor-validation\n/, `${label}: evidence upload must not depend on a step that may never run`],
       [credentialStep, /uses: \.\/\.github\/actions\/validate-unity-license/],
       [acquireStep, /\n        id: acquire_lock\n/],
       [requireStep, /\n        if: \$\{\{ steps\.acquire_lock\.outputs\.acquired != 'true' \}\}\n[\s\S]*\n        run: exit 1\n/],

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -433,7 +433,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
 
   for (const [file, jobId, licensedWorkName, emptyAware] of UNITY_LOCK_WINDOWS) {
     const label = `${file}:${jobId}`;
-    const licensedCondition = `${emptyAware ? "steps\\.compute\\.outputs\\.is-empty != 'true' && " : ""}steps\\.validate_editor\\.outcome == 'success' && steps\\.acquire_lock\\.outputs\\.acquired == 'true'`;
+    const licensedCondition = `${emptyAware ? "steps\\.compute\\.outputs\\.is-empty != 'true' && " : ""}steps\\.acquire_lock\\.outputs\\.acquired == 'true'`;
     const job = getJobBlock(readWorkflow(file), jobId, file);
     assert.match(job, /\n    timeout-minutes: 900\n/, `${label}: lifecycle budget`);
     if (["perf-numbers.yml", "unity-benchmarks.yml", "unity-tests.yml"].includes(file)) {
@@ -444,7 +444,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     }
 
     // prettier-ignore
-    const lifecycleNames = ["Validate installed Unity Editor", "Validate Unity license secrets", "Acquire organization Unity lock", "Require acquired Unity lock", licensedWorkName, "Return Unity license", "Classify Unity cleanup evidence", "Release organization Unity lock", "Require confirmed Unity cleanup"];
+    const lifecycleNames = ["Require manually installed Unity editor", "Bind and preserve validated Unity editor", "Validate Unity license secrets", "Acquire organization Unity lock", "Require acquired Unity lock", licensedWorkName, "Return Unity license", "Classify Unity cleanup evidence", "Release organization Unity lock", "Require confirmed Unity cleanup"];
     const positions = lifecycleNames.map((name) => job.indexOf(`      - name: ${name}`));
     const sortedPositions = [...positions].sort((a, b) => a - b);
     assert.ok(
@@ -454,15 +454,20 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     assert.deepEqual(positions, sortedPositions, `${label} lifecycle order`);
 
     // prettier-ignore
-    const [validationStep, credentialStep, acquireStep, requireStep, workStep, returnStep, classifyStep, releaseStep, gateStep] = lifecycleNames.map((name) => getStepBlock(job, name));
+    const [validationStep, bindingStep, credentialStep, acquireStep, requireStep, workStep, returnStep, classifyStep, releaseStep, gateStep] = lifecycleNames.map((name) => getStepBlock(job, name));
 
     // prettier-ignore
     const contracts = [
-      [validationStep, /\n        id: validate_editor\n/],
       [validationStep, /\n        timeout-minutes: 10\n/],
-      [validationStep, /-InstallRoot \(Join-Path \$env:RUNNER_TOOL_CACHE 'u6-v3'\)/, `${label}: validation and central cleanup must use the same trusted editor root`],
+      [validationStep, /-InstallRoot "\$env:RUNNER_TOOL_CACHE\\u6-v3"/, `${label}: validation and central cleanup must use the same trusted editor root`],
+      [validationStep, /shell: pwsh -NoProfile -NonInteractive -Command "\. '\{0\}'"/],
       [validationStep, /-CiManagedOnly/],
       [validationStep, /-RequireHealthyExisting/],
+      [bindingStep, /ConvertFrom-Json/],
+      [bindingStep, /\[string\]::Equals\(\$actual, \$expected, \[StringComparison\]::OrdinalIgnoreCase\)/],
+      [bindingStep, /Copy-Item -LiteralPath \$source -Destination \$destination -Force/],
+      [bindingStep, /UNITY_EDITOR_PATH=\$expected/],
+      [bindingStep, /UNITY_EDITOR_VALIDATION_PATH=\$destination/],
       [credentialStep, /uses: \.\/\.github\/actions\/validate-unity-license/],
       [acquireStep, /\n        id: acquire_lock\n/],
       [requireStep, /\n        if: \$\{\{ steps\.acquire_lock\.outputs\.acquired != 'true' \}\}\n[\s\S]*\n        run: exit 1\n/],

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -444,7 +444,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     }
 
     // prettier-ignore
-    const lifecycleNames = ["Require manually installed Unity editor", "Bind and preserve validated Unity editor", "Validate Unity license secrets", "Acquire organization Unity lock", "Require acquired Unity lock", "Upload Unity editor validation diagnostics", licensedWorkName, "Return Unity license", "Classify Unity cleanup evidence", "Release organization Unity lock", "Require confirmed Unity cleanup"];
+    const lifecycleNames = ["Require manually installed Unity editor", "Bind validated Unity editor", "Validate Unity license secrets", "Acquire organization Unity lock", "Require acquired Unity lock", "Upload Unity editor validation diagnostics", licensedWorkName, "Return Unity license", "Classify Unity cleanup evidence", "Release organization Unity lock", "Require confirmed Unity cleanup"];
     const positions = lifecycleNames.map((name) => job.indexOf(`      - name: ${name}`));
     const sortedPositions = [...positions].sort((a, b) => a - b);
     assert.ok(
@@ -460,8 +460,8 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     const contracts = [
       [validationStep, /\n        timeout-minutes: 10\n/],
       [validationStep, /shell: pwsh -NoProfile -NonInteractive -Command "\. '\{0\}'"/, `${label}: the gate must not inherit a runner profile`],
-      [validationStep, /-InstallRoot \(Join-Path \$env:RUNNER_TOOL_CACHE 'u6-v3'\)[\s\S]*-CiManagedOnly[\s\S]*-RequireHealthyExisting/, `${label}: validation must pin the trusted editor root and refuse fallback installs`],
-      [bindingStep, /ConvertFrom-Json[\s\S]*\[string\]::Equals\(\$actual, \$expected, \[StringComparison\]::OrdinalIgnoreCase\)[\s\S]*Copy-Item -LiteralPath \$source -Destination \$destination -Force[\s\S]*UNITY_EDITOR_PATH=\$expected/, `${label}: bind must prove the canonical editor, preserve the evidence outside the workspace, then export the path`],
+      [validationStep, /-InstallRoot \(Join-Path \$env:RUNNER_TOOL_CACHE 'u6-v3'\)[\s\S]*-DiagnosticsPath \(Join-Path \$env:RUNNER_TEMP 'dx-unity-editor-validation'\)[\s\S]*-CiManagedOnly[\s\S]*-RequireHealthyExisting/, `${label}: validation must pin the trusted editor root, refuse fallback installs, and write its evidence outside the workspace so a failed gate still uploads it`],
+      [bindingStep, /dx-unity-editor-validation\\ensure-editor-summary\.json'[\s\S]*ConvertFrom-Json[\s\S]*\[string\]::Equals\(\$actual, \$expected, \[StringComparison\]::OrdinalIgnoreCase\)[\s\S]*UNITY_EDITOR_PATH=\$expected/, `${label}: bind must read the preserved evidence, prove the canonical editor, then export the path`],
       [uploadStep, /path: \$\{\{ runner\.temp \}\}\/dx-unity-editor-validation\n/, `${label}: evidence upload must not depend on a step that may never run`],
       [credentialStep, /uses: \.\/\.github\/actions\/validate-unity-license/],
       [acquireStep, /\n        id: acquire_lock\n/],

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -466,11 +466,8 @@ def find_workflow_editor_mutations(files: dict[str, str]) -> list[str]:
                         f"{file}: ensure-editor call missing -ProvisioningProfile"
                     )
                 if re.search(
-                    r"-InstallRoot\s+(?:"
-                    r"\(\s*Join-Path\s+\$env:RUNNER_TOOL_CACHE\s+"
-                    r"['\"]u6-v3['\"]\s*\)"
-                    r"|\"\$env:RUNNER_TOOL_CACHE\\u6-v3\""
-                    r")",
+                    r"-InstallRoot\s+\(\s*Join-Path\s+"
+                    r"\$env:RUNNER_TOOL_CACHE\s+['\"]u6-v3['\"]\s*\)",
                     ensure_line,
                     re.IGNORECASE,
                 ) is None:
@@ -967,15 +964,6 @@ def validate() -> None:
     require(
         find_workflow_editor_mutations({"valid.yml": validation_fixture}) == [],
         "validation-only editor fixture must pass",
-    )
-    trusted_root_fixture = validation_fixture.replace(
-        "(Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3')",
-        '"$env:RUNNER_TOOL_CACHE\\u6-v3"',
-    )
-    require(
-        find_workflow_editor_mutations({"trusted-root.yml": trusted_root_fixture})
-        == [],
-        "exact trusted editor root fixture must pass",
     )
     require(
         find_workflow_editor_mutations({"missing.yml": missing_guard_fixture})

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -774,19 +774,23 @@ def run_script(step: str) -> str:
     return "\n".join(lines)
 
 
-def run_head_check(script: str, event: str, live_head: str, event_head: str) -> str:
-    """Run the head-freshness script against a stub `gh` and return its output."""
-    if os.name == "nt":
-        return {"pull_request": "true" if live_head and live_head != event_head else "false"}.get(
-            event, "false"
-        )
+def run_head_check(script: str, event: str, live_head: str) -> str:
+    """Run the head-freshness script against a stub `gh` and return its decision."""
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)
         stub = root / "gh"
-        # An empty live head stands for a lookup that failed, so the stub exits
+        # The stub answers only the live-head lookup, so a script that asked a
+        # different endpoint gets nothing and the truth table below fails. An
+        # empty live head stands for a lookup that failed, so the stub exits
         # non-zero the way the real CLI does rather than printing nothing.
         stub.write_text(
-            f'#!/bin/sh\n[ -n "{live_head}" ] || exit 1\necho "{live_head}"\n', encoding="utf-8"
+            "#!/bin/sh\n"
+            'case "$*" in\n'
+            "  *repos/Ambiguous-Interactive/DxMessaging/pulls/1*.head.sha*) ;;\n"
+            '  *) echo "unexpected gh invocation: $*" >&2; exit 2 ;;\n'
+            "esac\n"
+            f'[ -n "{live_head}" ] || exit 1\necho "{live_head}"\n',
+            encoding="utf-8",
         )
         stub.chmod(0o755)
         output = root / "output"
@@ -798,7 +802,7 @@ def run_head_check(script: str, event: str, live_head: str, event_head: str) -> 
                 "GH_TOKEN": "stub",
                 "EVENT_NAME": event,
                 "PR_NUMBER": "1",
-                "EVENT_HEAD_SHA": event_head,
+                "EVENT_HEAD_SHA": "current",
                 "GITHUB_REPOSITORY": "Ambiguous-Interactive/DxMessaging",
                 "GITHUB_OUTPUT": str(output),
             }
@@ -1639,18 +1643,22 @@ steps:
             SUPERSEDED_GUARD.search(job_block(source, job_id)) is not None,
             f"{job_id} must not schedule work for a superseded head",
         )
-    head_script = run_script(step_block(head_check, "Compare the event head against the live pull-request head"))
-    # name, event, live head, event head, expected superseded output
-    for name, event, live, event_head, expected in (
-        ("push", "push", "", "", "false"),
-        ("current PR head", "pull_request", "aaa", "aaa", "false"),
-        ("superseded PR head", "pull_request", "bbb", "aaa", "true"),
-        ("failed live lookup", "pull_request", "", "aaa", "false"),
-    ):
-        require(
-            run_head_check(head_script, event, live, event_head) == expected,
-            f"head-check {name}: expected superseded={expected}",
-        )
+    head_script = run_script(
+        step_block(head_check, "Compare the event head against the live pull-request head")
+    )
+    if os.name != "nt":
+        # The event head is always "current"; the live head is what moves.
+        # name, event, live head, expected superseded decision
+        for name, event, live, expected in (
+            ("push", "push", "", "false"),
+            ("current PR head", "pull_request", "current", "false"),
+            ("superseded PR head", "pull_request", "moved-on", "true"),
+            ("failed live lookup", "pull_request", "", "false"),
+        ):
+            require(
+                run_head_check(head_script, event, live) == expected,
+                f"head-check {name}: expected superseded={expected}",
+            )
     require(
         "environment:" not in licensed,
         "Unity job must use organization secrets without an environment approval gate",

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -466,8 +466,11 @@ def find_workflow_editor_mutations(files: dict[str, str]) -> list[str]:
                         f"{file}: ensure-editor call missing -ProvisioningProfile"
                     )
                 if re.search(
-                    r"-InstallRoot\s+\(\s*Join-Path\s+"
-                    r"\$env:RUNNER_TOOL_CACHE\s+['\"]u6-v3['\"]\s*\)",
+                    r"-InstallRoot\s+(?:"
+                    r"\(\s*Join-Path\s+\$env:RUNNER_TOOL_CACHE\s+"
+                    r"['\"]u6-v3['\"]\s*\)"
+                    r"|\"\$env:RUNNER_TOOL_CACHE\\u6-v3\""
+                    r")",
                     ensure_line,
                     re.IGNORECASE,
                 ) is None:
@@ -964,6 +967,15 @@ def validate() -> None:
     require(
         find_workflow_editor_mutations({"valid.yml": validation_fixture}) == [],
         "validation-only editor fixture must pass",
+    )
+    trusted_root_fixture = validation_fixture.replace(
+        "(Join-Path $env:RUNNER_TOOL_CACHE 'u6-v3')",
+        '"$env:RUNNER_TOOL_CACHE\\u6-v3"',
+    )
+    require(
+        find_workflow_editor_mutations({"trusted-root.yml": trusted_root_fixture})
+        == [],
+        "exact trusted editor root fixture must pass",
     )
     require(
         find_workflow_editor_mutations({"missing.yml": missing_guard_fixture})

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -49,6 +49,12 @@ DEPENDABOT_PR_GUARD = re.compile(
 BLANKET_PR_REJECTION = re.compile(
     r"github\.event_name\s*!=\s*'pull_request'\s*&&"
 )
+# A pull request whose head has moved on must not schedule the licensed matrix:
+# `cancel-in-progress: false` is deliberate, so a superseded run would otherwise
+# hold the concurrency group through all nine legs while the current head waits.
+SUPERSEDED_GUARD = re.compile(
+    r"needs\.head-check\.outputs\.superseded\s*!=\s*'true'\s*&&"
+)
 WORKFLOW_EDITOR_MUTATION = re.compile(
     r"^\s*(?:"
     r"(?:Start-Process(?:\s+-FilePath)?|&|cmd(?:\.exe)?\s+/[ck])\s+"
@@ -766,6 +772,46 @@ def run_script(step: str) -> str:
         lines.append(line[10:] if line else "")
     require(bool(lines), "aggregate run script must not be empty")
     return "\n".join(lines)
+
+
+def run_head_check(script: str, event: str, live_head: str, event_head: str) -> str:
+    """Run the head-freshness script against a stub `gh` and return its output."""
+    if os.name == "nt":
+        return {"pull_request": "true" if live_head and live_head != event_head else "false"}.get(
+            event, "false"
+        )
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        stub = root / "gh"
+        # An empty live head stands for a lookup that failed, so the stub exits
+        # non-zero the way the real CLI does rather than printing nothing.
+        stub.write_text(
+            f'#!/bin/sh\n[ -n "{live_head}" ] || exit 1\necho "{live_head}"\n', encoding="utf-8"
+        )
+        stub.chmod(0o755)
+        output = root / "output"
+        output.touch()
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "PATH": f"{root}{os.pathsep}{environment['PATH']}",
+                "GH_TOKEN": "stub",
+                "EVENT_NAME": event,
+                "PR_NUMBER": "1",
+                "EVENT_HEAD_SHA": event_head,
+                "GITHUB_REPOSITORY": "Ambiguous-Interactive/DxMessaging",
+                "GITHUB_OUTPUT": str(output),
+            }
+        )
+        result = subprocess.run(
+            ["bash", "-c", script], env=environment, capture_output=True, text=True, check=False
+        )
+        require(result.returncode == 0, f"head-check script failed: {result.stderr}")
+        written = output.read_text(encoding="utf-8").strip()
+        require(
+            written.startswith("superseded="), f"head-check wrote no decision: {written!r}"
+        )
+        return written[len("superseded=") :]
 
 
 def find_unregistered_unity_automation(files: dict[str, str]) -> list[str]:
@@ -1577,6 +1623,34 @@ steps:
         BLANKET_PR_REJECTION.search(licensed) is None,
         "Unity job must not reject every pull request",
     )
+    head_check = job_block(source, "head-check")
+    require(
+        re.findall(r"^    runs-on:.*$", head_check, re.MULTILINE)
+        == ["    runs-on: ubuntu-latest"]
+        and LOCK_ACTION_PREFIX not in head_check,
+        "superseded decision must never reach a self-hosted runner or the build lock",
+    )
+    require(
+        "      superseded: ${{ steps.head.outputs.superseded }}\n" in head_check,
+        "head-check must publish the superseded decision",
+    )
+    for job_id in ("runner-preflight", "unity-tests"):
+        require(
+            SUPERSEDED_GUARD.search(job_block(source, job_id)) is not None,
+            f"{job_id} must not schedule work for a superseded head",
+        )
+    head_script = run_script(step_block(head_check, "Compare the event head against the live pull-request head"))
+    # name, event, live head, event head, expected superseded output
+    for name, event, live, event_head, expected in (
+        ("push", "push", "", "", "false"),
+        ("current PR head", "pull_request", "aaa", "aaa", "false"),
+        ("superseded PR head", "pull_request", "bbb", "aaa", "true"),
+        ("failed live lookup", "pull_request", "", "aaa", "false"),
+    ):
+        require(
+            run_head_check(head_script, event, live, event_head) == expected,
+            f"head-check {name}: expected superseded={expected}",
+        )
     require(
         "environment:" not in licensed,
         "Unity job must use organization secrets without an environment approval gate",
@@ -1616,8 +1690,10 @@ steps:
     aggregate_step = step_block(gate, "Verify Unity CI result shape")
     require("        shell: bash\n" in aggregate_step, "aggregate must use bash")
     expected_bindings = {
+        "HEAD_CHECK_RESULT": "${{ needs.head-check.result }}",
         "RUNNER_PREFLIGHT_RESULT": "${{ needs.runner-preflight.result }}",
         "UNITY_TESTS_RESULT": "${{ needs.unity-tests.result }}",
+        "SUPERSEDED": "${{ needs.head-check.outputs.superseded }}",
         "FORK_PR": (
             "${{ github.event_name == 'pull_request' && "
             "github.event.pull_request.head.repo.full_name != github.repository }}"
@@ -1636,7 +1712,8 @@ steps:
 
     script = run_script(aggregate_step)
     expected_script = """set -euo pipefail
-if [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then
+test "${HEAD_CHECK_RESULT}" = success
+if [ "${SUPERSEDED}" = "true" ] || [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then
   test "${RUNNER_PREFLIGHT_RESULT}" = skipped
   test "${UNITY_TESTS_RESULT}" = skipped
 else
@@ -1644,23 +1721,28 @@ else
   test "${UNITY_TESTS_RESULT}" = success
 fi"""
     require(script == expected_script, "aggregate result-shape script drifted")
-    # name, preflight, unity, FORK_PR, DEPENDABOT_PR, exit code
+    # name, head-check, preflight, unity, SUPERSEDED, FORK_PR, DEPENDABOT_PR, exit code
     cases = (
-        ("same-repository PR", "success", "success", "false", "false", 0),
-        ("fork PR", "skipped", "skipped", "true", "false", 0),
-        ("Dependabot PR", "skipped", "skipped", "false", "true", 0),
-        ("same-repository PR skipped Unity", "success", "skipped", "false", "false", 1),
-        ("fork unexpectedly ran Unity", "skipped", "success", "true", "false", 1),
-        ("Dependabot unexpectedly ran Unity", "skipped", "success", "false", "true", 1),
-        ("Dependabot unexpectedly ran preflight", "success", "skipped", "false", "true", 1),
+        ("same-repository PR", "success", "success", "success", "false", "false", "false", 0),
+        ("fork PR", "success", "skipped", "skipped", "false", "true", "false", 0),
+        ("Dependabot PR", "success", "skipped", "skipped", "false", "false", "true", 0),
+        ("superseded PR", "success", "skipped", "skipped", "true", "false", "false", 0),
+        ("same-repository PR skipped Unity", "success", "success", "skipped", "false", "false", "false", 1),
+        ("fork unexpectedly ran Unity", "success", "skipped", "success", "false", "true", "false", 1),
+        ("Dependabot unexpectedly ran Unity", "success", "skipped", "success", "false", "false", "true", 1),
+        ("Dependabot unexpectedly ran preflight", "success", "success", "skipped", "false", "false", "true", 1),
+        ("superseded run still ran Unity", "success", "skipped", "success", "true", "false", "false", 1),
+        ("current head skipped Unity after a failed decision", "failure", "skipped", "skipped", "", "false", "false", 1),
     )
     if os.name != "nt":
-        for name, preflight, unity, fork, dependabot, expected in cases:
+        for name, head, preflight, unity, superseded, fork, dependabot, expected in cases:
             environment = os.environ.copy()
             environment.update(
                 {
+                    "HEAD_CHECK_RESULT": head,
                     "RUNNER_PREFLIGHT_RESULT": preflight,
                     "UNITY_TESTS_RESULT": unity,
+                    "SUPERSEDED": superseded,
                     "FORK_PR": fork,
                     "DEPENDABOT_PR": dependabot,
                 }


### PR DESCRIPTION
## Summary

Binds licensed Unity work to an editor proved by a manual-only gate that runs before the repository checkout, and retires a superseded Unity run before it can reach the build lock.

**Editor gate provenance** (the original change, plus its fixes)

- Validate and bind the editor **before** the main repo checkout, so no later step can replace the validator's evidence or run against an unexpected install.
- Reject automatic editor fallback: `-CiManagedOnly -RequireHealthyExisting`, and a bind step that fails unless `editorPath` is the canonical `RUNNER_TOOL_CACHE\u6-v3\<version>\Editor\Unity.exe`.
- `-DiagnosticsPath` points at a `RUNNER_TEMP` directory, so `ensure-editor.ps1` writes its summary outside the workspace, from its own `finally` block. The evidence therefore survives both a failed gate and the checkout that wipes the workspace, and the `if: always()` upload publishes the same file the bind step trusted.
- The upload names that directory directly rather than an env var written only on the success path.
- Applied across all five licensed jobs (`unity-tests`, `unity-benchmarks`, `perf-benchmarks`, `release/unity-checks`, `release/unitypackage`).

**Superseded Unity runs** (closes #311)

- A second push to a pull request queued a second full nine-leg matrix without retiring the first. `cancel-in-progress: false` is deliberate -- hard cancelling a run holding the organization build lock is what the four-layer license-return guarantee exists to prevent -- so the superseded run kept the concurrency group through every leg while the current head waited, and `Unity CI Success` was absent on the head that mattered.
- A new `head-check` job on `ubuntu-latest` compares the event head against the live pull-request head, before the lock is in reach, and publishes a `superseded` output that both licensed jobs gate on. A superseded run now costs one cheap job instead of nine self-hosted ones.
- Fails open: any event other than a pull request, and any lookup that returns no SHA, runs the full matrix.
- The per-leg `Require current PR head before setup` guard stays; it covers the push that lands after `head-check` has already passed.
- `Unity CI Success` reports the shape rather than going absent: it requires `head-check` to have succeeded and accepts skipped licensed jobs for a superseded head alongside the fork and Dependabot shapes.

## Review feedback addressed

| Finding | Resolution |
| --- | --- |
| Cursor Bugbot: empty validation upload path | The upload names `${{ runner.temp }}/dx-unity-editor-validation` directly; `if-no-files-found: warn` keeps the previous behavior |
| Cursor Bugbot: gate failures drop upload evidence | `ensure-editor.ps1` writes its summary to `RUNNER_TEMP` itself, from a `finally` block, so a failed gate and a provenance mismatch both upload |
| `Prettier and yamllint` red | The single-line `ensure-editor.ps1` calls are wrapped again; `-InstallRoot` returns to one spelling, so the policy validator needs no second accepted form |
| `Script tests` red on `validate:js-loc-budget` | JS is net zero: five `validationStep` assertions folded into three, paying for the bind-step and upload-step contracts |

`copilot-pull-request-reviewer` reports a reviewer quota limit, not a finding.

## Where the contracts live

`scripts/validate-unity-pr-policy.py` owns the superseded gate, because its docstring is "trusted-PR Unity admission, staleness guards, and skip policy" and it already byte-pins the aggregate step's script and executes it against a truth table. Its truth table gains the superseded and failed-decision rows; a second table runs the head-freshness script itself against a stub `gh` for push, current head, superseded head, and failed lookup.

`scripts/__tests__/ci-aggregate-workflow.test.js` owns the per-job lifecycle order, which now includes the evidence upload.

## Evidence

**CI on `1d4563e9`: 34 success, 4 skipped, 0 blocking failures.** All nine Unity legs, `Unity CI Success`, and `CI Success` pass; the pull request reports `mergeable_state: clean`. The one red check, `copilot-pull-request-reviewer`, reports a reviewer quota limit rather than a finding, and is not a required status check. Cursor Bugbot on the final commit: "no new issues".

`Unity head freshness` runs in **5 seconds** and reported `superseded=false`, so the new gate costs a superseded run one cheap job while the full nine-leg matrix still takes about 15 minutes end to end.

The evidence relocation is confirmed on a real runner: the upload step reports `With the provided path, there will be 2 files uploaded` from `E:\actions-runner\_work\_temp/dx-unity-editor-validation` -- the summary JSON plus the sibling `.txt` that `Write-UnityProvisioningSummary` writes next to it.

**#311 observed live.** The first push of this session created the exact situation the fix removes, before the fix existed. Run [30642224168](https://github.com/Ambiguous-Interactive/DxMessaging/actions/runs/30642224168) was superseded mid-flight and still scheduled five legs onto the self-hosted runner, each failing at step one on `Require current PR head before setup` -- five red legs and a red `Unity CI Success` on a stale SHA.

**One leg needed a re-run, and not as a flake write-off.** `Unity 2021.3.45f1 playmode` first failed on the shared build lock, not on tests: it acquired the lock, and 68 seconds later the release reported `Lock is already free` (`acquired=true ... reservation=missing`). The predecessor commit `abaabb68` passed all nine legs with byte-identical lock code, and no other non-superseded run in the last eight has failed that step. Filed as **#329** against the lock action with the full evidence, then the single job was re-run and passed.

Every guard was mutated and confirmed to fail:

| Mutation | Caught by |
| --- | --- |
| upload path back to the env var | `ci-aggregate-workflow.test.js` |
| `-InstallRoot` back to the quoted form | `ci-aggregate-workflow.test.js` |
| `shell: pwsh` without `-NoProfile -NonInteractive` | `ci-aggregate-workflow.test.js` |
| export the editor path before preserving the evidence | `ci-aggregate-workflow.test.js` |
| case-sensitive canonical-path compare | `ci-aggregate-workflow.test.js` |
| evidence written back inside the workspace | `ci-aggregate-workflow.test.js` |
| bind reading an unpreserved copy | `ci-aggregate-workflow.test.js` |
| inverted superseded comparison | `validate-unity-pr-policy.py` |
| failed lookup stops failing open | `validate-unity-pr-policy.py` |
| superseded guard dropped from the licensed jobs | `validate-unity-pr-policy.py` |
| aggregate stops requiring the decision | `validate-unity-pr-policy.py` |
| decision moved onto a self-hosted runner | `validate-unity-pr-policy.py` |
| head-freshness querying a different endpoint | `validate-unity-pr-policy.py` |
| head-freshness dropping `--jq .head.sha` | `validate-unity-pr-policy.py` |

Local: `npm test` 406/0, `npm run validate:all` pass, `validate-js-loc-budget` 17500/17500, `actionlint`, `yamllint --strict`, prettier, markdownlint and cspell clean.

No Unity MCP run: this diff touches no C#, so the local editor signal would prove nothing about it. The real signal is the nine-leg matrix on this pull request.

## Docs

`docs/runbooks/required-checks.md` described a `matrix-config` job and an `re-actors/alls-green` aggregate for `Unity CI Success`. Neither exists, and `validate-unity-pr-policy.py` rejects the latter outright. That section now describes the three validated skip shapes and the gate as written.

## Self-review, beyond what reviewers raised

- The five new validator checkouts had dropped the `# v7` comment every other `actions/checkout` pin in the repository carries.
- Three workflows still told a reader that editor validation happens alongside credential validation and lock acquisition; the gate now runs before the repository checkout.
- A summary written by a failed gate can record no `editorPath`, and `[IO.Path]::GetFullPath('')` throws an `ArgumentException` rather than saying so. The binder reports `(none recorded)` through its own mismatch message.
- On Windows the head-freshness truth table returned a hardcoded answer instead of running the script, so its four cases asserted the helper's own logic. The table is skipped there now, matching how the aggregate result-shape table already handles the same constraint. The stub `gh` also accepted any invocation; it now answers only the live-head lookup.

## Issues opened while working on this

- **#327** -- a Unity leg that aborts before lock acquisition also fails `Require confirmed Unity cleanup`, because the classify step skips and the gate reads an empty classification.
- **#328** -- the stuck-job watchdog reports `success` while it cannot read runner inventory, which is why an eight-hour-stuck `Performance Numbers` queue on `master` went unreported.
- **#329** -- the build-lock reservation race above.

Follow-up to #322, which squash-merged before the provenance binder commit was ready.

Closes #311.
