### PR TITLE
ci: disable safe-directory writes in trusted Unity checkouts

### DIFF
--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -193,6 +193,7 @@ jobs:
           path: .ci/unity-helpers
           persist-credentials: false
           clean: true
+          set-safe-directory: false
 
       - name: Require manually installed Unity editor
         timeout-minutes: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,6 +230,7 @@ jobs:
           path: .ci/unity-helpers
           persist-credentials: false
           clean: true
+          set-safe-directory: false
 
       - name: Require manually installed Unity editor
         timeout-minutes: 10
@@ -544,6 +545,7 @@ jobs:
           path: .ci/unity-helpers
           persist-credentials: false
           clean: true
+          set-safe-directory: false
 
       - name: Require manually installed Unity editor
         timeout-minutes: 10

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -95,6 +95,7 @@ jobs:
           path: .ci/unity-helpers
           persist-credentials: false
           clean: true
+          set-safe-directory: false
 
       - name: Require manually installed Unity editor
         timeout-minutes: 10

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -185,6 +185,7 @@ jobs:
           path: .ci/unity-helpers
           persist-credentials: false
           clean: true
+          set-safe-directory: false
 
       - name: Require manually installed Unity editor
         timeout-minutes: 10

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -476,7 +476,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
       [gateStep, /\n        if: always\(\)\n        timeout-minutes: 2\n/],
       [gateStep, /classification-complete: \$\{\{ steps\.cleanup_classification\.outputs\.classification-complete \}\}/],
       [gateStep, /release-outcome: \$\{\{ steps\.release_unity_lock\.outcome \}\}/],
-      [getStepBlock(job, "Checkout trusted Unity editor validator"), /persist-credentials: false[\s\S]*clean: true[\s\S]*set-safe-directory: false/, `${label}: isolated validator checkout must not write global safe.directory`],
+      [getStepBlock(job, "Checkout trusted Unity editor validator"), /GIT_CONFIG_NOSYSTEM: 1[\s\S]*GIT_CONFIG_GLOBAL: \/dev\/null[\s\S]*repository: Ambiguous-Interactive\/unity-helpers[\s\S]*path: \.ci\/unity-helpers[\s\S]*persist-credentials: false[\s\S]*clean: true[\s\S]*set-safe-directory: false/, `${label}: isolated validator checkout must use the trusted closed shape`],
       ...(["perf-numbers.yml", "unity-benchmarks.yml", "unity-tests.yml"].includes(file) || jobId === "unity-checks" ? [[workStep, /-UnityInstallRoot \(Join-Path \$env:RUNNER_TOOL_CACHE 'u6-v3'\)/, `${label}: licensed work and central return must use the same trusted editor root`]] : [])
     ];
     for (const [actual, contract, message] of contracts) assert.match(actual, contract, message);

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -477,6 +477,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
       [gateStep, /classification-complete: \$\{\{ steps\.cleanup_classification\.outputs\.classification-complete \}\}/],
       [gateStep, /release-outcome: \$\{\{ steps\.release_unity_lock\.outcome \}\}/],
       [validationStep, /\.ci\/unity-helpers\/scripts\/unity\/ensure-editor\.ps1/],
+      [job, /Checkout trusted Unity editor validator[\s\S]*persist-credentials: false[\s\S]*clean: true[\s\S]*set-safe-directory: false/, `${label}: isolated validator checkout must not write global safe.directory`],
       ...(["perf-numbers.yml", "unity-benchmarks.yml", "unity-tests.yml"].includes(file) || jobId === "unity-checks" ? [[workStep, /-UnityInstallRoot \(Join-Path \$env:RUNNER_TOOL_CACHE 'u6-v3'\)/, `${label}: licensed work and central return must use the same trusted editor root`]] : [])
     ];
     for (const [actual, contract, message] of contracts) assert.match(actual, contract, message);

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -476,7 +476,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
       [gateStep, /\n        if: always\(\)\n        timeout-minutes: 2\n/],
       [gateStep, /classification-complete: \$\{\{ steps\.cleanup_classification\.outputs\.classification-complete \}\}/],
       [gateStep, /release-outcome: \$\{\{ steps\.release_unity_lock\.outcome \}\}/],
-      [job, /Checkout trusted Unity editor validator[\s\S]*persist-credentials: false[\s\S]*clean: true[\s\S]*set-safe-directory: false[\s\S]*Require manually installed Unity editor[\s\S]*\.ci\/unity-helpers\/scripts\/unity\/ensure-editor\.ps1/, `${label}: trusted checkout and editor gate contract`],
+      [getStepBlock(job, "Checkout trusted Unity editor validator"), /persist-credentials: false[\s\S]*clean: true[\s\S]*set-safe-directory: false/, `${label}: isolated validator checkout must not write global safe.directory`],
       ...(["perf-numbers.yml", "unity-benchmarks.yml", "unity-tests.yml"].includes(file) || jobId === "unity-checks" ? [[workStep, /-UnityInstallRoot \(Join-Path \$env:RUNNER_TOOL_CACHE 'u6-v3'\)/, `${label}: licensed work and central return must use the same trusted editor root`]] : [])
     ];
     for (const [actual, contract, message] of contracts) assert.match(actual, contract, message);

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -460,7 +460,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
     const contracts = [
       [validationStep, /\n        timeout-minutes: 10\n/],
       [validationStep, /shell: pwsh -NoProfile -NonInteractive -Command "\. '\{0\}'"/, `${label}: the gate must not inherit a runner profile`],
-      [validationStep, /-InstallRoot \(Join-Path \$env:RUNNER_TOOL_CACHE 'u6-v3'\)[\s\S]*-DiagnosticsPath \(Join-Path \$env:RUNNER_TEMP 'dx-unity-editor-validation'\)[\s\S]*-CiManagedOnly[\s\S]*-RequireHealthyExisting/, `${label}: validation must pin the trusted editor root, refuse fallback installs, and write its evidence outside the workspace so a failed gate still uploads it`],
+      [validationStep, /\.ci\/unity-helpers\/scripts\/unity\/ensure-editor\.ps1[\s\S]*-InstallRoot \(Join-Path \$env:RUNNER_TOOL_CACHE 'u6-v3'\)[\s\S]*-DiagnosticsPath \(Join-Path \$env:RUNNER_TEMP 'dx-unity-editor-validation'\)[\s\S]*-CiManagedOnly[\s\S]*-RequireHealthyExisting/, `${label}: validation must pin the trusted editor root, refuse fallback installs, and write its evidence outside the workspace so a failed gate still uploads it`],
       [bindingStep, /dx-unity-editor-validation\\ensure-editor-summary\.json'[\s\S]*ConvertFrom-Json[\s\S]*\[string\]::Equals\(\$actual, \$expected, \[StringComparison\]::OrdinalIgnoreCase\)[\s\S]*UNITY_EDITOR_PATH=\$expected/, `${label}: bind must read the preserved evidence, prove the canonical editor, then export the path`],
       [uploadStep, /path: \$\{\{ runner\.temp \}\}\/dx-unity-editor-validation\n/, `${label}: evidence upload must not depend on a step that may never run`],
       [credentialStep, /uses: \.\/\.github\/actions\/validate-unity-license/],

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -476,8 +476,7 @@ test("every Unity lock window releases with explicit cleanup proof", () => {
       [gateStep, /\n        if: always\(\)\n        timeout-minutes: 2\n/],
       [gateStep, /classification-complete: \$\{\{ steps\.cleanup_classification\.outputs\.classification-complete \}\}/],
       [gateStep, /release-outcome: \$\{\{ steps\.release_unity_lock\.outcome \}\}/],
-      [validationStep, /\.ci\/unity-helpers\/scripts\/unity\/ensure-editor\.ps1/],
-      [job, /Checkout trusted Unity editor validator[\s\S]*persist-credentials: false[\s\S]*clean: true[\s\S]*set-safe-directory: false/, `${label}: isolated validator checkout must not write global safe.directory`],
+      [job, /Checkout trusted Unity editor validator[\s\S]*persist-credentials: false[\s\S]*clean: true[\s\S]*set-safe-directory: false[\s\S]*Require manually installed Unity editor[\s\S]*\.ci\/unity-helpers\/scripts\/unity\/ensure-editor\.ps1/, `${label}: trusted checkout and editor gate contract`],
       ...(["perf-numbers.yml", "unity-benchmarks.yml", "unity-tests.yml"].includes(file) || jobId === "unity-checks" ? [[workStep, /-UnityInstallRoot \(Join-Path \$env:RUNNER_TOOL_CACHE 'u6-v3'\)/, `${label}: licensed work and central return must use the same trusted editor root`]] : [])
     ];
     for (const [actual, contract, message] of contracts) assert.match(actual, contract, message);


### PR DESCRIPTION
## Summary

- add literal `set-safe-directory: false` to all five trusted `unity-helpers` validator checkouts
- extend the existing Unity lifecycle contract test to require the closed checkout shape

This prevents `actions/checkout` from attempting a global `safe.directory` write while the trusted validator checkout intentionally uses `GIT_CONFIG_GLOBAL=/dev/null`.

## Validation

- `node --test scripts/__tests__/ci-aggregate-workflow.test.js` (17 passed)
- `git diff --check`

Closes Ambiguous-Interactive/ambiguous-organization-build-lock#168

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and test-only changes with no runtime or security logic changes; risk is limited to whether trusted validator checkouts still succeed on self-hosted runners.
> 
> **Overview**
> Trusted **`unity-helpers`** validator checkouts in **perf-numbers**, **release** (two jobs), **unity-benchmarks**, and **unity-tests** now set **`set-safe-directory: false`** on `actions/checkout`, alongside the existing isolated git env (`GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_NOSYSTEM=1`). That stops checkout from trying to write **`safe.directory`** into a global config that is intentionally disabled.
> 
> The Unity lifecycle contract test now requires that closed checkout shape on **Checkout trusted Unity editor validator** and ties the editor validation step contract to the **`ensure-editor.ps1`** path under **`.ci/unity-helpers`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcfd722cc052cb72b2f9b6d06c7d3f250a0ba3d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->