### PR TITLE
ci: count only runner groups this repository can actually use

### DIFF
--- a/.github/workflows/stuck-job-watchdog.yml
+++ b/.github/workflows/stuck-job-watchdog.yml
@@ -376,6 +376,16 @@ jobs:
               runner_group_ids+=("${group_id}")
               continue
             fi
+            # `private` means "every PRIVATE repository in the organization" --
+            # not a selected list. This repository is public, so such a group can
+            # never serve it. Excluded here rather than fetching its repositories
+            # endpoint, which would answer a question that does not apply and
+            # could fail the whole audit closed on an error it did not need to
+            # make. (Cursor Bugbot.)
+            if [[ "${group_visibility}" == "private" ]]; then
+              excluded_groups+=("${group_name} (private repositories only)")
+              continue
+            fi
             if ! gh_reader api --paginate \
                 "orgs/${OWNER}/actions/runner-groups/${group_id}/repositories?per_page=100" \
                 | jq -s '[.[] | (.repositories // [])[] | .id | tostring]' > "${group_repos_json}"; then

--- a/.github/workflows/stuck-job-watchdog.yml
+++ b/.github/workflows/stuck-job-watchdog.yml
@@ -338,7 +338,11 @@ jobs:
           # and `ambiguous-interactive-organization-builds` -- so that premise
           # was simply wrong, and the risk documented in #335 was live rather
           # than hypothetical.
-          if ! group_rows_raw="$(jq -r '.[] | "\(.id)\t\(.visibility // "all")\t\(.name)"' < "${runner_groups_json}")"; then
+          # `!= false`, NOT `// true`: jq's `//` treats an explicit `false` as
+          # absent and yields the right-hand side, so a group that genuinely
+          # refuses public repositories would read as allowing them -- the
+          # exact inversion of the check. Caught by the fixture for it.
+          if ! group_rows_raw="$(jq -r '.[] | "\(.id)\t\(.visibility // "all")\t\(.allows_public_repositories != false)\t\(.name)"' < "${runner_groups_json}")"; then
             fail_closed "could not parse the organization runner-group inventory."
           fi
           group_rows=()
@@ -352,27 +356,45 @@ jobs:
           excluded_groups=()
           group_repos_json="$(mktemp)"
           for group_row in "${group_rows[@]}"; do
-            group_id="${group_row%%$'\t'*}"
-            group_rest="${group_row#*$'\t'}"
-            group_visibility="${group_rest%%$'\t'*}"
-            group_name="${group_rest#*$'\t'}"
+            IFS=$'\t' read -r group_id group_visibility group_public group_name <<< "${group_row}"
+            # A group can be `visibility: all` and still refuse PUBLIC
+            # repositories, and this repository is public -- its runners are
+            # then unusable capacity, which is the wrongful cancel this walk
+            # exists to prevent. (Cursor Bugbot.)
+            #
+            # Excluded unconditionally rather than only when we know we are
+            # public, which would need another API call and another failure
+            # mode. The cost of being wrong is asymmetric: for a PRIVATE
+            # repository this under-counts capacity, and under-counting can only
+            # produce a starvation report, never a cancel. Over-counting is what
+            # cancels a live run.
+            if [[ "${group_public}" != "true" ]]; then
+              excluded_groups+=("${group_name} (refuses public repositories)")
+              continue
+            fi
             if [[ "${group_visibility}" == "all" ]]; then
               runner_group_ids+=("${group_id}")
               continue
             fi
             if ! gh_reader api --paginate \
                 "orgs/${OWNER}/actions/runner-groups/${group_id}/repositories?per_page=100" \
-                | jq -s '[.[] | (.repositories // [])[] | .id]' > "${group_repos_json}"; then
+                | jq -s '[.[] | (.repositories // [])[] | .id | tostring]' > "${group_repos_json}"; then
               fail_closed "could not read which repositories may use runner group ${group_name} (${group_id})."
             fi
-            if [[ "$(jq --argjson want "${REPO_ID}" 'any(.[]; . == $want)' < "${group_repos_json}")" == "true" ]]; then
+            # `--arg`, not `--argjson`: an empty or non-numeric REPO_ID makes
+            # `--argjson` fail to parse, which under `set -e` aborts the script
+            # WITHOUT reaching `fail_closed` -- an audit that dies instead of
+            # reporting. Both sides are compared as strings. (GitHub Copilot.)
+            if [[ "$(jq --arg want "${REPO_ID}" 'any(.[]; . == $want)' < "${group_repos_json}")" == "true" ]]; then
               runner_group_ids+=("${group_id}")
             else
               excluded_groups+=("${group_name}")
             fi
           done
           if (( ${#excluded_groups[@]} > 0 )); then
-            log_summary "Runner groups not visible to ${REPO} (excluded from capacity): $(IFS=', '; echo "${excluded_groups[*]}")"
+            # NOT `IFS=', '` with `"${arr[*]}"`: bash joins with only the FIRST
+            # character of IFS there, so that renders `a,b`. (GitHub Copilot.)
+            log_summary "Runner groups not usable by ${REPO} (excluded from capacity): $(printf '%s, ' "${excluded_groups[@]}" | sed 's/, $//')"
           fi
           if (( ${#runner_group_ids[@]} == 0 )); then
             fail_closed "no organization runner group is visible to ${REPO}; the inventory cannot be trusted."

--- a/.github/workflows/stuck-job-watchdog.yml
+++ b/.github/workflows/stuck-job-watchdog.yml
@@ -133,6 +133,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUNNER_INVENTORY_TOKEN: ${{ steps.reader_token.outputs.token }}
           REPO: ${{ github.repository }}
+          REPO_ID: ${{ github.repository_id }}
           OWNER: ${{ github.repository_owner }}
           SELF_RUN_ID: ${{ github.run_id }}
           STATE_BRANCH: watchdog-state
@@ -302,10 +303,15 @@ jobs:
             GH_TOKEN="${RUNNER_INVENTORY_TOKEN}" gh "$@"
           }
 
+          # `unique_by(.id)`: `--paginate` concatenates page objects, and the
+          # live organization returns "Default" twice through this walk. The
+          # runner dedupe below already made that harmless for the COUNTS, but
+          # it still cost a redundant API call per duplicate and printed a
+          # group list that made an operator distrust the summary.
           runner_groups_json="$(mktemp)"
           if ! gh_reader api --paginate \
               "orgs/${OWNER}/actions/runner-groups?per_page=100" \
-              | jq -s '[.[] | (.runner_groups // [])[] | select(.id != null)]' > "${runner_groups_json}"; then
+              | jq -s '[.[] | (.runner_groups // [])[] | select(.id != null)] | unique_by(.id)' > "${runner_groups_json}"; then
             fail_closed "could not read the organization runner groups."
           fi
           group_count="$(jq 'length' < "${runner_groups_json}")"
@@ -314,15 +320,62 @@ jobs:
           fi
           log_summary "Organization runner groups: $(jq -r '[.[].name] | join(", ")' < "${runner_groups_json}")"
 
+          # Only groups THIS repository may actually use. Counting a runner that
+          # cannot serve our jobs inflates capacity, and inflated capacity is
+          # what turns a legitimately queued run into a wrongful cancel: the
+          # audit would see an idle runner carrying the right labels, conclude
+          # the dispatcher is stuck, and cancel a run that was correctly waiting.
+          #
+          # This reads each group's documented `visibility` field rather than the
+          # `visible_to_repository` query parameter, which the REST docs type
+          # only as "string" with no stated format. `all` needs no further call;
+          # `selected` (and `private`) are resolved against the group's own
+          # repositories endpoint, which returns repository objects with numeric
+          # ids -- an unambiguous comparison against `github.repository_id`.
+          #
+          # The previous revision walked every group on the stated grounds that
+          # the organization had exactly one. It has at least two -- `Default`
+          # and `ambiguous-interactive-organization-builds` -- so that premise
+          # was simply wrong, and the risk documented in #335 was live rather
+          # than hypothetical.
+          if ! group_rows_raw="$(jq -r '.[] | "\(.id)\t\(.visibility // "all")\t\(.name)"' < "${runner_groups_json}")"; then
+            fail_closed "could not parse the organization runner-group inventory."
+          fi
+          group_rows=()
+          if [[ -n "${group_rows_raw}" ]]; then
+            mapfile -t group_rows <<< "${group_rows_raw}"
+          fi
           # mapfile, not `while read < <(...)`: the loop body runs `gh`, and a
           # child that consumes the loop's stdin silently eats the remaining
           # group ids.
-          if ! runner_group_ids_raw="$(jq -r '.[].id' < "${runner_groups_json}")"; then
-            fail_closed "could not parse the organization runner-group inventory."
-          fi
           runner_group_ids=()
-          if [[ -n "${runner_group_ids_raw}" ]]; then
-            mapfile -t runner_group_ids <<< "${runner_group_ids_raw}"
+          excluded_groups=()
+          group_repos_json="$(mktemp)"
+          for group_row in "${group_rows[@]}"; do
+            group_id="${group_row%%$'\t'*}"
+            group_rest="${group_row#*$'\t'}"
+            group_visibility="${group_rest%%$'\t'*}"
+            group_name="${group_rest#*$'\t'}"
+            if [[ "${group_visibility}" == "all" ]]; then
+              runner_group_ids+=("${group_id}")
+              continue
+            fi
+            if ! gh_reader api --paginate \
+                "orgs/${OWNER}/actions/runner-groups/${group_id}/repositories?per_page=100" \
+                | jq -s '[.[] | (.repositories // [])[] | .id]' > "${group_repos_json}"; then
+              fail_closed "could not read which repositories may use runner group ${group_name} (${group_id})."
+            fi
+            if [[ "$(jq --argjson want "${REPO_ID}" 'any(.[]; . == $want)' < "${group_repos_json}")" == "true" ]]; then
+              runner_group_ids+=("${group_id}")
+            else
+              excluded_groups+=("${group_name}")
+            fi
+          done
+          if (( ${#excluded_groups[@]} > 0 )); then
+            log_summary "Runner groups not visible to ${REPO} (excluded from capacity): $(IFS=', '; echo "${excluded_groups[*]}")"
+          fi
+          if (( ${#runner_group_ids[@]} == 0 )); then
+            fail_closed "no organization runner group is visible to ${REPO}; the inventory cannot be trusted."
           fi
           runners_json="$(mktemp)"
           : > "${runners_json}"
@@ -355,7 +408,7 @@ jobs:
           registered_count="$(jq 'length' < "${inventory_json}")"
           online_count="$(jq '[.[] | select(.online)] | length' < "${inventory_json}")"
           idle_count="$(jq '[.[] | select(.online and (.busy | not))] | length' < "${inventory_json}")"
-          log_summary "Runner inventory (all organization groups): ${registered_count} registered, ${online_count} online, ${idle_count} idle."
+          log_summary "Runner inventory (groups visible to ${REPO}): ${registered_count} registered, ${online_count} online, ${idle_count} idle."
 
           # ------------------------------------------------------------------
           # 3. Classify every queued run. Nothing is cancelled in this pass, so

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -1888,7 +1888,7 @@ def validate_stuck_job_watchdog() -> None:
                 ),
             },
             0,
-            ("starved", "not visible to", "org-builds", "Not dispatcher-stuck; no action."),
+            ("starved", "not usable by", "org-builds", "Not dispatcher-stuck; no action."),
             # NOT "dispatcher-stuck" on its own: the starvation line legitimately
             # says "Not dispatcher-stuck", so the loose needle forbids the very
             # text this case wants to see.
@@ -1912,7 +1912,38 @@ def validate_stuck_job_watchdog() -> None:
             },
             0,
             ("dispatcher-stuck", "cancelled 1"),
-            ("not visible to",),
+            ("not usable by",),
+        ),
+        (
+            # `visibility: all` is not sufficient. A group that refuses PUBLIC
+            # repositories cannot serve this one, and counting its idle runner
+            # is exactly the over-count that cancels a live run.
+            "a group refusing public repositories is not capacity",
+            {
+                queued: watchdog_queued_runs(watchdog_run(1)),
+                inventory: (
+                    0,
+                    {
+                        "runner_groups": [
+                            {"id": 7, "name": "Default", "visibility": "all"},
+                            {
+                                "id": 9,
+                                "name": "private-only",
+                                "visibility": "all",
+                                "allows_public_repositories": False,
+                            },
+                        ]
+                    },
+                ),
+                "actions/runs/1/jobs": watchdog_jobs(self_hosted),
+                "runner-groups/7/runners": watchdog_runners(("MAC", "online", False, ["self-hosted", "macOS"])),
+                "runner-groups/9/runners": watchdog_runners(
+                    ("ELI", "online", False, self_hosted), first_id=70
+                ),
+            },
+            0,
+            ("starved", "refuses public repositories", "private-only"),
+            ("cancelled 1", "queued for cancel"),
         ),
         (
             # Every group restricted, none listing us: capacity is unknowable,

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -1946,6 +1946,32 @@ def validate_stuck_job_watchdog() -> None:
             ("cancelled 1", "queued for cancel"),
         ),
         (
+            # `private` is "every PRIVATE repository", not a selected list, so a
+            # public repository can never use such a group -- and asking its
+            # repositories endpoint answers the wrong question.
+            "a private-visibility group is not capacity for a public repo",
+            {
+                queued: watchdog_queued_runs(watchdog_run(1)),
+                inventory: (
+                    0,
+                    {
+                        "runner_groups": [
+                            {"id": 7, "name": "Default", "visibility": "all"},
+                            {"id": 11, "name": "priv", "visibility": "private"},
+                        ]
+                    },
+                ),
+                "actions/runs/1/jobs": watchdog_jobs(self_hosted),
+                "runner-groups/7/runners": watchdog_runners(("MAC", "online", False, ["self-hosted", "macOS"])),
+                "runner-groups/11/runners": watchdog_runners(
+                    ("ELI", "online", False, self_hosted), first_id=50
+                ),
+            },
+            0,
+            ("starved", "private repositories only", "priv"),
+            ("cancelled 1", "queued for cancel"),
+        ),
+        (
             # Every group restricted, none listing us: capacity is unknowable,
             # not zero. Reporting "no runner matches" would be indistinguishable
             # from a real starvation, and the audit must not issue a verdict it

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -975,6 +975,7 @@ WATCHDOG_CONTEXT_ENV = {
     "RUNNER_INVENTORY_TOKEN": "stub-reader",
     "REPO": "Ambiguous-Interactive/DxMessaging",
     "OWNER": "Ambiguous-Interactive",
+    "REPO_ID": "101020635",
     "SELF_RUN_ID": "999",
     "EXTRA_EXCLUDED_WORKFLOWS": "",
 }
@@ -1117,7 +1118,17 @@ def watchdog_jobs(*label_sets: list[str], extra: list[dict] | None = None) -> tu
     return 0, {"jobs": jobs + list(extra or [])}
 
 
-def watchdog_runners(*specs: tuple[str, str, bool, list[str]]) -> tuple[int, object]:
+def watchdog_runners(
+    *specs: tuple[str, str, bool, list[str]], first_id: int = 1
+) -> tuple[int, object]:
+    """Runners for one group.
+
+    `first_id` exists because the inventory is deduplicated by runner id, and
+    ids were numbered from 1 in EVERY call -- so two groups' runners collided
+    and the second group's silently vanished. A multi-group fixture then proved
+    nothing: a case checking that an invisible group's runner is excluded passed
+    identically whether or not the exclusion worked.
+    """
     return 0, {
         "runners": [
             {
@@ -1127,7 +1138,7 @@ def watchdog_runners(*specs: tuple[str, str, bool, list[str]]) -> tuple[int, obj
                 "busy": busy,
                 "labels": [{"name": label} for label in labels],
             }
-            for index, (name, status, busy, labels) in enumerate(specs, start=1)
+            for index, (name, status, busy, labels) in enumerate(specs, start=first_id)
         ]
     }
 
@@ -1190,6 +1201,24 @@ def validate_stuck_job_watchdog() -> None:
     queued = "actions/runs?status=queued"
     inventory = "runner-groups?per_page"
     one_group = (0, {"runner_groups": [{"id": 7, "name": "Default"}]})
+    # The live organization returns TWO distinct groups and repeats one of them
+    # through `--paginate`. The premise that it had exactly one -- which is what
+    # justified dropping the visibility filter -- was simply wrong.
+    duplicated_group = (
+        0,
+        {"runner_groups": [{"id": 7, "name": "Default"}, {"id": 7, "name": "Default"}]},
+    )
+    two_groups = (
+        0,
+        {
+            "runner_groups": [
+                {"id": 7, "name": "Default", "visibility": "all"},
+                {"id": 8, "name": "org-builds", "visibility": "selected"},
+            ]
+        },
+    )
+    ours = (0, {"repositories": [{"id": 101020635}]})
+    not_ours = (0, {"repositories": [{"id": 55555}]})
 
     # name, gh routes, expected exit, must appear, must NOT appear
     #
@@ -1840,6 +1869,81 @@ def validate_stuck_job_watchdog() -> None:
             ("workflow is excluded",),
             ("cancelled 1",),
             {"extra_env": {"EXTRA_EXCLUDED_WORKFLOWS": ".github/workflows/ci.yml"}},
+        ),
+        (
+            # THE WRONGFUL CANCEL THIS GUARDS. The only idle runner carrying the
+            # required labels sits in a `selected` group that does NOT list this
+            # repository, so it can never take the job. Counting it would make
+            # the audit conclude the dispatcher is stuck and cancel a run that
+            # was correctly waiting. It must read as starved instead.
+            "an idle runner in a group we cannot use is not capacity",
+            {
+                queued: watchdog_queued_runs(watchdog_run(1)),
+                inventory: two_groups,
+                "runner-groups/8/repositories": not_ours,
+                "actions/runs/1/jobs": watchdog_jobs(self_hosted),
+                "runner-groups/7/runners": watchdog_runners(("MAC", "online", False, ["self-hosted", "macOS"])),
+                "runner-groups/8/runners": watchdog_runners(
+                    ("ELI", "online", False, self_hosted), first_id=90
+                ),
+            },
+            0,
+            ("starved", "not visible to", "org-builds", "Not dispatcher-stuck; no action."),
+            # NOT "dispatcher-stuck" on its own: the starvation line legitimately
+            # says "Not dispatcher-stuck", so the loose needle forbids the very
+            # text this case wants to see.
+            ("cancelled 1", "queued for cancel"),
+        ),
+        (
+            # The same group, now listing this repository: its idle runner IS
+            # ours, so the run is dispatcher-stuck and gets cancelled.
+            "an idle runner in a group we CAN use is capacity",
+            {
+                queued: watchdog_queued_runs(watchdog_run(1)),
+                inventory: two_groups,
+                "runner-groups/8/repositories": ours,
+                "actions/runs/1/jobs": watchdog_jobs(self_hosted),
+                "runner-groups/7/runners": watchdog_runners(("MAC", "online", False, ["self-hosted", "macOS"])),
+                "runner-groups/8/runners": watchdog_runners(
+                    ("ELI", "online", False, self_hosted), first_id=90
+                ),
+                "actions/workflows/42": (0, {"path": ".github/workflows/perf-numbers.yml"}),
+                "contents/.github/workflows/perf-numbers.yml": (0, EMPTY_WORKFLOW_CONTENT),
+            },
+            0,
+            ("dispatcher-stuck", "cancelled 1"),
+            ("not visible to",),
+        ),
+        (
+            # Every group restricted, none listing us: capacity is unknowable,
+            # not zero. Reporting "no runner matches" would be indistinguishable
+            # from a real starvation, and the audit must not issue a verdict it
+            # could not reach.
+            "no visible runner group fails closed",
+            {
+                queued: watchdog_queued_runs(watchdog_run(1)),
+                inventory: (
+                    0,
+                    {"runner_groups": [{"id": 8, "name": "org-builds", "visibility": "selected"}]},
+                ),
+                "runner-groups/8/repositories": not_ours,
+            },
+            1,
+            ("no organization runner group is visible",),
+            ("cancelled 1",),
+        ),
+        (
+            # `--paginate` repeats a group; the walk must not read it twice.
+            "a group repeated by pagination is walked once",
+            {
+                queued: watchdog_queued_runs(watchdog_run(1)),
+                inventory: duplicated_group,
+                "actions/runs/1/jobs": watchdog_jobs(self_hosted),
+                "runner-groups/7/runners": watchdog_runners(("ELI", "offline", False, self_hosted)),
+            },
+            0,
+            ("Organization runner groups: Default",),
+            ("Default, Default", "cancelled 1"),
         ),
     )
 


### PR DESCRIPTION
Follow-up to #331, correcting a claim I made in it.

## What was wrong

#331 removed the `visible_to_repository` filter from the watchdog's runner-group
walk, on the stated grounds that *"the organization registers a single group
today, so the filter selects exactly what the unfiltered call already returns."*
The first production run after that merge disproved it:

```
Organization runner groups: Default, ambiguous-interactive-organization-builds, Default
```

Two distinct groups, one repeated by `--paginate`. The premise was simply wrong,
and the risk I filed as hypothetical in #335 was live: runners in a group this
repository may not be allowed to use were being counted as available capacity.

**Why that matters.** Inflated capacity is what turns a legitimately queued run
into a *wrongful cancel* — the audit sees an idle runner carrying the required
labels, concludes the dispatcher is stuck, and cancels a run that was correctly
waiting for a runner it can actually use. No wrongful cancel has occurred: every
post-merge run so far reported `No dispatcher-stuck run found`. The exposure was
real but unrealised.

## The fix

Visibility is resolved through **documented shapes** rather than the ambiguous
query parameter that started all this:

* each group's own `visibility` field — `all` needs no further call;
* `selected` groups are resolved against the group's repositories endpoint and
  compared with `github.repository_id`.

Numeric ids on both sides, nothing to guess. This is what #335 asked for, minus
the `admin:org` probe, because the group object already carries `visibility`.

Groups that exclude us are named in the step summary, and a walk ending with
**no** visible group fails closed — capacity we cannot read is not capacity that
is zero.

Also dedupes the group list by id. The runner dedupe already made the repeat
harmless for the counts, so this is not a correctness fix; it removes a redundant
API call per duplicate and stops the summary printing `Default, …, Default`,
which is exactly the kind of line that makes an operator distrust the report.

## A harness bug that made the first version of these tests worthless

`watchdog_runners` numbered runner ids from 1 on **every** call, and the
inventory is deduplicated by runner id — so two groups' runners collided and the
second group's silently vanished. My multi-group fixture therefore proved
nothing: the case asserting *"an invisible group's runner is excluded"* passed
identically whether or not the exclusion worked. Ids are now distinct per group,
and only then did the mutations start failing as they should.

## Verification

Four mutations, each against a verified-green baseline:

| mutation | result |
|---|---|
| visibility filtering removed (the pre-fix behaviour) | killed |
| an invisible group treated as visible | killed |
| group dedupe removed | killed |
| an empty visible set tolerated instead of failing closed | killed |

New rows: an idle runner in a group we cannot use is not capacity · an idle
runner in a group we can use is capacity · no visible group fails closed · a
group repeated by pagination is walked once.

Refs #335.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how the watchdog decides dispatcher-stuck vs legitimately queued runs; over-counting capacity was the path to cancelling runs that were correctly waiting, and this PR is the corrective logic on that automation.
> 
> **Overview**
> The stuck-job watchdog no longer treats **every** organization runner group as capacity for this repo. It filters groups by documented `visibility`, `allows_public_repositories`, and (for `selected` groups) whether `github.repository_id` appears in the group’s repository list—so idle runners in groups this public repo cannot use are not counted and cannot trigger a wrongful cancel.
> 
> Runner groups are **deduped by id** after pagination (fewer redundant API calls and cleaner summaries). Excluded groups are named in the step summary; if **no** group is usable, the audit **fails closed** instead of reporting zero capacity. Inventory logging now says capacity is from groups visible to `${REPO}`.
> 
> `REPO_ID` is passed into the audit step. The unity PR policy harness adds `REPO_ID`, fixes `watchdog_runners` so multi-group fixtures use distinct runner ids, and adds regression cases for invisible groups, public-repo refusal, `private` visibility, fail-closed when nothing is visible, and pagination duplicates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c2967b80a0435c67c9132a8a7fc29c67b49d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->