### PR TITLE
Render a real Flow Graph and recover diagnostics sample routes

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -198,6 +198,7 @@
     "libfbxsdk",
     "libz",
     "linenums",
+    "Lerp",
     "LLMS",
     "llms",
     "llmstxt",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change Flow Graph to lead with a compact, route-first view. Concrete routes
-  sort before catch-all routes, the first eight routes remain visible, and
-  route insights, trace activity, raw topology, and overflow routes start
-  collapsed. Empty captures now explain how to restore live registrations
-  instead of filling the window with zero-value summaries
+- Change Flow Graph to lead with an interactive node-and-edge canvas. Message
+  nodes connect to receiver nodes through live registration edges, with pan,
+  zoom, automatic framing, and selection. Text-heavy route analysis, trace
+  activity, raw topology, and overflow rows now start inside one collapsed
+  section. Empty captures explain how to restore live registrations instead of
+  filling the window with zero-value summaries
   ([#345](https://github.com/Ambiguous-Interactive/DxMessaging/issues/345)).
 - Improve targeted and source-bound broadcast routing throughput and reduce the
   memory retained by their per-target lookup tables without changing the public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change Flow Graph to lead with a compact, route-first view. Concrete routes
+  sort before catch-all routes, the first eight routes remain visible, and
+  route insights, trace activity, raw topology, and overflow routes start
+  collapsed. Empty captures now explain how to restore live registrations
+  instead of filling the window with zero-value summaries
+  ([#345](https://github.com/Ambiguous-Interactive/DxMessaging/issues/345)).
 - Improve targeted and source-bound broadcast routing throughput and reduce the
   memory retained by their per-target lookup tables without changing the public
   messaging API or delivery behavior
@@ -43,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix the Diagnostics Tooling Exerciser losing all live registrations after a
+  reload-disabled Play Mode reset. Active receivers now rebuild their tokens and
+  the runner restarts its deterministic emissions on every activation
+  ([#346](https://github.com/Ambiguous-Interactive/DxMessaging/issues/346)).
 - Pooled collection rentals now return to their pool when attaching them to a
   registration or reclamation owner throws, instead of remaining stranded
   after a failed ownership transfer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   zoom, automatic framing, and selection. Text-heavy route analysis, trace
   activity, raw topology, and overflow rows now start inside one collapsed
   section. Empty captures explain how to restore live registrations instead of
-  filling the window with zero-value summaries
+  filling the window with zero-value summaries. A crossing-aware layered layout
+  and ordered node ports keep arrow paths traceable without text labels on the
+  lines. Nodes use named metric rows instead of compact `+N` summaries, and
+  multi-kind message types use neutral `MIXED` metrics until filtered to one
+  route kind. Route selection opens responsive route, activity, emission, and
+  trace cards while
+  the dense technical report stays collapsed. Broadcast and targeted routes
+  expose recent component- and registration-exact delivery call sites without
+  leaking evidence across message buses. Global accept-all
+  registrations appear as `ANY MESSAGE` observers instead of a misleading
+  `IMessage` message type
   ([#345](https://github.com/Ambiguous-Interactive/DxMessaging/issues/345)).
 - Improve targeted and source-bound broadcast routing throughput and reduce the
   memory retained by their per-target lookup tables without changing the public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   expose recent component- and registration-exact delivery call sites without
   leaking evidence across message buses. Global accept-all
   registrations appear as `ANY MESSAGE` observers instead of a misleading
-  `IMessage` message type
+  `IMessage` message type. Destroyed Unity context references fall back to their
+  stable instance ID instead of aborting capture for that component
   ([#345](https://github.com/Ambiguous-Interactive/DxMessaging/issues/345)).
 - Improve targeted and source-bound broadcast routing throughput and reduce the
   memory retained by their per-target lookup tables without changing the public
@@ -60,6 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reflexive message dispatch to a destroyed `GameObject` or `Component` target
+  now skips Unity hierarchy delivery instead of throwing
+  `MissingReferenceException`; normal targeted bus handlers still run.
 - Fix the Diagnostics Tooling Exerciser losing all live registrations after a
   reload-disabled Play Mode reset. Active receivers now rebuild their tokens and
   the runner restarts its deterministic emissions on every activation

--- a/Editor/DxMessagingEditorTheme.cs
+++ b/Editor/DxMessagingEditorTheme.cs
@@ -98,15 +98,24 @@ namespace DxMessaging.Editor
 
         internal static void ApplyCompleteBorder(VisualElement element, Color borderColor)
         {
+            ApplyCompleteBorder(element, borderColor, CompleteBorderWidth);
+        }
+
+        internal static void ApplyCompleteBorder(
+            VisualElement element,
+            Color borderColor,
+            float borderWidth
+        )
+        {
             if (element == null)
             {
                 return;
             }
 
-            element.style.borderTopWidth = CompleteBorderWidth;
-            element.style.borderRightWidth = CompleteBorderWidth;
-            element.style.borderBottomWidth = CompleteBorderWidth;
-            element.style.borderLeftWidth = CompleteBorderWidth;
+            element.style.borderTopWidth = borderWidth;
+            element.style.borderRightWidth = borderWidth;
+            element.style.borderBottomWidth = borderWidth;
+            element.style.borderLeftWidth = borderWidth;
             element.style.borderTopColor = borderColor;
             element.style.borderRightColor = borderColor;
             element.style.borderBottomColor = borderColor;

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -8,6 +8,7 @@ namespace DxMessaging.Editor.Windows
     using System.Text;
     using Core;
     using Core.Diagnostics;
+    using Core.Messages;
     using DxMessaging.Editor;
     using DxMessaging.Editor.Testing;
     using DxMessaging.Unity;
@@ -159,15 +160,21 @@ namespace DxMessaging.Editor.Windows
         internal const string DetailsPaneName = "dxmessaging-flow-graph-details";
         internal const string DetailsTitleLabelName = "dxmessaging-flow-graph-details-title";
         internal const string DetailsBodyLabelName = "dxmessaging-flow-graph-details-body";
+        internal const string DetailsSectionClassName = "dxmessaging-flow-graph-details-section";
+        internal const string DetailsMetricClassName = "dxmessaging-flow-graph-details-metric";
+        internal const string DetailsTechnicalFoldoutName =
+            "dxmessaging-flow-graph-details-technical";
+        internal const string GraphNodeMetricClassName = "dxmessaging-flow-graph-node-metric";
         internal const string WarningLabelName = "dxmessaging-flow-graph-warning";
+        internal const string GlobalObserverMessageName = "ANY MESSAGE";
 
         private const string Title = "Message Flow Graph";
         private const int VisibleRouteLimit = 8;
-        private const float GraphNodeWidth = 250f;
-        private const float GraphNodeHeight = 92f;
-        private const float GraphNodeGap = 34f;
+        private const float GraphNodeWidth = 270f;
+        private const float GraphNodeHeight = 132f;
+        private const float GraphNodeGap = 42f;
         private const float GraphCanvasHeight = 520f;
-        private const int ExportSchemaVersion = 5;
+        private const int ExportSchemaVersion = 6;
         private const string ExportCaptureMode = "registration-topology-with-recent-diagnostics";
         private const string ExportTraceSemantics =
             "traceId is emitted by concrete MessageBus dispatch and copied to token delivery records when diagnostics are enabled; edge traced counts are registration-handle exact, trace paths are built from token delivery records to avoid cross-bus trace-id collisions, recentTraceIdCount counts distinct trace ids observed for each trace path, and recentTraceIds lists those positive trace ids for cross-path breadth analysis.";
@@ -189,6 +196,9 @@ namespace DxMessaging.Editor.Windows
                 string targetComponentId,
                 string targetComponentPath,
                 string routeKind,
+                string context,
+                int contextId,
+                IReadOnlyList<string> recentEmissionSites,
                 int activityCount,
                 string selectionKey,
                 bool traceOnly
@@ -198,6 +208,9 @@ namespace DxMessaging.Editor.Windows
                 TargetComponentId = targetComponentId ?? string.Empty;
                 TargetComponentPath = targetComponentPath ?? string.Empty;
                 RouteKind = routeKind ?? string.Empty;
+                Context = context ?? string.Empty;
+                ContextId = contextId;
+                RecentEmissionSites = recentEmissionSites ?? Array.Empty<string>();
                 ActivityCount = activityCount;
                 SelectionKey = selectionKey ?? string.Empty;
                 TraceOnly = traceOnly;
@@ -211,11 +224,76 @@ namespace DxMessaging.Editor.Windows
 
             internal string RouteKind { get; }
 
+            internal string Context { get; }
+
+            internal int ContextId { get; }
+
+            internal IReadOnlyList<string> RecentEmissionSites { get; }
+
             internal int ActivityCount { get; }
 
             internal string SelectionKey { get; }
 
             internal bool TraceOnly { get; }
+        }
+
+        private readonly struct GraphNodeMetric
+        {
+            internal GraphNodeMetric(string label, string value)
+            {
+                Label = label ?? string.Empty;
+                Value = value ?? string.Empty;
+            }
+
+            internal string Label { get; }
+
+            internal string Value { get; }
+        }
+
+        private readonly struct CapturedEdgeEmission
+        {
+            internal CapturedEdgeEmission(string componentId, MessageEmissionData emission)
+            {
+                ComponentId = componentId ?? string.Empty;
+                Emission = emission;
+            }
+
+            internal string ComponentId { get; }
+
+            internal MessageEmissionData Emission { get; }
+        }
+
+        private readonly struct EdgeEmissionKey : IEquatable<EdgeEmissionKey>
+        {
+            internal EdgeEmissionKey(string componentId, MessageRegistrationHandle handle)
+            {
+                ComponentId = componentId ?? string.Empty;
+                Handle = handle;
+            }
+
+            private string ComponentId { get; }
+
+            private MessageRegistrationHandle Handle { get; }
+
+            public bool Equals(EdgeEmissionKey other)
+            {
+                return string.Equals(ComponentId, other.ComponentId, StringComparison.Ordinal)
+                    && Handle == other.Handle;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is EdgeEmissionKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (StringComparer.Ordinal.GetHashCode(ComponentId) * 397)
+                        ^ Handle.GetHashCode();
+                }
+            }
         }
 
         internal sealed class FlowGraphCanvasState
@@ -496,6 +574,7 @@ namespace DxMessaging.Editor.Windows
             Dictionary<string, MessageNodeBuilder> messageNodes = new(StringComparer.Ordinal);
             Dictionary<string, EdgeBuilder> edgeBuilders = new(StringComparer.Ordinal);
             Dictionary<string, TracePathBuilder> tracePathBuilders = new(StringComparer.Ordinal);
+            List<CapturedEdgeEmission> capturedEdgeEmissions = new();
             List<string> warnings = new();
             bool globalEmissionEvidenceCaptured = false;
 
@@ -549,6 +628,11 @@ namespace DxMessaging.Editor.Windows
                             messageNodes,
                             listener.EmissionHistory,
                             isGlobalEvidence: false
+                        );
+                        CaptureEdgeEmissionEvidence(
+                            capturedEdgeEmissions,
+                            componentId,
+                            listener.EmissionHistory
                         );
                         Dictionary<MessageRegistrationHandle, int> recentTracedDeliveryCounts =
                             CountRecentTracedDeliveriesByHandle(listener.EmissionHistory);
@@ -607,6 +691,8 @@ namespace DxMessaging.Editor.Windows
                 }
             }
 
+            AddEdgeEmissionEvidence(edgeBuilders.Values, capturedEdgeEmissions);
+
             return new FlowGraphSnapshot(
                 componentNodes
                     .OrderBy(component => component.HierarchyPath, StringComparer.Ordinal)
@@ -621,11 +707,14 @@ namespace DxMessaging.Editor.Windows
                     .ThenBy(edge => edge.TargetComponentPath, StringComparer.Ordinal)
                     .ThenBy(edge => edge.TargetComponentId, StringComparer.Ordinal)
                     .ThenBy(edge => edge.RegistrationTypeName, StringComparer.Ordinal)
+                    .ThenBy(edge => edge.Context, StringComparer.Ordinal)
+                    .ThenBy(edge => edge.ContextId)
                     .ToArray(),
                 tracePathBuilders
                     .Values.Select(builder => builder.Build())
                     .OrderBy(path => path.MessageTypeName, StringComparer.Ordinal)
                     .ThenBy(path => path.Context, StringComparer.Ordinal)
+                    .ThenBy(path => path.ContextId)
                     .ThenBy(path => path.TargetComponentPath, StringComparer.Ordinal)
                     .ThenBy(path => path.TargetComponentId, StringComparer.Ordinal)
                     .ThenBy(path => path.RegistrationTypeName, StringComparer.Ordinal)
@@ -764,6 +853,15 @@ namespace DxMessaging.Editor.Windows
 
             FlowGraphFoldoutState foldoutState =
                 content.userData as FlowGraphFoldoutState ?? new FlowGraphFoldoutState();
+            VisualElement focusedElement =
+                content.panel?.focusController.focusedElement as VisualElement;
+            bool restoreGraphFocus =
+                focusedElement != null
+                && (
+                    focusedElement.ClassListContains(GraphMessageNodeClassName)
+                    || focusedElement.ClassListContains(GraphReceiverNodeClassName)
+                    || focusedElement.ClassListContains(GraphConnectionClassName)
+                );
             Foldout existingAnalysis = content.Q<Foldout>(AnalysisFoldoutName);
             Foldout existingRouteInsights = content.Q<Foldout>(RouteMapInsightsFoldoutName);
             Foldout existingMoreRoutes = content.Q<Foldout>(RouteMapMoreRoutesFoldoutName);
@@ -965,6 +1063,22 @@ namespace DxMessaging.Editor.Windows
                 warningLabel.style.whiteSpace = WhiteSpace.Normal;
                 content.Add(warningLabel);
             }
+
+            if (restoreGraphFocus && !string.IsNullOrWhiteSpace(viewState.SelectedItemKey))
+            {
+                VisualElement selectedControl = content
+                    .Query<VisualElement>()
+                    .ToList()
+                    .FirstOrDefault(element =>
+                        element.focusable
+                        && string.Equals(
+                            element.userData as string,
+                            viewState.SelectedItemKey,
+                            StringComparison.Ordinal
+                        )
+                    );
+                selectedControl?.schedule.Execute(selectedControl.Focus);
+            }
         }
 
         internal static string CreateExportText(FlowGraphSnapshot snapshot, string filterText = "")
@@ -1060,6 +1174,12 @@ namespace DxMessaging.Editor.Windows
                     message.MessageTypeName,
                     trailingComma: true
                 );
+                AppendJsonProperty(
+                    builder,
+                    "messageKind",
+                    message.MessageKindName,
+                    trailingComma: true
+                );
                 builder
                     .Append("      \"registrationCount\": ")
                     .Append(message.RegistrationCount)
@@ -1076,7 +1196,21 @@ namespace DxMessaging.Editor.Windows
                 builder
                     .Append("      \"recentTracedDeliveryCount\": ")
                     .Append(message.RecentTracedDeliveryCount)
-                    .AppendLine();
+                    .AppendLine(",");
+                AppendJsonStringArray(
+                    builder,
+                    indentSize: 6,
+                    "recentEmissionSites",
+                    message.RecentEmissionSites,
+                    trailingComma: true
+                );
+                AppendJsonStringArray(
+                    builder,
+                    indentSize: 6,
+                    "recentContexts",
+                    message.RecentContexts,
+                    trailingComma: false
+                );
                 builder.Append("    }");
                 if (i < visibleSnapshot.MessageNodes.Count - 1)
                 {
@@ -1115,6 +1249,8 @@ namespace DxMessaging.Editor.Windows
                     edge.RegistrationTypeName,
                     trailingComma: true
                 );
+                AppendJsonProperty(builder, "context", edge.Context, trailingComma: true);
+                builder.Append("      \"contextId\": ").Append(edge.ContextId).AppendLine(",");
                 builder
                     .Append("      \"registrationCount\": ")
                     .Append(edge.RegistrationCount)
@@ -1123,7 +1259,14 @@ namespace DxMessaging.Editor.Windows
                 builder
                     .Append("      \"recentTracedDeliveryCount\": ")
                     .Append(edge.RecentTracedDeliveryCount)
-                    .AppendLine();
+                    .AppendLine(",");
+                AppendJsonStringArray(
+                    builder,
+                    indentSize: 6,
+                    "recentEmissionSites",
+                    edge.RecentEmissionSites,
+                    trailingComma: false
+                );
                 builder.Append("    }");
                 if (i < visibleSnapshot.Edges.Count - 1)
                 {
@@ -1145,6 +1288,7 @@ namespace DxMessaging.Editor.Windows
                     trailingComma: true
                 );
                 AppendJsonProperty(builder, "context", path.Context, trailingComma: true);
+                builder.Append("      \"contextId\": ").Append(path.ContextId).AppendLine(",");
                 AppendJsonProperty(
                     builder,
                     "targetComponentId",
@@ -1235,14 +1379,14 @@ namespace DxMessaging.Editor.Windows
 
                 Type messageType = emission.message.MessageType;
                 string messageTypeName = CreateMessageTypeName(messageType);
-                string context = CreateTraceContextText(
-                    emission.context ?? registration.Metadata.context
-                );
+                InstanceId? contextId = emission.context ?? registration.Metadata.context;
+                string context = CreateTraceContextText(contextId);
                 string registrationTypeName = registration.Metadata.registrationType.ToString();
                 string key = string.Join(
                     "|",
                     messageTypeName,
                     context,
+                    contextId?.Id.ToString(CultureInfo.InvariantCulture) ?? "0",
                     componentId,
                     registrationTypeName
                 );
@@ -1251,6 +1395,7 @@ namespace DxMessaging.Editor.Windows
                     builder = new TracePathBuilder(
                         messageTypeName,
                         context,
+                        contextId?.Id ?? 0,
                         componentId,
                         componentPath,
                         registrationTypeName
@@ -1273,13 +1418,21 @@ namespace DxMessaging.Editor.Windows
         )
         {
             MessageRegistrationMetadata metadata = registration.Metadata;
-            string messageKey = CreateMessageKey(metadata.type);
-            string messageTypeName = CreateMessageTypeName(metadata.type);
+            bool globalObserver =
+                metadata.registrationType == MessageRegistrationType.GlobalAcceptAll;
+            string messageKey = globalObserver
+                ? "message:<global-observer>"
+                : CreateMessageKey(metadata.type);
+            string messageTypeName = globalObserver
+                ? GlobalObserverMessageName
+                : CreateMessageTypeName(metadata.type);
             if (!messageNodes.TryGetValue(messageKey, out MessageNodeBuilder messageBuilder))
             {
                 messageBuilder = new MessageNodeBuilder(messageTypeName);
                 messageNodes[messageKey] = messageBuilder;
             }
+
+            messageBuilder.ObserveRegistrationType(metadata.registrationType);
 
             messageBuilder.RegistrationCount++;
             messageBuilder.CallCount += registration.CallCount;
@@ -1289,18 +1442,31 @@ namespace DxMessaging.Editor.Windows
             }
 
             string registrationTypeName = metadata.registrationType.ToString();
-            string edgeKey = string.Join("|", messageKey, componentId, registrationTypeName);
+            string context = CreateContextDisplayText(metadata.context);
+            string contextId = metadata.context.HasValue
+                ? metadata.context.Value.Id.ToString(CultureInfo.InvariantCulture)
+                : string.Empty;
+            string edgeKey = string.Join(
+                "|",
+                messageKey,
+                componentId,
+                registrationTypeName,
+                contextId
+            );
             if (!edgeBuilders.TryGetValue(edgeKey, out EdgeBuilder edgeBuilder))
             {
                 edgeBuilder = new EdgeBuilder(
                     messageTypeName,
                     componentId,
                     componentPath,
-                    registrationTypeName
+                    registrationTypeName,
+                    context,
+                    metadata.context
                 );
                 edgeBuilders[edgeKey] = edgeBuilder;
             }
 
+            edgeBuilder.AddRegistrationHandle(registration.Handle);
             edgeBuilder.RegistrationCount++;
             edgeBuilder.CallCount += registration.CallCount;
             edgeBuilder.RecentTracedDeliveryCount += recentTracedDeliveryCount;
@@ -1397,6 +1563,8 @@ namespace DxMessaging.Editor.Windows
                     messageNodes[messageKey] = messageBuilder;
                 }
 
+                messageBuilder.ObserveEmission(emission);
+
                 if (isGlobalEvidence)
                 {
                     messageBuilder.RecentGlobalEmissionCount++;
@@ -1404,6 +1572,99 @@ namespace DxMessaging.Editor.Windows
                 else
                 {
                     messageBuilder.RecentLocalMessageCount++;
+                }
+            }
+        }
+
+        private static void CaptureEdgeEmissionEvidence(
+            ICollection<CapturedEdgeEmission> capturedEmissions,
+            string componentId,
+            IEnumerable<MessageEmissionData> emissions
+        )
+        {
+            if (capturedEmissions == null || emissions == null)
+            {
+                return;
+            }
+
+            foreach (MessageEmissionData emission in emissions)
+            {
+                if (emission.registrationHandle != default(MessageRegistrationHandle))
+                {
+                    capturedEmissions.Add(new CapturedEdgeEmission(componentId, emission));
+                }
+            }
+        }
+
+        private static void AddEdgeEmissionEvidence(
+            IEnumerable<EdgeBuilder> edgeBuilders,
+            IEnumerable<CapturedEdgeEmission> emissions
+        )
+        {
+            Dictionary<EdgeEmissionKey, List<MessageEmissionData>> emissionsByRegistration = new();
+            foreach (CapturedEdgeEmission capturedEmission in emissions)
+            {
+                MessageEmissionData emission = capturedEmission.Emission;
+                EdgeEmissionKey key = new(
+                    capturedEmission.ComponentId,
+                    emission.registrationHandle
+                );
+                if (!emissionsByRegistration.TryGetValue(key, out List<MessageEmissionData> group))
+                {
+                    group = new List<MessageEmissionData>();
+                    emissionsByRegistration[key] = group;
+                }
+                group.Add(emission);
+            }
+
+            foreach (EdgeBuilder edgeBuilder in edgeBuilders)
+            {
+                if (
+                    string.Equals(
+                        edgeBuilder.RegistrationTypeName,
+                        MessageRegistrationType.GlobalAcceptAll.ToString(),
+                        StringComparison.Ordinal
+                    )
+                )
+                {
+                    continue;
+                }
+
+                foreach (MessageRegistrationHandle handle in edgeBuilder.RegistrationHandles)
+                {
+                    EdgeEmissionKey key = new(edgeBuilder.TargetComponentId, handle);
+                    if (
+                        !emissionsByRegistration.TryGetValue(
+                            key,
+                            out List<MessageEmissionData> matchingEmissions
+                        )
+                    )
+                    {
+                        continue;
+                    }
+
+                    foreach (MessageEmissionData emission in matchingEmissions)
+                    {
+                        if (
+                            !string.Equals(
+                                edgeBuilder.MessageTypeName,
+                                CreateMessageTypeName(emission.message?.MessageType),
+                                StringComparison.Ordinal
+                            )
+                            || (
+                                edgeBuilder.ContextId.HasValue
+                                && (
+                                    !emission.context.HasValue
+                                    || edgeBuilder.ContextId.Value.Id != emission.context.Value.Id
+                                )
+                            )
+                        )
+                        {
+                            continue;
+                        }
+
+                        edgeBuilder.ObserveEmission(emission);
+                    }
                 }
             }
         }
@@ -1529,6 +1790,27 @@ namespace DxMessaging.Editor.Windows
                     edge.RegistrationTypeName,
                     path.RegistrationTypeName,
                     StringComparison.Ordinal
+                )
+            )
+            {
+                return false;
+            }
+
+            string normalizedRouteKind = DxMessagingEditorPalette.NormalizeRouteKind(
+                edge.RegistrationTypeName
+            );
+            bool hasSpecificRegistrationContext =
+                !string.IsNullOrWhiteSpace(edge.Context) && edge.Context != "<none>";
+            bool routeUsesSpecificContext =
+                normalizedRouteKind == DxMessagingEditorPalette.BroadcastKind
+                || normalizedRouteKind == DxMessagingEditorPalette.TargetedKind;
+            if (
+                routeUsesSpecificContext
+                && hasSpecificRegistrationContext
+                && (
+                    (edge.ContextId != 0 && path.ContextId != 0)
+                        ? edge.ContextId != path.ContextId
+                        : !string.Equals(edge.Context, path.Context, StringComparison.Ordinal)
                 )
             )
             {
@@ -1756,13 +2038,100 @@ namespace DxMessaging.Editor.Windows
 
         private static string CreateTraceContextText(InstanceId? context)
         {
+            return CreateContextDisplayText(context);
+        }
+
+        private static string CreateContextDisplayText(InstanceId? context)
+        {
             if (!context.HasValue)
             {
                 return "<none>";
             }
 
-            string contextText = context.Value.ToString();
-            return string.IsNullOrWhiteSpace(contextText) ? "<none>" : contextText;
+            UnityEngine.Object contextObject = context.Value.Object;
+            switch (contextObject)
+            {
+                case GameObject gameObject:
+                    return GetHierarchyPath(gameObject.transform) + " (GameObject)";
+                case Component component:
+                    return $"{GetHierarchyPath(component.transform)} ({component.GetType().Name})";
+                case null:
+                    return "Instance " + context.Value.Id;
+                default:
+                    return string.IsNullOrWhiteSpace(contextObject.name)
+                        ? $"{contextObject.GetType().Name} ({context.Value.Id})"
+                        : $"{contextObject.name} ({contextObject.GetType().Name})";
+            }
+        }
+
+        private static string CreateMessageKindName(
+            IMessage message,
+            MessageRegistrationType registrationType = MessageRegistrationType.None
+        )
+        {
+            if (registrationType == MessageRegistrationType.GlobalAcceptAll)
+            {
+                return "GLOBAL OBSERVER";
+            }
+            if (
+                registrationType == MessageRegistrationType.Broadcast
+                || registrationType == MessageRegistrationType.BroadcastPostProcessor
+                || registrationType == MessageRegistrationType.BroadcastWithoutSource
+                || registrationType == MessageRegistrationType.BroadcastWithoutSourcePostProcessor
+                || registrationType == MessageRegistrationType.BroadcastInterceptor
+                || message is IBroadcastMessage
+            )
+            {
+                return "BROADCAST";
+            }
+            if (
+                registrationType == MessageRegistrationType.Targeted
+                || registrationType == MessageRegistrationType.TargetedPostProcessor
+                || registrationType == MessageRegistrationType.TargetedWithoutTargeting
+                || registrationType == MessageRegistrationType.TargetedWithoutTargetingPostProcessor
+                || registrationType == MessageRegistrationType.TargetedInterceptor
+                || message is ITargetedMessage
+            )
+            {
+                return "TARGETED";
+            }
+            if (
+                registrationType == MessageRegistrationType.Untargeted
+                || registrationType == MessageRegistrationType.UntargetedPostProcessor
+                || registrationType == MessageRegistrationType.UntargetedInterceptor
+                || message is IUntargetedMessage
+            )
+            {
+                return "GLOBAL";
+            }
+
+            return "MESSAGE";
+        }
+
+        internal static string CreateEmissionSite(string stackTrace)
+        {
+            if (string.IsNullOrWhiteSpace(stackTrace))
+            {
+                return "<unknown call site>";
+            }
+
+            string firstFrame = stackTrace
+                .Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(line => line.Trim())
+                .FirstOrDefault(line =>
+                    !string.IsNullOrWhiteSpace(line)
+                    && line.IndexOf("UnityEngine.Debug:ExtractStackTrace", StringComparison.Ordinal)
+                        < 0
+                    && line.IndexOf("UnityEngine.StackTraceUtility", StringComparison.Ordinal) < 0
+                    && line.IndexOf("StackTraceUtility:ExtractStackTrace", StringComparison.Ordinal)
+                        < 0
+                );
+            if (string.IsNullOrWhiteSpace(firstFrame))
+            {
+                return "<unknown call site>";
+            }
+
+            return firstFrame;
         }
 
         private static Label CreateSectionTitle(string text)
@@ -1812,12 +2181,14 @@ namespace DxMessaging.Editor.Windows
             title.style.marginRight = 12;
             legend.Add(title);
             legend.Add(CreateGraphLegendBadge("MESSAGE", DxMessagingEditorPalette.AmberSoft));
-
-            Label direction = new("routes ->");
-            direction.style.marginLeft = 6;
-            direction.style.marginRight = 6;
-            legend.Add(direction);
+            Label arrow = new("->");
+            arrow.style.marginLeft = 6;
+            arrow.style.marginRight = 6;
+            legend.Add(arrow);
             legend.Add(CreateGraphLegendBadge("RECEIVER", DxMessagingEditorPalette.Amber));
+            legend.Add(CreateGraphLegendBadge("BROADCAST", DxMessagingEditorPalette.Broadcast));
+            legend.Add(CreateGraphLegendBadge("TARGETED", DxMessagingEditorPalette.Targeted));
+            legend.Add(CreateGraphLegendBadge("GLOBAL", DxMessagingEditorPalette.Untargeted));
 
             Label controls = new("Drag empty space to pan | Scroll to zoom | Select to inspect");
             controls.style.flexGrow = 1;
@@ -1840,43 +2211,23 @@ namespace DxMessaging.Editor.Windows
                 .Distinct(StringComparer.Ordinal)
                 .ToArray();
 
-            Dictionary<string, int> messageIndexes = messageNames
-                .Select((messageTypeName, index) => new { messageTypeName, index })
-                .ToDictionary(
-                    item => item.messageTypeName,
-                    item => item.index,
-                    StringComparer.Ordinal
-                );
             receiverIds = receiverIds
-                .OrderBy(componentId =>
-                {
-                    int[] indexes = connections
-                        .Where(connection =>
-                            string.Equals(
-                                connection.TargetComponentId,
-                                componentId,
-                                StringComparison.Ordinal
-                            ) && messageIndexes.ContainsKey(connection.MessageTypeName)
-                        )
-                        .Select(connection => messageIndexes[connection.MessageTypeName])
-                        .ToArray();
-                    return indexes.Length == 0 ? float.MaxValue : indexes.Average();
-                })
-                .ThenBy(
+                .OrderBy(
                     componentId => CreateReceiverPath(visibleSnapshot, connections, componentId),
                     StringComparer.Ordinal
                 )
                 .ThenBy(componentId => componentId, StringComparer.Ordinal)
                 .ToArray();
+            OrderGraphLayersForReadability(ref messageNames, ref receiverIds, connections);
 
             int rowCount = Math.Max(messageNames.Length, receiverIds.Length);
             float graphHeight = Math.Max(
                 GraphCanvasHeight,
                 80f + rowCount * (GraphNodeHeight + GraphNodeGap)
             );
-            const float contentWidth = 990f;
+            const float contentWidth = 1100f;
             const float messageX = 60f;
-            const float receiverX = 680f;
+            const float receiverX = 770f;
             Dictionary<string, Vector2> messagePositions = new(StringComparer.Ordinal);
             Dictionary<string, Vector2> receiverPositions = new(StringComparer.Ordinal);
             for (int index = 0; index < messageNames.Length; index++)
@@ -1892,6 +2243,70 @@ namespace DxMessaging.Editor.Windows
                     receiverX,
                     CreateGraphNodeY(index, receiverIds.Length, rowCount)
                 );
+            }
+            Dictionary<string, int> orderedMessageIndexes = messageNames
+                .Select((messageTypeName, index) => new { messageTypeName, index })
+                .ToDictionary(
+                    item => item.messageTypeName,
+                    item => item.index,
+                    StringComparer.Ordinal
+                );
+            Dictionary<string, int> orderedReceiverIndexes = receiverIds
+                .Select((componentId, index) => new { componentId, index })
+                .ToDictionary(item => item.componentId, item => item.index, StringComparer.Ordinal);
+            Dictionary<string, GraphConnectionDescriptor[]> outgoingConnectionsByMessage =
+                connections
+                    .GroupBy(connection => connection.MessageTypeName, StringComparer.Ordinal)
+                    .ToDictionary(
+                        group => group.Key,
+                        group =>
+                            group
+                                .OrderBy(candidate =>
+                                    orderedReceiverIndexes.GetValueOrDefault(
+                                        candidate.TargetComponentId,
+                                        int.MaxValue
+                                    )
+                                )
+                                .ThenBy(candidate => candidate.RouteKind, StringComparer.Ordinal)
+                                .ThenBy(candidate => candidate.Context, StringComparer.Ordinal)
+                                .ThenBy(candidate => candidate.ContextId)
+                                .ToArray(),
+                        StringComparer.Ordinal
+                    );
+            Dictionary<string, GraphConnectionDescriptor[]> incomingConnectionsByReceiver =
+                connections
+                    .GroupBy(connection => connection.TargetComponentId, StringComparer.Ordinal)
+                    .ToDictionary(
+                        group => group.Key,
+                        group =>
+                            group
+                                .OrderBy(candidate =>
+                                    orderedMessageIndexes.GetValueOrDefault(
+                                        candidate.MessageTypeName,
+                                        int.MaxValue
+                                    )
+                                )
+                                .ThenBy(candidate => candidate.RouteKind, StringComparer.Ordinal)
+                                .ThenBy(candidate => candidate.Context, StringComparer.Ordinal)
+                                .ThenBy(candidate => candidate.ContextId)
+                                .ToArray(),
+                        StringComparer.Ordinal
+                    );
+            Dictionary<string, int> outgoingPortIndexes = new(StringComparer.Ordinal);
+            foreach (GraphConnectionDescriptor[] outgoing in outgoingConnectionsByMessage.Values)
+            {
+                for (int index = 0; index < outgoing.Length; index++)
+                {
+                    outgoingPortIndexes[CreateGraphConnectionIdentity(outgoing[index])] = index;
+                }
+            }
+            Dictionary<string, int> incomingPortIndexes = new(StringComparer.Ordinal);
+            foreach (GraphConnectionDescriptor[] incoming in incomingConnectionsByReceiver.Values)
+            {
+                for (int index = 0; index < incoming.Length; index++)
+                {
+                    incomingPortIndexes[CreateGraphConnectionIdentity(incoming[index])] = index;
+                }
             }
 
             string layoutSignature = CreateGraphLayoutSignature(
@@ -1935,8 +2350,11 @@ namespace DxMessaging.Editor.Windows
             viewport.Add(graphContent);
 
             List<GraphCurveDescriptor> curves = new();
-            List<(GraphConnectionDescriptor connection, GraphCurveDescriptor curve)> markers =
-                new();
+            List<(
+                GraphConnectionDescriptor connection,
+                GraphCurveDescriptor curve,
+                float position
+            )> markers = new();
             foreach (
                 IGrouping<string, GraphConnectionDescriptor> pair in connections.GroupBy(
                     connection => connection.MessageTypeName + "\n" + connection.TargetComponentId,
@@ -1948,6 +2366,8 @@ namespace DxMessaging.Editor.Windows
                         connection => connection.RouteKind,
                         StringComparer.Ordinal
                     )
+                    .ThenBy(connection => connection.Context, StringComparer.Ordinal)
+                    .ThenBy(connection => connection.ContextId)
                     .ToArray();
                 for (int index = 0; index < parallelConnections.Length; index++)
                 {
@@ -1966,20 +2386,34 @@ namespace DxMessaging.Editor.Windows
                         continue;
                     }
 
+                    GraphConnectionDescriptor[] outgoingConnections = outgoingConnectionsByMessage[
+                        connection.MessageTypeName
+                    ];
+                    GraphConnectionDescriptor[] incomingConnections = incomingConnectionsByReceiver[
+                        connection.TargetComponentId
+                    ];
+                    string connectionIdentity = CreateGraphConnectionIdentity(connection);
+                    float sourcePortOffset = CreateGraphPortOffset(
+                        outgoingPortIndexes[connectionIdentity],
+                        outgoingConnections.Length
+                    );
+                    float targetPortOffset = CreateGraphPortOffset(
+                        incomingPortIndexes[connectionIdentity],
+                        incomingConnections.Length
+                    );
                     float parallelIndex = index - (parallelConnections.Length - 1) * 0.5f;
-                    float portOffset = parallelIndex * 16f;
-                    float curveOffset = parallelIndex * 38f;
+                    float curveOffset = parallelIndex * 8f;
                     Color edgeColor = connection.TraceOnly
                         ? DxMessagingEditorPalette.Trace
                         : DxMessagingEditorPalette.RouteKindColor(connection.RouteKind);
                     GraphCurveDescriptor curve = new(
                         new Vector2(
                             messagePosition.x + GraphNodeWidth + 7f,
-                            messagePosition.y + GraphNodeHeight * 0.5f + portOffset
+                            messagePosition.y + GraphNodeHeight * 0.5f + sourcePortOffset
                         ),
                         new Vector2(
                             receiverPosition.x - 7f,
-                            receiverPosition.y + GraphNodeHeight * 0.5f + portOffset
+                            receiverPosition.y + GraphNodeHeight * 0.5f + targetPortOffset
                         ),
                         curveOffset,
                         edgeColor,
@@ -1990,7 +2424,17 @@ namespace DxMessaging.Editor.Windows
                         )
                     );
                     curves.Add(curve);
-                    markers.Add((connection, curve));
+                    markers.Add(
+                        (
+                            connection,
+                            curve,
+                            CreateGraphMarkerPosition(
+                                orderedMessageIndexes[connection.MessageTypeName],
+                                messageNames.Length,
+                                curveOffset
+                            )
+                        )
+                    );
                 }
             }
 
@@ -2023,17 +2467,22 @@ namespace DxMessaging.Editor.Windows
                         )
                     )
                     .ToArray();
-                int activityCount = message.HasValue
-                    ? message.Value.CallCount
-                    : messageConnections.Sum(connection => connection.ActivityCount);
+                int activityCount = messageConnections.Sum(connection => connection.ActivityCount);
+                string messageKind = CreateGraphMessageKind(message, messageConnections);
                 string selectionKey = message.HasValue
                     ? CreateMessageSelectionKey(message.Value)
                     : string.Empty;
                 graphContent.Add(
                     CreateGraphNode(
+                        messageKind,
                         CreateCompactGraphLabel(messageTypeName),
-                        $"{FormatCount(messageConnections.Length, "route")} | {FormatCount(messageConnections.Select(connection => connection.TargetComponentId).Distinct(StringComparer.Ordinal).Count(), "receiver")} | {FormatCount(activityCount, "call")}",
-                        messageTypeName,
+                        CreateGraphMessageMetrics(
+                            message,
+                            messageConnections,
+                            messageKind,
+                            activityCount
+                        ),
+                        CreateGraphMessageTooltip(message, messageTypeName, messageKind),
                         GraphMessageNodeClassName,
                         DxMessagingEditorPalette.AmberSoft,
                         messagePositions[messageTypeName],
@@ -2068,9 +2517,7 @@ namespace DxMessaging.Editor.Windows
                         .Select(connection => connection.TargetComponentPath)
                         .FirstOrDefault(path => !string.IsNullOrWhiteSpace(path))
                         ?? componentId;
-                int activityCount = component.HasValue
-                    ? component.Value.CallCount
-                    : receiverConnections.Sum(connection => connection.ActivityCount);
+                int activityCount = receiverConnections.Sum(connection => connection.ActivityCount);
                 string stateText =
                     !component.HasValue || component.Value.ActiveInHierarchy
                         ? "active"
@@ -2080,8 +2527,28 @@ namespace DxMessaging.Editor.Windows
                     : string.Empty;
                 graphContent.Add(
                     CreateGraphNode(
+                        "RECEIVER",
                         CreateCompactReceiverLabel(receiverPath),
-                        $"{FormatCount(receiverConnections.Length, "route")} | {FormatCount(receiverConnections.Select(connection => connection.MessageTypeName).Distinct(StringComparer.Ordinal).Count(), "message")} | {FormatCount(activityCount, "call")} | {stateText}",
+                        new[]
+                        {
+                            new GraphNodeMetric(
+                                "Routes",
+                                receiverConnections.Length.ToString(CultureInfo.InvariantCulture)
+                            ),
+                            new GraphNodeMetric(
+                                "Messages",
+                                receiverConnections
+                                    .Select(connection => connection.MessageTypeName)
+                                    .Distinct(StringComparer.Ordinal)
+                                    .Count()
+                                    .ToString(CultureInfo.InvariantCulture)
+                            ),
+                            new GraphNodeMetric(
+                                "Calls",
+                                activityCount.ToString(CultureInfo.InvariantCulture)
+                            ),
+                            new GraphNodeMetric("State", stateText),
+                        },
                         receiverPath,
                         GraphReceiverNodeClassName,
                         DxMessagingEditorPalette.Amber,
@@ -2094,10 +2561,16 @@ namespace DxMessaging.Editor.Windows
                 );
             }
 
-            foreach ((GraphConnectionDescriptor connection, GraphCurveDescriptor curve) in markers)
+            foreach (
+                (
+                    GraphConnectionDescriptor connection,
+                    GraphCurveDescriptor curve,
+                    float position
+                ) in markers
+            )
             {
                 graphContent.Add(
-                    CreateGraphConnectionMarker(connection, curve, onSelectionChanged)
+                    CreateGraphConnectionMarker(connection, curve, position, onSelectionChanged)
                 );
             }
 
@@ -2123,6 +2596,9 @@ namespace DxMessaging.Editor.Windows
                         edge.TargetComponentId,
                         edge.TargetComponentPath,
                         edge.RegistrationTypeName,
+                        edge.Context,
+                        edge.ContextId,
+                        edge.RecentEmissionSites,
                         edge.CallCount,
                         CreateEdgeSelectionKey(edge),
                         traceOnly: false
@@ -2137,12 +2613,17 @@ namespace DxMessaging.Editor.Windows
                     path.TargetComponentId,
                     path.TargetComponentPath,
                     path.RegistrationTypeName,
+                    path.Context,
+                    path.ContextId,
                 })
                 .Select(group => new GraphConnectionDescriptor(
                     group.Key.MessageTypeName,
                     group.Key.TargetComponentId,
                     group.Key.TargetComponentPath,
                     group.Key.RegistrationTypeName,
+                    group.Key.Context,
+                    group.Key.ContextId,
+                    Array.Empty<string>(),
                     group.Sum(path => path.RecentTracedDeliveryCount),
                     string.Empty,
                     traceOnly: true
@@ -2150,12 +2631,123 @@ namespace DxMessaging.Editor.Windows
                 .OrderBy(connection => connection.MessageTypeName, StringComparer.Ordinal)
                 .ThenBy(connection => connection.TargetComponentPath, StringComparer.Ordinal)
                 .ThenBy(connection => connection.RouteKind, StringComparer.Ordinal)
+                .ThenBy(connection => connection.Context, StringComparer.Ordinal)
+                .ThenBy(connection => connection.ContextId)
                 .ToArray();
         }
 
+        private static void OrderGraphLayersForReadability(
+            ref string[] messageNames,
+            ref string[] receiverIds,
+            IReadOnlyList<GraphConnectionDescriptor> connections
+        )
+        {
+            const int sweepCount = 6;
+            Dictionary<string, string[]> messagesByReceiver = connections
+                .GroupBy(connection => connection.TargetComponentId, StringComparer.Ordinal)
+                .ToDictionary(
+                    group => group.Key,
+                    group =>
+                        group
+                            .Select(connection => connection.MessageTypeName)
+                            .Distinct(StringComparer.Ordinal)
+                            .ToArray(),
+                    StringComparer.Ordinal
+                );
+            Dictionary<string, string[]> receiversByMessage = connections
+                .GroupBy(connection => connection.MessageTypeName, StringComparer.Ordinal)
+                .ToDictionary(
+                    group => group.Key,
+                    group =>
+                        group
+                            .Select(connection => connection.TargetComponentId)
+                            .Distinct(StringComparer.Ordinal)
+                            .ToArray(),
+                    StringComparer.Ordinal
+                );
+            for (int sweep = 0; sweep < sweepCount; sweep++)
+            {
+                Dictionary<string, int> messageIndexes = CreateGraphOrderIndexes(messageNames);
+                receiverIds = OrderGraphLayer(
+                    receiverIds,
+                    receiverId =>
+                        messagesByReceiver
+                            .GetValueOrDefault(receiverId, Array.Empty<string>())
+                            .Select(messageName =>
+                                messageIndexes.GetValueOrDefault(messageName, int.MaxValue)
+                            )
+                );
+
+                Dictionary<string, int> receiverIndexes = CreateGraphOrderIndexes(receiverIds);
+                messageNames = OrderGraphLayer(
+                    messageNames,
+                    messageName =>
+                        receiversByMessage
+                            .GetValueOrDefault(messageName, Array.Empty<string>())
+                            .Select(receiverId =>
+                                receiverIndexes.GetValueOrDefault(receiverId, int.MaxValue)
+                            )
+                );
+            }
+        }
+
+        private static Dictionary<string, int> CreateGraphOrderIndexes(IReadOnlyList<string> values)
+        {
+            Dictionary<string, int> indexes = new(values.Count, StringComparer.Ordinal);
+            for (int index = 0; index < values.Count; index++)
+            {
+                indexes[values[index]] = index;
+            }
+            return indexes;
+        }
+
+        private static string[] OrderGraphLayer(
+            IReadOnlyList<string> values,
+            Func<string, IEnumerable<int>> connectedIndexes
+        )
+        {
+            Dictionary<string, int> previousIndexes = CreateGraphOrderIndexes(values);
+            return values
+                .OrderBy(value =>
+                {
+                    int[] indexes = connectedIndexes(value)
+                        .Where(index => index != int.MaxValue)
+                        .ToArray();
+                    return indexes.Length == 0 ? double.MaxValue : indexes.Average();
+                })
+                .ThenBy(value => previousIndexes[value])
+                .ThenBy(value => value, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static string CreateGraphConnectionIdentity(GraphConnectionDescriptor connection)
+        {
+            return string.Join(
+                "|",
+                connection.MessageTypeName,
+                connection.TargetComponentId,
+                connection.RouteKind,
+                connection.Context,
+                connection.ContextId.ToString(CultureInfo.InvariantCulture)
+            );
+        }
+
+        private static float CreateGraphPortOffset(int index, int count)
+        {
+            if (count <= 1)
+            {
+                return 0f;
+            }
+
+            const float usableHeightRatio = 0.64f;
+            float halfRange = GraphNodeHeight * usableHeightRatio * 0.5f;
+            return Mathf.Lerp(-halfRange, halfRange, index / (float)(count - 1));
+        }
+
         private static VisualElement CreateGraphNode(
+            string eyebrow,
             string title,
-            string summary,
+            IReadOnlyList<GraphNodeMetric> metrics,
             string tooltip,
             string className,
             Color accent,
@@ -2169,6 +2761,8 @@ namespace DxMessaging.Editor.Windows
             VisualElement node = new() { tooltip = tooltip };
             node.AddToClassList(className);
             node.AddToClassList(DxMessagingEditorTheme.CardClassName);
+            node.focusable = !string.IsNullOrWhiteSpace(selectionKey);
+            node.userData = selectionKey;
             node.style.position = Position.Absolute;
             node.style.left = position.x;
             node.style.top = position.y;
@@ -2179,6 +2773,7 @@ namespace DxMessaging.Editor.Windows
             node.style.paddingBottom = 8;
             node.style.paddingLeft = 10;
             DxMessagingEditorTheme.ApplyCompleteBorder(node, accent);
+            ConfigureGraphFocusIndicator(node, node, accent);
             if (selected)
             {
                 node.AddToClassList(SelectedRowClassName);
@@ -2188,31 +2783,65 @@ namespace DxMessaging.Editor.Windows
             Label titleLabel = new(title);
             titleLabel.style.unityFontStyleAndWeight = FontStyle.Bold;
             titleLabel.style.fontSize = 13;
+            titleLabel.style.maxWidth = GraphNodeWidth - 92f;
+            titleLabel.style.whiteSpace = WhiteSpace.NoWrap;
+            titleLabel.style.overflow = Overflow.Hidden;
+            titleLabel.style.textOverflow = TextOverflow.Ellipsis;
             node.Add(titleLabel);
 
-            Label summaryLabel = new(summary);
-            summaryLabel.style.marginTop = 5;
-            summaryLabel.style.whiteSpace = WhiteSpace.Normal;
-            node.Add(summaryLabel);
+            Label eyebrowLabel = new(eyebrow);
+            eyebrowLabel.style.position = Position.Absolute;
+            eyebrowLabel.style.right = 10;
+            eyebrowLabel.style.top = 9;
+            eyebrowLabel.style.fontSize = 9;
+            eyebrowLabel.style.unityFontStyleAndWeight = FontStyle.Bold;
+            eyebrowLabel.style.color = accent;
+            node.Add(eyebrowLabel);
+
+            VisualElement metricsContainer = new();
+            metricsContainer.style.marginTop = 8;
+            foreach (GraphNodeMetric metric in metrics)
+            {
+                VisualElement metricRow = new();
+                metricRow.AddToClassList(GraphNodeMetricClassName);
+                metricRow.style.flexDirection = FlexDirection.Row;
+                metricRow.style.marginBottom = 2;
+                Label metricLabel = new(metric.Label);
+                metricLabel.style.width = 72;
+                metricLabel.style.fontSize = 10;
+                metricLabel.style.opacity = 0.7f;
+                metricRow.Add(metricLabel);
+                Label metricValue = new(metric.Value);
+                metricValue.style.flexGrow = 1;
+                metricValue.style.fontSize = 11;
+                metricValue.style.unityFontStyleAndWeight = FontStyle.Bold;
+                metricValue.style.whiteSpace = WhiteSpace.NoWrap;
+                metricValue.style.overflow = Overflow.Hidden;
+                metricValue.style.textOverflow = TextOverflow.Ellipsis;
+                metricRow.Add(metricValue);
+                metricsContainer.Add(metricRow);
+            }
+            node.Add(metricsContainer);
 
             VisualElement port = new();
             port.pickingMode = PickingMode.Ignore;
             port.style.position = Position.Absolute;
-            port.style.top = GraphNodeHeight * 0.5f - 6f;
+            float portHeight = GraphNodeHeight * 0.64f;
+            port.style.top = (GraphNodeHeight - portHeight) * 0.5f;
             if (outputPort)
             {
-                port.style.right = -7f;
+                port.style.right = -3f;
             }
             else
             {
-                port.style.left = -7f;
+                port.style.left = -3f;
             }
-            port.style.width = 12;
-            port.style.height = 12;
-            port.style.borderTopLeftRadius = 6;
-            port.style.borderTopRightRadius = 6;
-            port.style.borderBottomLeftRadius = 6;
-            port.style.borderBottomRightRadius = 6;
+            port.style.width = 6;
+            port.style.height = portHeight;
+            port.style.borderTopLeftRadius = 3;
+            port.style.borderTopRightRadius = 3;
+            port.style.borderBottomLeftRadius = 3;
+            port.style.borderBottomRightRadius = 3;
             port.style.backgroundColor = accent;
             DxMessagingEditorTheme.ApplyCompleteBorder(port, DxMessagingEditorPalette.BorderStrong);
             node.Add(port);
@@ -2225,6 +2854,15 @@ namespace DxMessaging.Editor.Windows
                     evt.StopPropagation();
                     onSelectionChanged.Invoke(selectionKey);
                 });
+                node.RegisterCallback<KeyDownEvent>(evt =>
+                {
+                    if (evt.keyCode != KeyCode.Return && evt.keyCode != KeyCode.Space)
+                    {
+                        return;
+                    }
+                    evt.StopPropagation();
+                    onSelectionChanged.Invoke(selectionKey);
+                });
             }
             return node;
         }
@@ -2232,33 +2870,50 @@ namespace DxMessaging.Editor.Windows
         private static VisualElement CreateGraphConnectionMarker(
             GraphConnectionDescriptor connection,
             GraphCurveDescriptor curve,
+            float markerPosition,
             Action<string> onSelectionChanged
         )
         {
-            Vector2 midpoint = curve.Evaluate(0.5f);
-            float size = curve.Selected ? 18f : 14f;
+            Vector2 midpoint = curve.Evaluate(markerPosition);
+            const float hitSize = 30f;
+            float glyphSize = curve.Selected ? 18f : 12f;
             VisualElement marker = new()
             {
                 tooltip =
-                    $"{connection.MessageTypeName} -> {connection.TargetComponentPath}\n{connection.RouteKind} | {connection.ActivityCount} {(connection.TraceOnly ? "deliveries" : "calls")}",
+                    $"{CreateConnectionFlowText(connection)}\n{connection.RouteKind} | {connection.ActivityCount} {(connection.TraceOnly ? "deliveries" : "calls")}{CreateConnectionEmissionSiteText(connection)}",
             };
             marker.AddToClassList(GraphConnectionClassName);
+            marker.focusable = !string.IsNullOrWhiteSpace(connection.SelectionKey);
+            marker.userData = connection.SelectionKey;
             if (curve.Selected)
             {
                 marker.AddToClassList(SelectedRowClassName);
             }
             marker.style.position = Position.Absolute;
-            marker.style.left = midpoint.x - size * 0.5f;
-            marker.style.top = midpoint.y - size * 0.5f;
-            marker.style.width = size;
-            marker.style.height = size;
-            marker.style.borderTopLeftRadius = size * 0.5f;
-            marker.style.borderTopRightRadius = size * 0.5f;
-            marker.style.borderBottomLeftRadius = size * 0.5f;
-            marker.style.borderBottomRightRadius = size * 0.5f;
-            marker.style.backgroundColor = curve.Color;
+            marker.style.left = midpoint.x - hitSize * 0.5f;
+            marker.style.top = midpoint.y - hitSize * 0.5f;
+            marker.style.width = hitSize;
+            marker.style.height = hitSize;
+
+            VisualElement glyph = new();
+            glyph.pickingMode = PickingMode.Ignore;
+            glyph.style.position = Position.Absolute;
+            glyph.style.left = (hitSize - glyphSize) * 0.5f;
+            glyph.style.top = (hitSize - glyphSize) * 0.5f;
+            glyph.style.width = glyphSize;
+            glyph.style.height = glyphSize;
+            glyph.style.backgroundColor = curve.Color;
+            ApplyGraphConnectionMarkerShape(glyph, connection.RouteKind, glyphSize);
             DxMessagingEditorTheme.ApplyCompleteBorder(
+                glyph,
+                curve.Selected
+                    ? DxMessagingEditorPalette.AmberSoft
+                    : DxMessagingEditorPalette.BorderStrong
+            );
+            marker.Add(glyph);
+            ConfigureGraphFocusIndicator(
                 marker,
+                glyph,
                 curve.Selected
                     ? DxMessagingEditorPalette.AmberSoft
                     : DxMessagingEditorPalette.BorderStrong
@@ -2272,8 +2927,109 @@ namespace DxMessaging.Editor.Windows
                     evt.StopPropagation();
                     onSelectionChanged.Invoke(selectionKey);
                 });
+                marker.RegisterCallback<KeyDownEvent>(evt =>
+                {
+                    if (evt.keyCode != KeyCode.Return && evt.keyCode != KeyCode.Space)
+                    {
+                        return;
+                    }
+                    evt.StopPropagation();
+                    onSelectionChanged.Invoke(selectionKey);
+                });
             }
             return marker;
+        }
+
+        private static void ConfigureGraphFocusIndicator(
+            VisualElement focusTarget,
+            VisualElement borderTarget,
+            Color restingColor
+        )
+        {
+            focusTarget.RegisterCallback<FocusInEvent>(_ =>
+                ApplyGraphFocusIndicator(borderTarget, restingColor, focused: true)
+            );
+            focusTarget.RegisterCallback<FocusOutEvent>(_ =>
+                ApplyGraphFocusIndicator(borderTarget, restingColor, focused: false)
+            );
+        }
+
+        internal static void ApplyGraphFocusIndicator(
+            VisualElement element,
+            Color restingColor,
+            bool focused
+        )
+        {
+            float width = focused ? 3f : DxMessagingEditorTheme.CompleteBorderWidth;
+            DxMessagingEditorTheme.ApplyCompleteBorder(
+                element,
+                focused ? DxMessagingEditorPalette.AmberSoft : restingColor,
+                width
+            );
+        }
+
+        internal static float CreateGraphMarkerPosition(
+            int sourceIndex,
+            int sourceCount,
+            float curveOffset
+        )
+        {
+            float sourcePosition =
+                sourceCount <= 1
+                    ? 0.5f
+                    : Mathf.Lerp(0.38f, 0.62f, sourceIndex / (sourceCount - 1f));
+            return Mathf.Clamp(sourcePosition + curveOffset / 160f, 0.3f, 0.7f);
+        }
+
+        private static void ApplyGraphConnectionMarkerShape(
+            VisualElement marker,
+            string routeKind,
+            float size
+        )
+        {
+            string normalizedKind = DxMessagingEditorPalette.NormalizeRouteKind(routeKind);
+            float radius =
+                normalizedKind == DxMessagingEditorPalette.BroadcastKind ? size * 0.5f : 2f;
+            marker.style.borderTopLeftRadius = radius;
+            marker.style.borderTopRightRadius = radius;
+            marker.style.borderBottomLeftRadius = radius;
+            marker.style.borderBottomRightRadius = radius;
+            if (normalizedKind == DxMessagingEditorPalette.TargetedKind)
+            {
+                marker.transform.rotation = Quaternion.Euler(0f, 0f, 45f);
+            }
+        }
+
+        private static string CreateConnectionEmissionSiteText(GraphConnectionDescriptor connection)
+        {
+            return connection.RecentEmissionSites.Count == 0
+                ? string.Empty
+                : "\nEMITTED BY " + string.Join(", ", connection.RecentEmissionSites);
+        }
+
+        private static string CreateConnectionFlowText(GraphConnectionDescriptor connection)
+        {
+            string context =
+                string.IsNullOrWhiteSpace(connection.Context) || connection.Context == "<none>"
+                    ? "ANY"
+                    : connection.Context;
+            switch (DxMessagingEditorPalette.NormalizeRouteKind(connection.RouteKind))
+            {
+                case DxMessagingEditorPalette.BroadcastKind:
+                    return $"{context} -> {connection.MessageTypeName} -> {connection.TargetComponentPath}";
+                case DxMessagingEditorPalette.TargetedKind:
+                    return $"{connection.MessageTypeName} -> {context} -> {connection.TargetComponentPath}";
+                case DxMessagingEditorPalette.UntargetedKind:
+                    return $"GLOBAL BUS -> {connection.MessageTypeName} -> {connection.TargetComponentPath}";
+                default:
+                    return string.Equals(
+                        connection.RouteKind,
+                        MessageRegistrationType.GlobalAcceptAll.ToString(),
+                        StringComparison.Ordinal
+                    )
+                        ? $"ANY MESSAGE -> {connection.TargetComponentPath}"
+                        : $"{connection.MessageTypeName} -> {connection.TargetComponentPath}";
+            }
         }
 
         private static void ConfigureGraphViewport(
@@ -2339,7 +3095,7 @@ namespace DxMessaging.Editor.Windows
             {
                 float previousZoom = canvasState.Zoom;
                 float zoomFactor = evt.delta.y > 0f ? 0.88f : 1.14f;
-                float nextZoom = Mathf.Clamp(previousZoom * zoomFactor, 0.02f, 2f);
+                float nextZoom = Mathf.Clamp(previousZoom * zoomFactor, 0.8f, 2f);
                 Vector2 contentCenter = contentSize * 0.5f;
                 Vector2 mousePosition = evt.localMousePosition;
                 Vector2 contentPoint =
@@ -2382,7 +3138,7 @@ namespace DxMessaging.Editor.Windows
 
             float horizontalScale = Math.Max(0f, viewportSize.x - 32f) / contentSize.x;
             float verticalScale = Math.Max(0f, viewportSize.y - 32f) / contentSize.y;
-            return Mathf.Clamp(Math.Min(horizontalScale, verticalScale), 0.02f, 1f);
+            return Mathf.Clamp(Math.Min(horizontalScale, verticalScale), 0.8f, 1f);
         }
 
         private static string CreateGraphLayoutSignature(
@@ -2409,6 +3165,10 @@ namespace DxMessaging.Editor.Windows
                     .Append(connection.TargetComponentId)
                     .Append('|')
                     .Append(connection.RouteKind)
+                    .Append('|')
+                    .Append(connection.Context)
+                    .Append('|')
+                    .Append(connection.ContextId)
                     .Append('\n');
             }
             return signature.ToString();
@@ -4679,14 +5439,230 @@ namespace DxMessaging.Editor.Windows
             return CreateEdgeSelectionKey(
                 edge.MessageTypeName,
                 edge.TargetComponentId,
-                edge.RegistrationTypeName
+                edge.RegistrationTypeName,
+                edge.Context,
+                edge.ContextId
             );
+        }
+
+        private static string CreateGraphMessageKind(
+            FlowGraphMessageNode? message,
+            IReadOnlyList<GraphConnectionDescriptor> connections
+        )
+        {
+            return CreateVisibleMessageKind(
+                message?.MessageKindName,
+                connections.Select(connection => connection.RouteKind)
+            );
+        }
+
+        private static string CreateVisibleMessageKind(
+            string fallbackKind,
+            IEnumerable<string> routeKinds
+        )
+        {
+            string[] visibleRouteKinds = routeKinds?.ToArray() ?? Array.Empty<string>();
+            if (
+                visibleRouteKinds.Any(kind =>
+                    string.Equals(
+                        kind,
+                        MessageRegistrationType.GlobalAcceptAll.ToString(),
+                        StringComparison.Ordinal
+                    )
+                )
+            )
+            {
+                return "GLOBAL OBSERVER";
+            }
+
+            string[] normalizedKinds = visibleRouteKinds
+                .Select(DxMessagingEditorPalette.NormalizeRouteKind)
+                .Where(kind => !string.IsNullOrWhiteSpace(kind) && kind != "none")
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+            if (normalizedKinds.Length > 1)
+            {
+                return "MIXED";
+            }
+            if (normalizedKinds.Length == 1)
+            {
+                switch (normalizedKinds[0])
+                {
+                    case "Broadcast":
+                        return "BROADCAST";
+                    case "Targeted":
+                        return "TARGETED";
+                    case "Untargeted":
+                        return "GLOBAL";
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(fallbackKind))
+            {
+                return fallbackKind;
+            }
+
+            return "MESSAGE";
+        }
+
+        private static string CreateVisibleMessageKind(
+            FlowGraphMessageNode message,
+            FlowGraphVisibleSnapshot visibleSnapshot
+        )
+        {
+            return CreateVisibleMessageKind(
+                message.MessageKindName,
+                visibleSnapshot
+                    .Edges.Where(edge =>
+                        string.Equals(
+                            edge.MessageTypeName,
+                            message.MessageTypeName,
+                            StringComparison.Ordinal
+                        )
+                    )
+                    .Select(edge => edge.RegistrationTypeName)
+            );
+        }
+
+        private static IReadOnlyList<GraphNodeMetric> CreateGraphMessageMetrics(
+            FlowGraphMessageNode? message,
+            IReadOnlyList<GraphConnectionDescriptor> connections,
+            string messageKind,
+            int activityCount
+        )
+        {
+            int receiverCount = connections
+                .Select(connection => connection.TargetComponentId)
+                .Distinct(StringComparer.Ordinal)
+                .Count();
+            int emissionSiteCount = connections
+                .SelectMany(connection => connection.RecentEmissionSites)
+                .Distinct(StringComparer.Ordinal)
+                .Count();
+            string contextSummary = CreateGraphContextMetric(connections);
+            switch (messageKind)
+            {
+                case "BROADCAST":
+                    return new[]
+                    {
+                        new GraphNodeMetric("Sources", contextSummary),
+                        new GraphNodeMetric(
+                            "Receivers",
+                            receiverCount.ToString(CultureInfo.InvariantCulture)
+                        ),
+                        new GraphNodeMetric(
+                            "Calls",
+                            activityCount.ToString(CultureInfo.InvariantCulture)
+                        ),
+                    };
+                case "TARGETED":
+                    return new[]
+                    {
+                        new GraphNodeMetric("Targets", contextSummary),
+                        new GraphNodeMetric(
+                            "Handlers",
+                            receiverCount.ToString(CultureInfo.InvariantCulture)
+                        ),
+                        new GraphNodeMetric(
+                            "Call sites",
+                            emissionSiteCount.ToString(CultureInfo.InvariantCulture)
+                        ),
+                    };
+                case "GLOBAL":
+                    return new[]
+                    {
+                        new GraphNodeMetric("Scope", "Global bus"),
+                        new GraphNodeMetric(
+                            "Receivers",
+                            receiverCount.ToString(CultureInfo.InvariantCulture)
+                        ),
+                        new GraphNodeMetric(
+                            "Calls",
+                            activityCount.ToString(CultureInfo.InvariantCulture)
+                        ),
+                    };
+                case "GLOBAL OBSERVER":
+                    return new[]
+                    {
+                        new GraphNodeMetric("Scope", "Any message"),
+                        new GraphNodeMetric(
+                            "Observers",
+                            receiverCount.ToString(CultureInfo.InvariantCulture)
+                        ),
+                        new GraphNodeMetric(
+                            "Calls",
+                            activityCount.ToString(CultureInfo.InvariantCulture)
+                        ),
+                    };
+                default:
+                    return new[]
+                    {
+                        new GraphNodeMetric(
+                            "Routes",
+                            connections.Count.ToString(CultureInfo.InvariantCulture)
+                        ),
+                        new GraphNodeMetric(
+                            "Receivers",
+                            receiverCount.ToString(CultureInfo.InvariantCulture)
+                        ),
+                        new GraphNodeMetric(
+                            "Calls",
+                            activityCount.ToString(CultureInfo.InvariantCulture)
+                        ),
+                    };
+            }
+        }
+
+        private static string CreateGraphMessageTooltip(
+            FlowGraphMessageNode? message,
+            string messageTypeName,
+            string messageKind
+        )
+        {
+            if (!message.HasValue)
+            {
+                return messageKind + ": " + messageTypeName;
+            }
+
+            return $"{messageKind}: {messageTypeName}\nObserved emit sites: {JoinDistinctOrNone(message.Value.RecentEmissionSites)}\nObserved contexts: {JoinDistinctOrNone(message.Value.RecentContexts)}";
+        }
+
+        private static string CreateGraphContextMetric(
+            IEnumerable<GraphConnectionDescriptor> connections
+        )
+        {
+            GraphConnectionDescriptor[] values = connections
+                .Where(connection =>
+                    !string.IsNullOrWhiteSpace(connection.Context) && connection.Context != "<none>"
+                )
+                .GroupBy(
+                    connection =>
+                        connection.ContextId == 0
+                            ? "text:" + connection.Context
+                            : "id:" + connection.ContextId.ToString(CultureInfo.InvariantCulture),
+                    StringComparer.Ordinal
+                )
+                .Select(group => group.First())
+                .OrderBy(connection => connection.Context, StringComparer.Ordinal)
+                .ThenBy(connection => connection.ContextId)
+                .ToArray();
+            if (values.Length == 0)
+            {
+                return "ANY";
+            }
+
+            string first = CreateCompactReceiverLabel(values[0].Context);
+            return values.Length == 1
+                ? first
+                : values.Length.ToString(CultureInfo.InvariantCulture) + " observed";
         }
 
         private static string CreateEdgeSelectionKey(
             string messageTypeName,
             string targetComponentId,
-            string registrationTypeName
+            string registrationTypeName,
+            string context,
+            int contextId
         )
         {
             return string.Join(
@@ -4694,7 +5670,9 @@ namespace DxMessaging.Editor.Windows
                 "edge",
                 messageTypeName ?? string.Empty,
                 targetComponentId ?? string.Empty,
-                registrationTypeName ?? string.Empty
+                registrationTypeName ?? string.Empty,
+                context ?? string.Empty,
+                contextId.ToString(CultureInfo.InvariantCulture)
             );
         }
 
@@ -4750,7 +5728,12 @@ namespace DxMessaging.Editor.Windows
                 string selectionKey = CreateMessageSelectionKey(message);
                 row.RegisterCallback<ClickEvent>(_ => onSelectionChanged.Invoke(selectionKey));
             }
-            row.Add(new Label(message.MessageTypeName) { name = NodeNameLabelName });
+            row.Add(
+                new Label($"{message.MessageKindName}: {message.MessageTypeName}")
+                {
+                    name = NodeNameLabelName,
+                }
+            );
             row.Add(
                 new Label(
                     $"Registrations: {message.RegistrationCount} | Calls: {message.CallCount} | Recent: {message.RecentGlobalEmissionCount} global / {message.RecentLocalMessageCount} listener | Traced deliveries: {message.RecentTracedDeliveryCount}"
@@ -4787,12 +5770,7 @@ namespace DxMessaging.Editor.Windows
             row.style.paddingBottom = 7;
             row.style.paddingLeft = 10;
 
-            Label label = new(
-                $"{edge.MessageTypeName} -> {edge.TargetComponentPath} ({edge.RegistrationTypeName})"
-            )
-            {
-                name = EdgeLabelName,
-            };
+            Label label = new(CreateEdgeFlowText(edge)) { name = EdgeLabelName };
             label.style.unityFontStyleAndWeight = FontStyle.Bold;
             row.Add(label);
 
@@ -4817,10 +5795,16 @@ namespace DxMessaging.Editor.Windows
         private static Label CreateRouteKindBadge(string routeKindText, string name)
         {
             string normalizedKind = DxMessagingEditorPalette.NormalizeRouteKind(routeKindText);
-            string labelText = string.IsNullOrWhiteSpace(normalizedKind)
-                ? string.IsNullOrWhiteSpace(routeKindText)
-                    ? "<unknown route kind>"
-                    : routeKindText.Trim()
+            string labelText =
+                string.Equals(
+                    routeKindText,
+                    MessageRegistrationType.GlobalAcceptAll.ToString(),
+                    StringComparison.Ordinal
+                )
+                    ? "GLOBAL OBSERVER"
+                : string.IsNullOrWhiteSpace(normalizedKind)
+                    ? string.IsNullOrWhiteSpace(routeKindText) ? "<unknown route kind>"
+                        : routeKindText.Trim()
                 : normalizedKind;
             Label routeKind = new(labelText) { name = name };
             DxMessagingEditorTheme.AddRouteKindTypeBadgeClasses(routeKind, routeKindText);
@@ -4861,26 +5845,483 @@ namespace DxMessaging.Editor.Windows
         {
             VisualElement details = new() { name = DetailsPaneName };
             details.AddToClassList(DxMessagingEditorTheme.CardClassName);
-            details.style.borderTopWidth = 1;
-            details.style.borderTopColor = DxMessagingEditorPalette.BorderPanel;
+            DxMessagingEditorTheme.ApplyCompleteBorder(
+                details,
+                DxMessagingEditorPalette.BorderPanel
+            );
             details.style.marginTop = 10;
-            details.style.paddingTop = 8;
+            details.style.paddingTop = 12;
+            details.style.paddingRight = 12;
+            details.style.paddingBottom = 12;
+            details.style.paddingLeft = 12;
 
+            VisualElement header = new();
+            header.style.flexDirection = FlexDirection.Row;
+            header.style.alignItems = Align.Center;
+            header.style.marginBottom = 10;
             Label title = new(CreateDetailsTitle(selectedItem)) { name = DetailsTitleLabelName };
             title.AddToClassList(DxMessagingEditorTheme.CardLabelClassName);
             title.style.unityFontStyleAndWeight = FontStyle.Bold;
             title.style.whiteSpace = WhiteSpace.Normal;
-            details.Add(title);
+            title.style.fontSize = 14;
+            title.style.flexGrow = 1;
+            title.style.marginBottom = 0;
+            header.Add(title);
+            if (selectedItem.Kind == FlowGraphSelectionKind.Edge)
+            {
+                header.Add(CreateRouteKindBadge(selectedItem.Edge.RegistrationTypeName, null));
+            }
+            else if (selectedItem.Kind == FlowGraphSelectionKind.Message)
+            {
+                header.Add(
+                    CreateGraphLegendBadge(
+                        CreateVisibleMessageKind(selectedItem.Message, visibleSnapshot),
+                        DxMessagingEditorPalette.AmberSoft
+                    )
+                );
+            }
+            details.Add(header);
 
+            switch (selectedItem.Kind)
+            {
+                case FlowGraphSelectionKind.Component:
+                    AddComponentDetailsCards(details, selectedItem.Component, visibleSnapshot);
+                    break;
+                case FlowGraphSelectionKind.Message:
+                    AddMessageDetailsCards(details, selectedItem.Message, visibleSnapshot);
+                    break;
+                case FlowGraphSelectionKind.Edge:
+                    AddEdgeDetailsCards(details, selectedItem.Edge, visibleSnapshot);
+                    break;
+            }
+
+            Foldout technical = new()
+            {
+                name = DetailsTechnicalFoldoutName,
+                text = "Technical diagnostics",
+                value = false,
+            };
+            technical.style.marginTop = 4;
             Label body = new(CreateDetailsBody(selectedItem, visibleSnapshot))
             {
                 name = DetailsBodyLabelName,
             };
             body.style.marginTop = 4;
             body.style.whiteSpace = WhiteSpace.Normal;
-            details.Add(body);
+            technical.Add(body);
+            details.Add(technical);
 
             return details;
+        }
+
+        private static void AddComponentDetailsCards(
+            VisualElement details,
+            FlowGraphComponentNode component,
+            FlowGraphVisibleSnapshot visibleSnapshot
+        )
+        {
+            FlowGraphEdge[] inboundEdges = visibleSnapshot
+                .Edges.Where(edge =>
+                    string.Equals(edge.TargetComponentId, component.Id, StringComparison.Ordinal)
+                )
+                .ToArray();
+            int totalCalls = SumVisibleCalls(visibleSnapshot);
+            int totalTracedDeliveries = SumVisibleTracedDeliveries(visibleSnapshot);
+            details.Add(
+                CreateDetailsMetricSection(
+                    "COMPONENT",
+                    new GraphNodeMetric(
+                        "State",
+                        component.ActiveInHierarchy ? "Active" : "Inactive"
+                    ),
+                    new GraphNodeMetric(
+                        "Listeners",
+                        component.ListenerCount.ToString(CultureInfo.InvariantCulture)
+                    ),
+                    new GraphNodeMetric(
+                        "Registrations",
+                        component.RegistrationCount.ToString(CultureInfo.InvariantCulture)
+                    ),
+                    new GraphNodeMetric(
+                        "Calls",
+                        component.CallCount.ToString(CultureInfo.InvariantCulture)
+                    ),
+                    new GraphNodeMetric(
+                        "Local messages",
+                        component.LocalMessageCount.ToString(CultureInfo.InvariantCulture)
+                    )
+                )
+            );
+            VisualElement traffic = CreateDetailsSection("VISIBLE TRAFFIC");
+            traffic.Add(CreateDetailsKeyValue("Type", component.ComponentTypeName));
+            traffic.Add(CreateDetailsKeyValue("Hierarchy", component.HierarchyPath));
+            traffic.Add(
+                CreateDetailsKeyValue(
+                    "Inbound routes",
+                    inboundEdges.Length.ToString(CultureInfo.InvariantCulture)
+                )
+            );
+            traffic.Add(
+                CreateDetailsKeyValue(
+                    "Message types",
+                    JoinDistinctOrNone(inboundEdges.Select(edge => edge.MessageTypeName))
+                )
+            );
+            traffic.Add(
+                CreateDetailsKeyValue(
+                    "Call share",
+                    CreateCallShareText(inboundEdges.Sum(edge => edge.CallCount), totalCalls)
+                )
+            );
+            traffic.Add(
+                CreateDetailsKeyValue(
+                    "Trace share",
+                    CreateCallShareText(
+                        inboundEdges.Sum(edge => edge.RecentTracedDeliveryCount),
+                        totalTracedDeliveries
+                    )
+                )
+            );
+            details.Add(traffic);
+        }
+
+        private static void AddMessageDetailsCards(
+            VisualElement details,
+            FlowGraphMessageNode message,
+            FlowGraphVisibleSnapshot visibleSnapshot
+        )
+        {
+            FlowGraphEdge[] messageEdges = visibleSnapshot
+                .Edges.Where(edge =>
+                    string.Equals(
+                        edge.MessageTypeName,
+                        message.MessageTypeName,
+                        StringComparison.Ordinal
+                    )
+                )
+                .ToArray();
+            string visibleMessageKind = CreateVisibleMessageKind(
+                message.MessageKindName,
+                messageEdges.Select(edge => edge.RegistrationTypeName)
+            );
+            details.Add(
+                CreateDetailsMetricSection(
+                    "MESSAGE",
+                    new GraphNodeMetric("Kind", visibleMessageKind),
+                    new GraphNodeMetric(
+                        "Routes",
+                        messageEdges.Length.ToString(CultureInfo.InvariantCulture)
+                    ),
+                    new GraphNodeMetric(
+                        "Receivers",
+                        CountDistinct(messageEdges.Select(edge => edge.TargetComponentId))
+                            .ToString(CultureInfo.InvariantCulture)
+                    ),
+                    new GraphNodeMetric(
+                        "Registrations",
+                        messageEdges
+                            .Sum(edge => edge.RegistrationCount)
+                            .ToString(CultureInfo.InvariantCulture)
+                    ),
+                    new GraphNodeMetric(
+                        "Calls",
+                        messageEdges
+                            .Sum(edge => edge.CallCount)
+                            .ToString(CultureInfo.InvariantCulture)
+                    ),
+                    new GraphNodeMetric(
+                        "Traced",
+                        message.RecentTracedDeliveryCount.ToString(CultureInfo.InvariantCulture)
+                    )
+                )
+            );
+            VisualElement evidence = CreateDetailsSection("RECENT EVIDENCE");
+            evidence.Add(CreateDetailsKeyValue("Message type", message.MessageTypeName));
+            evidence.Add(
+                CreateDetailsKeyValue("Contexts", JoinDistinctOrNone(message.RecentContexts))
+            );
+            AddDetailValues(evidence, "Emitted by", message.RecentEmissionSites);
+            if (visibleMessageKind == "GLOBAL OBSERVER")
+            {
+                evidence.Add(
+                    CreateDetailsKeyValue(
+                        "Observed types",
+                        JoinDistinctOrNone(
+                            visibleSnapshot
+                                .TracePaths.Where(path =>
+                                    string.Equals(
+                                        path.RegistrationTypeName,
+                                        MessageRegistrationType.GlobalAcceptAll.ToString(),
+                                        StringComparison.Ordinal
+                                    )
+                                )
+                                .Select(path => path.MessageTypeName)
+                        )
+                    )
+                );
+            }
+            details.Add(evidence);
+        }
+
+        private static void AddEdgeDetailsCards(
+            VisualElement details,
+            FlowGraphEdge edge,
+            FlowGraphVisibleSnapshot visibleSnapshot
+        )
+        {
+            FlowGraphTracePath[] tracePaths = visibleSnapshot
+                .TracePaths.Where(path => EdgeMatchesTracePath(edge, path))
+                .ToArray();
+            details.Add(CreateRoutePathSection(edge));
+            details.Add(
+                CreateDetailsMetricSection(
+                    "ROUTE ACTIVITY",
+                    new GraphNodeMetric(
+                        "Registrations",
+                        edge.RegistrationCount.ToString(CultureInfo.InvariantCulture)
+                    ),
+                    new GraphNodeMetric(
+                        "Calls",
+                        edge.CallCount.ToString(CultureInfo.InvariantCulture)
+                    ),
+                    new GraphNodeMetric(
+                        "Traced",
+                        edge.RecentTracedDeliveryCount.ToString(CultureInfo.InvariantCulture)
+                    ),
+                    new GraphNodeMetric(
+                        "Call share",
+                        CreateCallShareText(edge.CallCount, SumVisibleCalls(visibleSnapshot))
+                    ),
+                    new GraphNodeMetric(
+                        "Trace share",
+                        CreateCallShareText(
+                            edge.RecentTracedDeliveryCount,
+                            SumVisibleTracedDeliveries(visibleSnapshot)
+                        )
+                    )
+                )
+            );
+            VisualElement evidence = CreateDetailsSection("EMISSION EVIDENCE");
+            evidence.Add(
+                CreateDetailsKeyValue(
+                    "Route kind",
+                    DxMessagingEditorPalette.NormalizeRouteKind(edge.RegistrationTypeName)
+                )
+            );
+            evidence.Add(CreateDetailsKeyValue("Registration", edge.RegistrationTypeName));
+            evidence.Add(CreateDetailsKeyValue("Context", CreateReadableRouteContext(edge)));
+            evidence.Add(
+                CreateDetailsKeyValue(
+                    "Evidence scope",
+                    "Exact component registration delivery record"
+                )
+            );
+            AddDetailValues(evidence, "Matching call site", edge.RecentEmissionSites);
+            details.Add(evidence);
+
+            VisualElement traces = CreateDetailsSection("TRACE EVIDENCE");
+            traces.Add(
+                CreateDetailsKeyValue(
+                    "Paths",
+                    tracePaths.Length.ToString(CultureInfo.InvariantCulture)
+                )
+            );
+            traces.Add(
+                CreateDetailsKeyValue(
+                    "Deliveries",
+                    tracePaths
+                        .Sum(path => path.RecentTracedDeliveryCount)
+                        .ToString(CultureInfo.InvariantCulture)
+                )
+            );
+            traces.Add(CreateDetailsKeyValue("Contexts", JoinTraceContextsOrNone(tracePaths)));
+            traces.Add(
+                CreateDetailsKeyValue(
+                    "Trace ids",
+                    CountDistinctTraceIds(tracePaths).ToString(CultureInfo.InvariantCulture)
+                )
+            );
+            traces.Add(
+                CreateDetailsKeyValue(
+                    "Busiest path",
+                    CreateBusiestTracePathSummary(tracePaths)
+                        .Replace("Busiest path: ", string.Empty)
+                )
+            );
+            details.Add(traces);
+        }
+
+        private static VisualElement CreateRoutePathSection(FlowGraphEdge edge)
+        {
+            VisualElement section = CreateDetailsSection("ROUTE");
+            VisualElement flow = new();
+            flow.style.flexDirection = FlexDirection.Row;
+            flow.style.flexWrap = Wrap.Wrap;
+            flow.style.alignItems = Align.Center;
+            string kind = DxMessagingEditorPalette.NormalizeRouteKind(edge.RegistrationTypeName);
+            string context = CreateReadableRouteContext(edge);
+            if (kind == DxMessagingEditorPalette.BroadcastKind)
+            {
+                flow.Add(CreateRouteEndpoint("SOURCE", context));
+                flow.Add(CreateRouteArrow());
+                flow.Add(
+                    CreateRouteEndpoint("MESSAGE", CreateCompactGraphLabel(edge.MessageTypeName))
+                );
+                flow.Add(CreateRouteArrow());
+                flow.Add(CreateRouteEndpoint("RECEIVER", edge.TargetComponentPath));
+            }
+            else if (kind == DxMessagingEditorPalette.TargetedKind)
+            {
+                flow.Add(
+                    CreateRouteEndpoint("MESSAGE", CreateCompactGraphLabel(edge.MessageTypeName))
+                );
+                flow.Add(CreateRouteArrow());
+                flow.Add(CreateRouteEndpoint("TARGET", context));
+                flow.Add(CreateRouteArrow());
+                flow.Add(CreateRouteEndpoint("HANDLER", edge.TargetComponentPath));
+            }
+            else if (kind == DxMessagingEditorPalette.UntargetedKind)
+            {
+                flow.Add(CreateRouteEndpoint("SCOPE", "Global bus"));
+                flow.Add(CreateRouteArrow());
+                flow.Add(
+                    CreateRouteEndpoint("MESSAGE", CreateCompactGraphLabel(edge.MessageTypeName))
+                );
+                flow.Add(CreateRouteArrow());
+                flow.Add(CreateRouteEndpoint("RECEIVER", edge.TargetComponentPath));
+            }
+            else
+            {
+                flow.Add(CreateRouteEndpoint("SCOPE", GlobalObserverMessageName));
+                flow.Add(CreateRouteArrow());
+                flow.Add(CreateRouteEndpoint("GLOBAL OBSERVER", edge.TargetComponentPath));
+            }
+            section.Add(flow);
+            return section;
+        }
+
+        private static VisualElement CreateRouteEndpoint(string label, string value)
+        {
+            VisualElement endpoint = new();
+            endpoint.style.flexGrow = 1;
+            endpoint.style.flexBasis = 150;
+            endpoint.style.minWidth = 130;
+            endpoint.style.marginTop = 2;
+            endpoint.style.marginBottom = 2;
+            endpoint.style.paddingTop = 7;
+            endpoint.style.paddingRight = 8;
+            endpoint.style.paddingBottom = 7;
+            endpoint.style.paddingLeft = 8;
+            DxMessagingEditorTheme.ApplyCompleteBorder(
+                endpoint,
+                DxMessagingEditorPalette.BorderPanel
+            );
+            Label endpointLabel = new(label);
+            endpointLabel.AddToClassList(DxMessagingEditorTheme.CardLabelClassName);
+            endpointLabel.style.marginBottom = 2;
+            endpoint.Add(endpointLabel);
+            Label endpointValue = new(value);
+            endpointValue.style.unityFontStyleAndWeight = FontStyle.Bold;
+            endpointValue.style.whiteSpace = WhiteSpace.Normal;
+            endpoint.Add(endpointValue);
+            return endpoint;
+        }
+
+        private static Label CreateRouteArrow()
+        {
+            Label arrow = new("->");
+            arrow.style.marginLeft = 6;
+            arrow.style.marginRight = 6;
+            arrow.style.unityFontStyleAndWeight = FontStyle.Bold;
+            return arrow;
+        }
+
+        private static VisualElement CreateDetailsMetricSection(
+            string title,
+            params GraphNodeMetric[] metrics
+        )
+        {
+            VisualElement section = CreateDetailsSection(title);
+            VisualElement grid = new();
+            grid.style.flexDirection = FlexDirection.Row;
+            grid.style.flexWrap = Wrap.Wrap;
+            foreach (GraphNodeMetric metric in metrics)
+            {
+                VisualElement tile = new();
+                tile.AddToClassList(DetailsMetricClassName);
+                tile.style.flexGrow = 1;
+                tile.style.flexBasis = 105;
+                tile.style.minWidth = 92;
+                tile.style.marginRight = 6;
+                tile.style.marginBottom = 4;
+                tile.style.paddingTop = 6;
+                tile.style.paddingRight = 7;
+                tile.style.paddingBottom = 6;
+                tile.style.paddingLeft = 7;
+                DxMessagingEditorTheme.ApplyCompleteBorder(
+                    tile,
+                    DxMessagingEditorPalette.BorderPanel
+                );
+                Label metricLabel = new(metric.Label);
+                metricLabel.AddToClassList(DxMessagingEditorTheme.CardLabelClassName);
+                metricLabel.style.marginBottom = 2;
+                tile.Add(metricLabel);
+                Label metricValue = new(metric.Value);
+                metricValue.style.unityFontStyleAndWeight = FontStyle.Bold;
+                metricValue.style.whiteSpace = WhiteSpace.Normal;
+                tile.Add(metricValue);
+                grid.Add(tile);
+            }
+            section.Add(grid);
+            return section;
+        }
+
+        private static VisualElement CreateDetailsSection(string title)
+        {
+            VisualElement section = new();
+            section.AddToClassList(DetailsSectionClassName);
+            section.AddToClassList(DxMessagingEditorTheme.CardClassName);
+            section.style.marginBottom = 8;
+            Label label = new(title);
+            label.AddToClassList(DxMessagingEditorTheme.CardLabelClassName);
+            section.Add(label);
+            return section;
+        }
+
+        private static VisualElement CreateDetailsKeyValue(string key, string value)
+        {
+            VisualElement pair = new();
+            pair.AddToClassList(DxMessagingEditorTheme.KeyValueClassName);
+            Label keyLabel = new(key);
+            keyLabel.AddToClassList(DxMessagingEditorTheme.KeyValueKeyClassName);
+            keyLabel.style.width = 110;
+            keyLabel.style.whiteSpace = WhiteSpace.Normal;
+            pair.Add(keyLabel);
+            Label valueLabel = new(string.IsNullOrWhiteSpace(value) ? "none" : value);
+            valueLabel.AddToClassList(DxMessagingEditorTheme.KeyValueValueClassName);
+            valueLabel.style.whiteSpace = WhiteSpace.Normal;
+            pair.Add(valueLabel);
+            return pair;
+        }
+
+        private static void AddDetailValues(
+            VisualElement section,
+            string firstLabel,
+            IReadOnlyList<string> values
+        )
+        {
+            if (values.Count == 0)
+            {
+                section.Add(CreateDetailsKeyValue(firstLabel, "none captured"));
+                return;
+            }
+
+            for (int index = 0; index < values.Count; index++)
+            {
+                section.Add(
+                    CreateDetailsKeyValue(index == 0 ? firstLabel : string.Empty, values[index])
+                );
+            }
         }
 
         private static string CreateDetailsTitle(FlowGraphSelectedItem selectedItem)
@@ -4892,10 +6333,7 @@ namespace DxMessaging.Editor.Windows
                 case FlowGraphSelectionKind.Message:
                     return "Message: " + selectedItem.Message.MessageTypeName;
                 case FlowGraphSelectionKind.Edge:
-                    return "Route: "
-                        + selectedItem.Edge.MessageTypeName
-                        + " -> "
-                        + selectedItem.Edge.TargetComponentPath;
+                    return $"Route: {CreateCompactGraphLabel(selectedItem.Edge.MessageTypeName)} -> {selectedItem.Edge.TargetComponentPath}";
                 default:
                     return "Selection Details";
             }
@@ -5025,6 +6463,10 @@ namespace DxMessaging.Editor.Windows
             int totalCalls = SumVisibleCalls(visibleSnapshot);
             int selectedTracedDeliveries = messageEdges.Sum(edge => edge.RecentTracedDeliveryCount);
             int totalTracedDeliveries = SumVisibleTracedDeliveries(visibleSnapshot);
+            string visibleMessageKind = CreateVisibleMessageKind(
+                message.MessageKindName,
+                messageEdges.Select(edge => edge.RegistrationTypeName)
+            );
             FlowGraphEdge busiestEdge = messageEdges
                 .OrderByDescending(edge => edge.CallCount)
                 .ThenBy(edge => edge.TargetComponentPath, StringComparer.Ordinal)
@@ -5034,6 +6476,22 @@ namespace DxMessaging.Editor.Windows
                     ? "none"
                     : $"{busiestEdge.TargetComponentPath} ({busiestEdge.CallCount} calls)";
             StringBuilder builder = new();
+            builder
+                .Append("Message kind: ")
+                .Append(visibleMessageKind)
+                .Append(" | Observed emit sites: ")
+                .Append(message.RecentEmissionSites.Count)
+                .Append(" | Observed contexts: ")
+                .Append(message.RecentContexts.Count)
+                .AppendLine();
+            builder
+                .Append("Emit sites: ")
+                .Append(JoinDistinctOrNone(message.RecentEmissionSites))
+                .AppendLine();
+            builder
+                .Append("Observed FROM/AT contexts: ")
+                .Append(JoinDistinctOrNone(message.RecentContexts))
+                .AppendLine();
             builder
                 .Append("Visible registrations: ")
                 .Append(visibleRegistrationCount)
@@ -5077,6 +6535,25 @@ namespace DxMessaging.Editor.Windows
             builder.Append(CreateBusiestTraceContextShareSummary(tracePaths)).AppendLine();
             builder.Append(CreateBusiestTracePathSummary(tracePaths)).AppendLine();
             builder.Append(CreateBusiestTracePathShareSummary(tracePaths)).AppendLine();
+            if (visibleMessageKind == "GLOBAL OBSERVER")
+            {
+                builder
+                    .Append("Concrete message types recently observed: ")
+                    .Append(
+                        JoinDistinctOrNone(
+                            visibleSnapshot
+                                .TracePaths.Where(path =>
+                                    string.Equals(
+                                        path.RegistrationTypeName,
+                                        MessageRegistrationType.GlobalAcceptAll.ToString(),
+                                        StringComparison.Ordinal
+                                    )
+                                )
+                                .Select(path => path.MessageTypeName)
+                        )
+                    )
+                    .AppendLine();
+            }
             builder.Append("Busiest listener: ").Append(busiestText);
             return builder.ToString();
         }
@@ -5089,30 +6566,20 @@ namespace DxMessaging.Editor.Windows
             int totalCalls = SumVisibleCalls(visibleSnapshot);
             int totalTracedDeliveries = SumVisibleTracedDeliveries(visibleSnapshot);
             FlowGraphTracePath[] tracePaths = visibleSnapshot
-                .TracePaths.Where(path =>
-                    string.Equals(
-                        path.MessageTypeName,
-                        edge.MessageTypeName,
-                        StringComparison.Ordinal
-                    )
-                    && string.Equals(
-                        path.TargetComponentId,
-                        edge.TargetComponentId,
-                        StringComparison.Ordinal
-                    )
-                    && string.Equals(
-                        path.RegistrationTypeName,
-                        edge.RegistrationTypeName,
-                        StringComparison.Ordinal
-                    )
-                )
+                .TracePaths.Where(path => EdgeMatchesTracePath(edge, path))
                 .ToArray();
             StringBuilder builder = new();
+            builder.Append("Flow: ").Append(CreateEdgeFlowText(edge)).AppendLine();
             builder
                 .Append("Target component: ")
                 .Append(edge.TargetComponentPath)
                 .Append(" | Target id: ")
                 .Append(edge.TargetComponentId)
+                .AppendLine();
+            builder.Append("Route context: ").Append(edge.Context).AppendLine();
+            builder
+                .Append("Recent emit sites: ")
+                .Append(JoinDistinctOrNone(edge.RecentEmissionSites))
                 .AppendLine();
             builder
                 .Append("Registration type: ")
@@ -5150,6 +6617,57 @@ namespace DxMessaging.Editor.Windows
             builder.Append(CreateBusiestTracePathSummary(tracePaths)).AppendLine();
             builder.Append(CreateBusiestTracePathShareSummary(tracePaths));
             return builder.ToString();
+        }
+
+        private static string CreateEdgeFlowText(FlowGraphEdge edge)
+        {
+            string context =
+                string.IsNullOrWhiteSpace(edge.Context) || edge.Context == "<none>"
+                    ? "ANY"
+                    : edge.Context;
+            switch (DxMessagingEditorPalette.NormalizeRouteKind(edge.RegistrationTypeName))
+            {
+                case DxMessagingEditorPalette.BroadcastKind:
+                    return $"{edge.MessageTypeName} -> {edge.TargetComponentPath} | FROM {context} TO receiver";
+                case DxMessagingEditorPalette.TargetedKind:
+                    return $"{edge.MessageTypeName} -> {edge.TargetComponentPath} | AT {context}";
+                case DxMessagingEditorPalette.UntargetedKind:
+                    return $"{edge.MessageTypeName} -> {edge.TargetComponentPath} | GLOBAL";
+                default:
+                    return string.Equals(
+                        edge.RegistrationTypeName,
+                        MessageRegistrationType.GlobalAcceptAll.ToString(),
+                        StringComparison.Ordinal
+                    )
+                        ? $"{edge.TargetComponentPath} observes {GlobalObserverMessageName} globally"
+                        : $"{edge.MessageTypeName} -> {edge.TargetComponentPath}";
+            }
+        }
+
+        private static string CreateReadableRouteContext(FlowGraphEdge edge)
+        {
+            if (!string.IsNullOrWhiteSpace(edge.Context) && edge.Context != "<none>")
+            {
+                return edge.Context;
+            }
+
+            switch (DxMessagingEditorPalette.NormalizeRouteKind(edge.RegistrationTypeName))
+            {
+                case DxMessagingEditorPalette.BroadcastKind:
+                    return "Any source";
+                case DxMessagingEditorPalette.TargetedKind:
+                    return "Any target";
+                case DxMessagingEditorPalette.UntargetedKind:
+                    return "Global bus";
+                default:
+                    return string.Equals(
+                        edge.RegistrationTypeName,
+                        MessageRegistrationType.GlobalAcceptAll.ToString(),
+                        StringComparison.Ordinal
+                    )
+                        ? GlobalObserverMessageName
+                        : "Any context";
+            }
         }
 
         private static FlowGraphSelectedItem ResolveSelectedItem(
@@ -5446,6 +6964,32 @@ namespace DxMessaging.Editor.Windows
             builder.AppendLine();
         }
 
+        private static void AppendJsonStringArray(
+            StringBuilder builder,
+            int indentSize,
+            string name,
+            IReadOnlyList<string> values,
+            bool trailingComma
+        )
+        {
+            builder.Append(' ', indentSize).Append("\"").Append(name).Append("\": [");
+            for (int i = 0; i < values.Count; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append(", ");
+                }
+
+                builder.Append("\"").Append(EscapeJson(values[i])).Append("\"");
+            }
+            builder.Append("]");
+            if (trailingComma)
+            {
+                builder.Append(",");
+            }
+            builder.AppendLine();
+        }
+
         private static string EscapeJson(string value)
         {
             if (string.IsNullOrEmpty(value))
@@ -5503,6 +7047,28 @@ namespace DxMessaging.Editor.Windows
 
             internal string MessageTypeName { get; }
 
+            internal string MessageKindName
+            {
+                get
+                {
+                    if (Kinds.Contains("GLOBAL OBSERVER"))
+                    {
+                        return "GLOBAL OBSERVER";
+                    }
+                    if (Kinds.Count > 1)
+                    {
+                        return "MIXED";
+                    }
+                    return Kinds.FirstOrDefault() ?? "MESSAGE";
+                }
+            }
+
+            private HashSet<string> Kinds { get; } = new(StringComparer.Ordinal);
+
+            private HashSet<string> EmissionSites { get; } = new(StringComparer.Ordinal);
+
+            private HashSet<string> Contexts { get; } = new(StringComparer.Ordinal);
+
             internal int RegistrationCount { get; set; }
 
             internal int CallCount { get; set; }
@@ -5513,6 +7079,36 @@ namespace DxMessaging.Editor.Windows
 
             internal int RecentTracedDeliveryCount { get; set; }
 
+            internal void ObserveRegistrationType(MessageRegistrationType registrationType)
+            {
+                string kind = CreateMessageKindName(message: null, registrationType);
+                if (kind != "MESSAGE")
+                {
+                    Kinds.Add(kind);
+                }
+            }
+
+            internal void ObserveEmission(MessageEmissionData emission)
+            {
+                if (emission.message is IBroadcastMessage)
+                {
+                    Kinds.Add("BROADCAST");
+                }
+                if (emission.message is ITargetedMessage)
+                {
+                    Kinds.Add("TARGETED");
+                }
+                if (emission.message is IUntargetedMessage)
+                {
+                    Kinds.Add("GLOBAL");
+                }
+                EmissionSites.Add(CreateEmissionSite(emission.stackTrace));
+                if (emission.context.HasValue)
+                {
+                    Contexts.Add(CreateContextDisplayText(emission.context));
+                }
+            }
+
             internal FlowGraphMessageNode Build()
             {
                 return new FlowGraphMessageNode(
@@ -5521,7 +7117,10 @@ namespace DxMessaging.Editor.Windows
                     CallCount,
                     RecentGlobalEmissionCount,
                     RecentLocalMessageCount,
-                    RecentTracedDeliveryCount
+                    RecentTracedDeliveryCount,
+                    MessageKindName,
+                    EmissionSites.OrderBy(site => site, StringComparer.Ordinal).ToArray(),
+                    Contexts.OrderBy(context => context, StringComparer.Ordinal).ToArray()
                 );
             }
         }
@@ -5532,13 +7131,17 @@ namespace DxMessaging.Editor.Windows
                 string messageTypeName,
                 string targetComponentId,
                 string targetComponentPath,
-                string registrationTypeName
+                string registrationTypeName,
+                string context,
+                InstanceId? contextId
             )
             {
                 MessageTypeName = messageTypeName ?? string.Empty;
                 TargetComponentId = targetComponentId ?? string.Empty;
                 TargetComponentPath = targetComponentPath ?? string.Empty;
                 RegistrationTypeName = registrationTypeName ?? string.Empty;
+                Context = context ?? string.Empty;
+                ContextId = contextId;
             }
 
             internal string MessageTypeName { get; }
@@ -5549,11 +7152,32 @@ namespace DxMessaging.Editor.Windows
 
             internal string RegistrationTypeName { get; }
 
+            internal string Context { get; }
+
+            internal InstanceId? ContextId { get; }
+
             internal int RegistrationCount { get; set; }
 
             internal int CallCount { get; set; }
 
             internal int RecentTracedDeliveryCount { get; set; }
+
+            private HashSet<string> EmissionSites { get; } = new(StringComparer.Ordinal);
+
+            internal HashSet<MessageRegistrationHandle> RegistrationHandles { get; } = new();
+
+            internal void AddRegistrationHandle(MessageRegistrationHandle handle)
+            {
+                if (handle != default(MessageRegistrationHandle))
+                {
+                    RegistrationHandles.Add(handle);
+                }
+            }
+
+            internal void ObserveEmission(MessageEmissionData emission)
+            {
+                EmissionSites.Add(CreateEmissionSite(emission.stackTrace));
+            }
 
             internal FlowGraphEdge Build()
             {
@@ -5564,7 +7188,10 @@ namespace DxMessaging.Editor.Windows
                     RegistrationTypeName,
                     RegistrationCount,
                     CallCount,
-                    RecentTracedDeliveryCount
+                    RecentTracedDeliveryCount,
+                    Context,
+                    EmissionSites.OrderBy(site => site, StringComparer.Ordinal).ToArray(),
+                    ContextId?.Id ?? 0
                 );
             }
         }
@@ -5574,6 +7201,7 @@ namespace DxMessaging.Editor.Windows
             internal TracePathBuilder(
                 string messageTypeName,
                 string context,
+                int contextId,
                 string targetComponentId,
                 string targetComponentPath,
                 string registrationTypeName
@@ -5581,6 +7209,7 @@ namespace DxMessaging.Editor.Windows
             {
                 MessageTypeName = messageTypeName ?? string.Empty;
                 Context = context ?? string.Empty;
+                ContextId = contextId;
                 TargetComponentId = targetComponentId ?? string.Empty;
                 TargetComponentPath = targetComponentPath ?? string.Empty;
                 RegistrationTypeName = registrationTypeName ?? string.Empty;
@@ -5589,6 +7218,8 @@ namespace DxMessaging.Editor.Windows
             internal string MessageTypeName { get; }
 
             internal string Context { get; }
+
+            internal int ContextId { get; }
 
             internal string TargetComponentId { get; }
 
@@ -5617,7 +7248,8 @@ namespace DxMessaging.Editor.Windows
                     TargetComponentPath,
                     RegistrationTypeName,
                     RecentTracedDeliveryCount,
-                    TraceIds.OrderBy(traceId => traceId).ToArray()
+                    TraceIds.OrderBy(traceId => traceId).ToArray(),
+                    ContextId
                 );
             }
         }
@@ -6423,7 +8055,10 @@ namespace DxMessaging.Editor.Windows
             int callCount,
             int recentGlobalEmissionCount = 0,
             int recentLocalMessageCount = 0,
-            int recentTracedDeliveryCount = 0
+            int recentTracedDeliveryCount = 0,
+            string messageKindName = "MESSAGE",
+            IReadOnlyList<string> recentEmissionSites = null,
+            IReadOnlyList<string> recentContexts = null
         )
         {
             MessageTypeName = messageTypeName ?? string.Empty;
@@ -6432,6 +8067,11 @@ namespace DxMessaging.Editor.Windows
             RecentGlobalEmissionCount = recentGlobalEmissionCount;
             RecentLocalMessageCount = recentLocalMessageCount;
             RecentTracedDeliveryCount = recentTracedDeliveryCount;
+            MessageKindName = string.IsNullOrWhiteSpace(messageKindName)
+                ? "MESSAGE"
+                : messageKindName;
+            RecentEmissionSites = recentEmissionSites ?? Array.Empty<string>();
+            RecentContexts = recentContexts ?? Array.Empty<string>();
         }
 
         internal string MessageTypeName { get; }
@@ -6446,9 +8086,18 @@ namespace DxMessaging.Editor.Windows
 
         internal int RecentTracedDeliveryCount { get; }
 
+        internal string MessageKindName { get; }
+
+        internal IReadOnlyList<string> RecentEmissionSites { get; }
+
+        internal IReadOnlyList<string> RecentContexts { get; }
+
         internal bool Matches(string filterText)
         {
-            return ContainsText(MessageTypeName, filterText);
+            return ContainsText(MessageTypeName, filterText)
+                || ContainsText(MessageKindName, filterText)
+                || RecentEmissionSites.Any(site => ContainsText(site, filterText))
+                || RecentContexts.Any(context => ContainsText(context, filterText));
         }
 
         private static bool ContainsText(string value, string filterText)
@@ -6467,11 +8116,13 @@ namespace DxMessaging.Editor.Windows
             string targetComponentPath,
             string registrationTypeName,
             int recentTracedDeliveryCount,
-            IReadOnlyList<long> traceIds = null
+            IReadOnlyList<long> traceIds = null,
+            int contextId = 0
         )
         {
             MessageTypeName = messageTypeName ?? string.Empty;
             Context = context ?? string.Empty;
+            ContextId = contextId;
             TargetComponentId = targetComponentId ?? string.Empty;
             TargetComponentPath = targetComponentPath ?? string.Empty;
             RegistrationTypeName = registrationTypeName ?? string.Empty;
@@ -6482,6 +8133,8 @@ namespace DxMessaging.Editor.Windows
         internal string MessageTypeName { get; }
 
         internal string Context { get; }
+
+        internal int ContextId { get; }
 
         internal string TargetComponentId { get; }
 
@@ -6564,7 +8217,10 @@ namespace DxMessaging.Editor.Windows
             string registrationTypeName,
             int registrationCount,
             int callCount,
-            int recentTracedDeliveryCount = 0
+            int recentTracedDeliveryCount = 0,
+            string context = "",
+            IReadOnlyList<string> recentEmissionSites = null,
+            int contextId = 0
         )
         {
             MessageTypeName = messageTypeName ?? string.Empty;
@@ -6574,6 +8230,9 @@ namespace DxMessaging.Editor.Windows
             RegistrationCount = registrationCount;
             CallCount = callCount;
             RecentTracedDeliveryCount = recentTracedDeliveryCount;
+            Context = context ?? string.Empty;
+            RecentEmissionSites = recentEmissionSites ?? Array.Empty<string>();
+            ContextId = contextId;
         }
 
         internal string MessageTypeName { get; }
@@ -6590,12 +8249,20 @@ namespace DxMessaging.Editor.Windows
 
         internal int RecentTracedDeliveryCount { get; }
 
+        internal string Context { get; }
+
+        internal IReadOnlyList<string> RecentEmissionSites { get; }
+
+        internal int ContextId { get; }
+
         internal bool Matches(string filterText)
         {
             return ContainsText(MessageTypeName, filterText)
                 || ContainsText(TargetComponentId, filterText)
                 || ContainsText(TargetComponentPath, filterText)
-                || ContainsText(RegistrationTypeName, filterText);
+                || ContainsText(RegistrationTypeName, filterText)
+                || ContainsText(Context, filterText)
+                || RecentEmissionSites.Any(site => ContainsText(site, filterText));
         }
 
         private static bool ContainsText(string value, string filterText)

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -34,6 +34,14 @@ namespace DxMessaging.Editor.Windows
             "dxmessaging-flow-graph-route-map-route-kind";
         internal const string RouteMapTargetLabelName = "dxmessaging-flow-graph-route-map-target";
         internal const string RouteMapSummaryLabelName = "dxmessaging-flow-graph-route-map-summary";
+        internal const string RouteMapOverviewLabelName =
+            "dxmessaging-flow-graph-route-map-overview";
+        internal const string RouteMapInsightsFoldoutName =
+            "dxmessaging-flow-graph-route-map-insights";
+        internal const string RouteMapMoreRoutesFoldoutName =
+            "dxmessaging-flow-graph-route-map-more";
+        internal const string TraceActivityFoldoutName = "dxmessaging-flow-graph-trace-activity";
+        internal const string TopologyFoldoutName = "dxmessaging-flow-graph-topology";
         internal const string VisibleMessageLanesName = "dxmessaging-flow-graph-message-lanes";
         internal const string VisibleMessageLaneRowClassName =
             "dxmessaging-flow-graph-message-lane-row";
@@ -148,10 +156,19 @@ namespace DxMessaging.Editor.Windows
         internal const string WarningLabelName = "dxmessaging-flow-graph-warning";
 
         private const string Title = "Message Flow Graph";
+        private const int VisibleRouteLimit = 8;
         private const int ExportSchemaVersion = 5;
         private const string ExportCaptureMode = "registration-topology-with-recent-diagnostics";
         private const string ExportTraceSemantics =
             "traceId is emitted by concrete MessageBus dispatch and copied to token delivery records when diagnostics are enabled; edge traced counts are registration-handle exact, trace paths are built from token delivery records to avoid cross-bus trace-id collisions, recentTraceIdCount counts distinct trace ids observed for each trace path, and recentTraceIds lists those positive trace ids for cross-path breadth analysis.";
+
+        private sealed class FlowGraphFoldoutState
+        {
+            internal bool RouteInsightsExpanded;
+            internal bool MoreRoutesExpanded;
+            internal bool TraceActivityExpanded;
+            internal bool TopologyExpanded;
+        }
 
         private string _filterText = string.Empty;
         private string _selectedItemKey = string.Empty;
@@ -543,6 +560,29 @@ namespace DxMessaging.Editor.Windows
                 throw new ArgumentNullException(nameof(content));
             }
 
+            FlowGraphFoldoutState foldoutState =
+                content.userData as FlowGraphFoldoutState ?? new FlowGraphFoldoutState();
+            Foldout existingRouteInsights = content.Q<Foldout>(RouteMapInsightsFoldoutName);
+            Foldout existingMoreRoutes = content.Q<Foldout>(RouteMapMoreRoutesFoldoutName);
+            Foldout existingTraceActivity = content.Q<Foldout>(TraceActivityFoldoutName);
+            Foldout existingTopology = content.Q<Foldout>(TopologyFoldoutName);
+            if (existingRouteInsights != null)
+            {
+                foldoutState.RouteInsightsExpanded = existingRouteInsights.value;
+            }
+            if (existingMoreRoutes != null)
+            {
+                foldoutState.MoreRoutesExpanded = existingMoreRoutes.value;
+            }
+            if (existingTraceActivity != null)
+            {
+                foldoutState.TraceActivityExpanded = existingTraceActivity.value;
+            }
+            if (existingTopology != null)
+            {
+                foldoutState.TopologyExpanded = existingTopology.value;
+            }
+            content.userData = foldoutState;
             content.Clear();
             bool hasGraphItems =
                 visibleSnapshot.ComponentNodes.Count > 0
@@ -550,6 +590,9 @@ namespace DxMessaging.Editor.Windows
                 || visibleSnapshot.Edges.Count > 0
                 || visibleSnapshot.TracePaths.Count > 0;
             bool hasWarnings = visibleSnapshot.Warnings.Count > 0;
+            bool hasObservedObjects =
+                snapshot.ComponentNodes.Count > 0 || snapshot.MessageNodes.Count > 0;
+            bool hasCapturedRoutes = snapshot.Edges.Count > 0 || snapshot.TracePaths.Count > 0;
 
             if (!hasGraphItems && !hasWarnings)
             {
@@ -571,6 +614,16 @@ namespace DxMessaging.Editor.Windows
                 );
                 content.Add(empty);
             }
+            else if (hasObservedObjects && !hasCapturedRoutes)
+            {
+                VisualElement empty = DxMessagingEditorTheme.CreateEmptyState(
+                    "No live routes",
+                    "MessagingComponents or recent messages are visible, but no live registration routes were captured. Enter Play mode (or restart it if already playing), make sure listeners are enabled, then click Refresh.",
+                    bodyName: EmptyStateLabelName,
+                    titleName: EmptyStateTitleLabelName
+                );
+                content.Add(empty);
+            }
             else if (hasGraphItems)
             {
                 FlowGraphSelectedItem selectedItem = ResolveSelectedItem(
@@ -578,7 +631,24 @@ namespace DxMessaging.Editor.Windows
                     viewState.SelectedItemKey
                 );
 
-                content.Add(CreateRouteMap(visibleSnapshot, selectedItem.Key, onSelectionChanged));
+                VisualElement routeMap = CreateRouteMap(
+                    visibleSnapshot,
+                    selectedItem.Key,
+                    onSelectionChanged
+                );
+                routeMap.Q<Foldout>(RouteMapInsightsFoldoutName).value =
+                    foldoutState.RouteInsightsExpanded;
+                Foldout moreRoutes = routeMap.Q<Foldout>(RouteMapMoreRoutesFoldoutName);
+                if (moreRoutes != null)
+                {
+                    moreRoutes.value |= foldoutState.MoreRoutesExpanded;
+                }
+                content.Add(routeMap);
+
+                if (selectedItem.HasValue)
+                {
+                    content.Add(CreateDetailsPane(selectedItem, visibleSnapshot));
+                }
 
                 if (visibleSnapshot.Edges.Count > 0)
                 {
@@ -588,19 +658,27 @@ namespace DxMessaging.Editor.Windows
 
                 if (visibleSnapshot.TracePaths.Count > 0)
                 {
-                    content.Add(CreateVisibleFlowCorridors(visibleSnapshot));
-                    content.Add(CreateVisibleTraceRouteKindLanes(visibleSnapshot));
-                    content.Add(CreateVisibleTraceIdLanes(visibleSnapshot));
-                    content.Add(CreateVisibleTraceMessageLanes(visibleSnapshot));
-                    content.Add(CreateVisibleTraceTargetLanes(visibleSnapshot));
-                    content.Add(CreateVisibleContextLanes(visibleSnapshot));
-                    content.Add(CreateTracePaths(visibleSnapshot));
+                    Foldout traceActivity = CreateCollapsedFoldout(
+                        TraceActivityFoldoutName,
+                        "Trace Activity"
+                    );
+                    traceActivity.value = foldoutState.TraceActivityExpanded;
+                    traceActivity.Add(CreateVisibleFlowCorridors(visibleSnapshot));
+                    traceActivity.Add(CreateVisibleTraceRouteKindLanes(visibleSnapshot));
+                    traceActivity.Add(CreateVisibleTraceIdLanes(visibleSnapshot));
+                    traceActivity.Add(CreateVisibleTraceMessageLanes(visibleSnapshot));
+                    traceActivity.Add(CreateVisibleTraceTargetLanes(visibleSnapshot));
+                    traceActivity.Add(CreateVisibleContextLanes(visibleSnapshot));
+                    traceActivity.Add(CreateTracePaths(visibleSnapshot));
+                    content.Add(traceActivity);
                 }
 
-                content.Add(CreateSectionTitle("Components"));
+                Foldout topology = CreateCollapsedFoldout(TopologyFoldoutName, "Topology Details");
+                topology.value = foldoutState.TopologyExpanded;
+                topology.Add(CreateSectionTitle("Components"));
                 foreach (FlowGraphComponentNode component in visibleSnapshot.ComponentNodes)
                 {
-                    content.Add(
+                    topology.Add(
                         CreateComponentNodeRow(
                             component,
                             string.Equals(
@@ -613,10 +691,10 @@ namespace DxMessaging.Editor.Windows
                     );
                 }
 
-                content.Add(CreateSectionTitle("Message Types"));
+                topology.Add(CreateSectionTitle("Message Types"));
                 foreach (FlowGraphMessageNode message in visibleSnapshot.MessageNodes)
                 {
-                    content.Add(
+                    topology.Add(
                         CreateMessageNodeRow(
                             message,
                             string.Equals(
@@ -629,10 +707,10 @@ namespace DxMessaging.Editor.Windows
                     );
                 }
 
-                content.Add(CreateSectionTitle("Registration Edges"));
+                topology.Add(CreateSectionTitle("Registration Edges"));
                 foreach (FlowGraphEdge edge in visibleSnapshot.Edges)
                 {
-                    content.Add(
+                    topology.Add(
                         CreateEdgeRow(
                             edge,
                             string.Equals(
@@ -644,11 +722,7 @@ namespace DxMessaging.Editor.Windows
                         )
                     );
                 }
-
-                if (selectedItem.HasValue)
-                {
-                    content.Add(CreateDetailsPane(selectedItem, visibleSnapshot));
-                }
+                content.Add(topology);
             }
 
             foreach (string warning in visibleSnapshot.Warnings)
@@ -1478,6 +1552,18 @@ namespace DxMessaging.Editor.Windows
             return title;
         }
 
+        private static Foldout CreateCollapsedFoldout(string name, string text)
+        {
+            Foldout foldout = new()
+            {
+                name = name,
+                text = text,
+                value = false,
+            };
+            foldout.style.marginTop = 8;
+            return foldout;
+        }
+
         private static VisualElement CreateRouteMap(
             FlowGraphVisibleSnapshot visibleSnapshot,
             string selectedItemKey,
@@ -1500,13 +1586,26 @@ namespace DxMessaging.Editor.Windows
             title.style.unityFontStyleAndWeight = FontStyle.Bold;
             routeMap.Add(title);
 
+            Label overview = new(CreateRouteMapOverviewText(visibleSnapshot))
+            {
+                name = RouteMapOverviewLabelName,
+            };
+            overview.style.marginTop = 2;
+            overview.style.whiteSpace = WhiteSpace.Normal;
+            routeMap.Add(overview);
+
+            Foldout insights = CreateCollapsedFoldout(
+                RouteMapInsightsFoldoutName,
+                "Route Insights"
+            );
             Label summary = new(CreateRouteMapSummaryText(visibleSnapshot))
             {
                 name = RouteMapSummaryLabelName,
             };
             summary.style.marginTop = 2;
             summary.style.whiteSpace = WhiteSpace.Normal;
-            routeMap.Add(summary);
+            insights.Add(summary);
+            routeMap.Add(insights);
 
             if (visibleSnapshot.Edges.Count == 0)
             {
@@ -1518,7 +1617,8 @@ namespace DxMessaging.Editor.Windows
             }
 
             int totalVisibleCalls = SumVisibleCalls(visibleSnapshot);
-            foreach (FlowGraphEdge edge in visibleSnapshot.Edges)
+            FlowGraphEdge[] orderedRoutes = OrderRoutesForDisplay(visibleSnapshot.Edges).ToArray();
+            foreach (FlowGraphEdge edge in orderedRoutes.Take(VisibleRouteLimit))
             {
                 string selectionKey = CreateEdgeSelectionKey(edge);
                 routeMap.Add(
@@ -1531,7 +1631,56 @@ namespace DxMessaging.Editor.Windows
                 );
             }
 
+            if (orderedRoutes.Length > VisibleRouteLimit)
+            {
+                FlowGraphEdge[] remainingRoutes = orderedRoutes.Skip(VisibleRouteLimit).ToArray();
+                Foldout moreRoutes = CreateCollapsedFoldout(
+                    RouteMapMoreRoutesFoldoutName,
+                    FormatCount(remainingRoutes.Length, "more route")
+                );
+                moreRoutes.value = remainingRoutes.Any(edge =>
+                    string.Equals(
+                        CreateEdgeSelectionKey(edge),
+                        selectedItemKey,
+                        StringComparison.Ordinal
+                    )
+                );
+                foreach (FlowGraphEdge edge in remainingRoutes)
+                {
+                    string selectionKey = CreateEdgeSelectionKey(edge);
+                    moreRoutes.Add(
+                        CreateRouteMapRow(
+                            edge,
+                            CreateCallShareText(edge.CallCount, totalVisibleCalls),
+                            string.Equals(selectionKey, selectedItemKey, StringComparison.Ordinal),
+                            onSelectionChanged
+                        )
+                    );
+                }
+                routeMap.Add(moreRoutes);
+            }
+
             return routeMap;
+        }
+
+        private static IOrderedEnumerable<FlowGraphEdge> OrderRoutesForDisplay(
+            IEnumerable<FlowGraphEdge> edges
+        )
+        {
+            return edges
+                .OrderBy(edge =>
+                    string.Equals(
+                        edge.RegistrationTypeName,
+                        nameof(MessageRegistrationType.GlobalAcceptAll),
+                        StringComparison.Ordinal
+                    )
+                )
+                .ThenByDescending(edge => edge.CallCount)
+                .ThenByDescending(edge => edge.RecentTracedDeliveryCount)
+                .ThenBy(edge => edge.MessageTypeName, StringComparer.Ordinal)
+                .ThenBy(edge => edge.TargetComponentPath, StringComparer.Ordinal)
+                .ThenBy(edge => edge.TargetComponentId, StringComparer.Ordinal)
+                .ThenBy(edge => edge.RegistrationTypeName, StringComparer.Ordinal);
         }
 
         private static VisualElement CreateVisibleMessageLanes(
@@ -3117,6 +3266,32 @@ namespace DxMessaging.Editor.Windows
             return $"{FormatCount(routeCount, "visible route")} | {FormatCount(messageCount, "message")} | {FormatCount(listenerCount, "listener")} | Calls: {totalVisibleCalls} | {CreateRouteKindMixSummary(visibleSnapshot)} | {CreateHottestRouteSummary(visibleSnapshot, totalVisibleCalls)} | {CreateWidestMessageSummary(visibleSnapshot)} | {CreateMostRoutedTargetSummary(visibleSnapshot)} | {CreateInactiveRoutedTargetsSummary(visibleSnapshot)} | No-call routes: {noCallRouteCount} | {CreateRecentTracedRoutesSummary(visibleSnapshot)} | {CreateBusiestTracedRouteSummary(visibleSnapshot.Edges)} | {CreateBusiestTracedMessageSummary(visibleSnapshot.Edges)} | {CreateBusiestTracedTargetSummary(visibleSnapshot.Edges)} | Recent traced: {tracedDeliveries} | Trace ids: {CountDistinctTraceIds(visibleSnapshot.TracePaths)} | {CreateWidestTraceSummary(visibleSnapshot.TracePaths)} | {CreateTraceContextVolumeSummary(visibleSnapshot.TracePaths)} | {CreateBusiestTraceContextShareSummary(visibleSnapshot.TracePaths)} | {CreateBusiestTraceMessageSummary(visibleSnapshot.TracePaths)} | {CreateBusiestTraceTargetSummary(visibleSnapshot.TracePaths)} | {CreateBusiestTracePathSummary(visibleSnapshot.TracePaths)} | {CreateBusiestTracePathShareSummary(visibleSnapshot.TracePaths)}";
         }
 
+        internal static string CreateRouteMapSummaryText(
+            FlowGraphSnapshot snapshot,
+            string filterText = ""
+        )
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            return CreateRouteMapSummaryText(FilterSnapshot(snapshot, filterText));
+        }
+
+        private static string CreateRouteMapOverviewText(FlowGraphVisibleSnapshot visibleSnapshot)
+        {
+            int routeCount = visibleSnapshot.Edges.Count;
+            int messageCount = CountDistinct(
+                visibleSnapshot.Edges.Select(edge => edge.MessageTypeName)
+            );
+            int receiverCount = CountDistinct(
+                visibleSnapshot.Edges.Select(edge => edge.TargetComponentId)
+            );
+            int totalVisibleCalls = SumVisibleCalls(visibleSnapshot);
+            return $"{FormatCount(routeCount, "route")} | {FormatCount(messageCount, "message")} | {FormatCount(receiverCount, "receiver")} | {FormatCount(totalVisibleCalls, "call")}";
+        }
+
         private static string CreateRouteKindMixSummary(FlowGraphVisibleSnapshot visibleSnapshot)
         {
             string[] routeKindCounts = visibleSnapshot
@@ -4109,6 +4284,13 @@ namespace DxMessaging.Editor.Windows
                 }
             }
 
+            if (visibleSnapshot.Edges.Count > 0)
+            {
+                return FlowGraphSelectedItem.ForEdge(
+                    OrderRoutesForDisplay(visibleSnapshot.Edges).First()
+                );
+            }
+
             if (visibleSnapshot.ComponentNodes.Count > 0)
             {
                 return FlowGraphSelectedItem.ForComponent(visibleSnapshot.ComponentNodes[0]);
@@ -4117,11 +4299,6 @@ namespace DxMessaging.Editor.Windows
             if (visibleSnapshot.MessageNodes.Count > 0)
             {
                 return FlowGraphSelectedItem.ForMessage(visibleSnapshot.MessageNodes[0]);
-            }
-
-            if (visibleSnapshot.Edges.Count > 0)
-            {
-                return FlowGraphSelectedItem.ForEdge(visibleSnapshot.Edges[0]);
             }
 
             return FlowGraphSelectedItem.None;

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -2049,14 +2049,17 @@ namespace DxMessaging.Editor.Windows
             }
 
             UnityEngine.Object contextObject = context.Value.Object;
+            if (contextObject == null)
+            {
+                return "Instance " + context.Value.Id;
+            }
+
             switch (contextObject)
             {
                 case GameObject gameObject:
                     return GetHierarchyPath(gameObject.transform) + " (GameObject)";
                 case Component component:
                     return $"{GetHierarchyPath(component.transform)} ({component.GetType().Name})";
-                case null:
-                    return "Instance " + context.Value.Id;
                 default:
                     return string.IsNullOrWhiteSpace(contextObject.name)
                         ? $"{contextObject.GetType().Name} ({context.Value.Id})"

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -27,6 +27,12 @@ namespace DxMessaging.Editor.Windows
         internal const string ContentName = "dxmessaging-flow-graph-content";
         internal const string EmptyStateLabelName = "dxmessaging-flow-graph-empty";
         internal const string EmptyStateTitleLabelName = "dxmessaging-flow-graph-empty-title";
+        internal const string GraphCanvasName = "dxmessaging-flow-graph-canvas";
+        internal const string GraphLegendName = "dxmessaging-flow-graph-legend";
+        internal const string GraphMessageNodeClassName = "dxmessaging-flow-graph-canvas-message";
+        internal const string GraphReceiverNodeClassName = "dxmessaging-flow-graph-canvas-receiver";
+        internal const string GraphConnectionClassName = "dxmessaging-flow-graph-canvas-connection";
+        internal const string AnalysisFoldoutName = "dxmessaging-flow-graph-analysis";
         internal const string RouteMapName = "dxmessaging-flow-graph-route-map";
         internal const string RouteMapRouteClassName = "dxmessaging-flow-graph-route-map-route";
         internal const string RouteMapMessageLabelName = "dxmessaging-flow-graph-route-map-message";
@@ -157,6 +163,10 @@ namespace DxMessaging.Editor.Windows
 
         private const string Title = "Message Flow Graph";
         private const int VisibleRouteLimit = 8;
+        private const float GraphNodeWidth = 250f;
+        private const float GraphNodeHeight = 92f;
+        private const float GraphNodeGap = 34f;
+        private const float GraphCanvasHeight = 520f;
         private const int ExportSchemaVersion = 5;
         private const string ExportCaptureMode = "registration-topology-with-recent-diagnostics";
         private const string ExportTraceSemantics =
@@ -164,10 +174,202 @@ namespace DxMessaging.Editor.Windows
 
         private sealed class FlowGraphFoldoutState
         {
+            internal bool AnalysisExpanded;
             internal bool RouteInsightsExpanded;
             internal bool MoreRoutesExpanded;
             internal bool TraceActivityExpanded;
             internal bool TopologyExpanded;
+            internal FlowGraphCanvasState CanvasState { get; } = new();
+        }
+
+        private readonly struct GraphConnectionDescriptor
+        {
+            internal GraphConnectionDescriptor(
+                string messageTypeName,
+                string targetComponentId,
+                string targetComponentPath,
+                string routeKind,
+                int activityCount,
+                string selectionKey,
+                bool traceOnly
+            )
+            {
+                MessageTypeName = messageTypeName ?? string.Empty;
+                TargetComponentId = targetComponentId ?? string.Empty;
+                TargetComponentPath = targetComponentPath ?? string.Empty;
+                RouteKind = routeKind ?? string.Empty;
+                ActivityCount = activityCount;
+                SelectionKey = selectionKey ?? string.Empty;
+                TraceOnly = traceOnly;
+            }
+
+            internal string MessageTypeName { get; }
+
+            internal string TargetComponentId { get; }
+
+            internal string TargetComponentPath { get; }
+
+            internal string RouteKind { get; }
+
+            internal int ActivityCount { get; }
+
+            internal string SelectionKey { get; }
+
+            internal bool TraceOnly { get; }
+        }
+
+        internal sealed class FlowGraphCanvasState
+        {
+            internal bool Initialized;
+            internal string LayoutSignature = string.Empty;
+            internal Vector2 Pan;
+            internal float Zoom = 1f;
+        }
+
+        private readonly struct GraphCurveDescriptor
+        {
+            internal GraphCurveDescriptor(
+                Vector2 start,
+                Vector2 end,
+                float curveOffset,
+                Color color,
+                bool selected
+            )
+            {
+                Start = start;
+                End = end;
+                CurveOffset = curveOffset;
+                Color = color;
+                Selected = selected;
+            }
+
+            internal Vector2 Start { get; }
+
+            internal Vector2 End { get; }
+
+            internal float CurveOffset { get; }
+
+            internal Color Color { get; }
+
+            internal bool Selected { get; }
+
+            internal Vector2 Evaluate(float t)
+            {
+                Vector2 controlOffset = new((End.x - Start.x) * 0.42f, CurveOffset);
+                Vector2 firstControl = Start + controlOffset;
+                Vector2 secondControl = End - new Vector2(controlOffset.x, -CurveOffset);
+                float inverse = 1f - t;
+                return inverse * inverse * inverse * Start
+                    + 3f * inverse * inverse * t * firstControl
+                    + 3f * inverse * t * t * secondControl
+                    + t * t * t * End;
+            }
+        }
+
+        private sealed class FlowGraphEdgeLayer : VisualElement
+        {
+            private const int SegmentCount = 28;
+            private readonly IReadOnlyList<GraphCurveDescriptor> _curves;
+
+            internal FlowGraphEdgeLayer(IReadOnlyList<GraphCurveDescriptor> curves)
+            {
+                _curves = curves ?? throw new ArgumentNullException(nameof(curves));
+                pickingMode = PickingMode.Ignore;
+                generateVisualContent += DrawConnections;
+            }
+
+            private void DrawConnections(MeshGenerationContext context)
+            {
+                foreach (GraphCurveDescriptor curve in _curves)
+                {
+                    DrawConnection(context, curve);
+                }
+            }
+
+            private static void DrawConnection(
+                MeshGenerationContext context,
+                GraphCurveDescriptor curve
+            )
+            {
+                const int arrowVertexCount = 3;
+                const int arrowIndexCount = 3;
+                MeshWriteData mesh = context.Allocate(
+                    SegmentCount * 4 + arrowVertexCount,
+                    SegmentCount * 6 + arrowIndexCount
+                );
+                float width = curve.Selected ? 4f : 2.5f;
+                ushort vertexIndex = 0;
+                Vector2 previous = curve.Evaluate(0f);
+                for (int segment = 1; segment <= SegmentCount; segment++)
+                {
+                    Vector2 next = curve.Evaluate(segment / (float)SegmentCount);
+                    AddSegment(mesh, previous, next, width, curve.Color, ref vertexIndex);
+                    previous = next;
+                }
+
+                AddArrow(mesh, curve, curve.Color, ref vertexIndex);
+            }
+
+            private static void AddSegment(
+                MeshWriteData mesh,
+                Vector2 start,
+                Vector2 end,
+                float width,
+                Color color,
+                ref ushort vertexIndex
+            )
+            {
+                Vector2 direction = NormalizeGraphDirection(end - start);
+                Vector2 normal = new(-direction.y, direction.x);
+                normal *= width * 0.5f;
+                ushort startIndex = vertexIndex;
+                mesh.SetNextVertex(CreateGraphVertex(start + normal, color));
+                mesh.SetNextVertex(CreateGraphVertex(start - normal, color));
+                mesh.SetNextVertex(CreateGraphVertex(end - normal, color));
+                mesh.SetNextVertex(CreateGraphVertex(end + normal, color));
+                vertexIndex += 4;
+                mesh.SetNextIndex(startIndex);
+                mesh.SetNextIndex((ushort)(startIndex + 1));
+                mesh.SetNextIndex((ushort)(startIndex + 2));
+                mesh.SetNextIndex(startIndex);
+                mesh.SetNextIndex((ushort)(startIndex + 2));
+                mesh.SetNextIndex((ushort)(startIndex + 3));
+            }
+
+            private static void AddArrow(
+                MeshWriteData mesh,
+                GraphCurveDescriptor curve,
+                Color color,
+                ref ushort vertexIndex
+            )
+            {
+                Vector2 tip = curve.End;
+                Vector2 direction = NormalizeGraphDirection(curve.End - curve.Evaluate(0.96f));
+                Vector2 normal = new(-direction.y, direction.x);
+                Vector2 baseCenter = tip - direction * 11f;
+                ushort startIndex = vertexIndex;
+                mesh.SetNextVertex(CreateGraphVertex(tip, color));
+                mesh.SetNextVertex(CreateGraphVertex(baseCenter + normal * 5f, color));
+                mesh.SetNextVertex(CreateGraphVertex(baseCenter - normal * 5f, color));
+                vertexIndex += 3;
+                mesh.SetNextIndex(startIndex);
+                mesh.SetNextIndex((ushort)(startIndex + 1));
+                mesh.SetNextIndex((ushort)(startIndex + 2));
+            }
+
+            private static Vertex CreateGraphVertex(Vector2 position, Color color)
+            {
+                return new Vertex
+                {
+                    position = new Vector3(position.x, position.y, Vertex.nearZ),
+                    tint = color,
+                };
+            }
+        }
+
+        internal static Vector2 NormalizeGraphDirection(Vector2 direction)
+        {
+            return direction.sqrMagnitude <= Mathf.Epsilon ? Vector2.right : direction.normalized;
         }
 
         private string _filterText = string.Empty;
@@ -562,10 +764,15 @@ namespace DxMessaging.Editor.Windows
 
             FlowGraphFoldoutState foldoutState =
                 content.userData as FlowGraphFoldoutState ?? new FlowGraphFoldoutState();
+            Foldout existingAnalysis = content.Q<Foldout>(AnalysisFoldoutName);
             Foldout existingRouteInsights = content.Q<Foldout>(RouteMapInsightsFoldoutName);
             Foldout existingMoreRoutes = content.Q<Foldout>(RouteMapMoreRoutesFoldoutName);
             Foldout existingTraceActivity = content.Q<Foldout>(TraceActivityFoldoutName);
             Foldout existingTopology = content.Q<Foldout>(TopologyFoldoutName);
+            if (existingAnalysis != null)
+            {
+                foldoutState.AnalysisExpanded = existingAnalysis.value;
+            }
             if (existingRouteInsights != null)
             {
                 foldoutState.RouteInsightsExpanded = existingRouteInsights.value;
@@ -631,6 +838,26 @@ namespace DxMessaging.Editor.Windows
                     viewState.SelectedItemKey
                 );
 
+                content.Add(
+                    CreateGraphCanvas(
+                        visibleSnapshot,
+                        selectedItem.Key,
+                        onSelectionChanged,
+                        foldoutState.CanvasState
+                    )
+                );
+
+                if (selectedItem.HasValue)
+                {
+                    content.Add(CreateDetailsPane(selectedItem, visibleSnapshot));
+                }
+
+                Foldout analysis = CreateCollapsedFoldout(
+                    AnalysisFoldoutName,
+                    "Analysis and Raw Data"
+                );
+                analysis.value = foldoutState.AnalysisExpanded;
+
                 VisualElement routeMap = CreateRouteMap(
                     visibleSnapshot,
                     selectedItem.Key,
@@ -643,17 +870,12 @@ namespace DxMessaging.Editor.Windows
                 {
                     moreRoutes.value |= foldoutState.MoreRoutesExpanded;
                 }
-                content.Add(routeMap);
-
-                if (selectedItem.HasValue)
-                {
-                    content.Add(CreateDetailsPane(selectedItem, visibleSnapshot));
-                }
+                analysis.Add(routeMap);
 
                 if (visibleSnapshot.Edges.Count > 0)
                 {
-                    content.Add(CreateVisibleMessageLanes(visibleSnapshot));
-                    content.Add(CreateVisibleTargetLanes(visibleSnapshot));
+                    analysis.Add(CreateVisibleMessageLanes(visibleSnapshot));
+                    analysis.Add(CreateVisibleTargetLanes(visibleSnapshot));
                 }
 
                 if (visibleSnapshot.TracePaths.Count > 0)
@@ -670,7 +892,7 @@ namespace DxMessaging.Editor.Windows
                     traceActivity.Add(CreateVisibleTraceTargetLanes(visibleSnapshot));
                     traceActivity.Add(CreateVisibleContextLanes(visibleSnapshot));
                     traceActivity.Add(CreateTracePaths(visibleSnapshot));
-                    content.Add(traceActivity);
+                    analysis.Add(traceActivity);
                 }
 
                 Foldout topology = CreateCollapsedFoldout(TopologyFoldoutName, "Topology Details");
@@ -722,7 +944,8 @@ namespace DxMessaging.Editor.Windows
                         )
                     );
                 }
-                content.Add(topology);
+                analysis.Add(topology);
+                content.Add(analysis);
             }
 
             foreach (string warning in visibleSnapshot.Warnings)
@@ -1562,6 +1785,701 @@ namespace DxMessaging.Editor.Windows
             };
             foldout.style.marginTop = 8;
             return foldout;
+        }
+
+        private static VisualElement CreateGraphCanvas(
+            FlowGraphVisibleSnapshot visibleSnapshot,
+            string selectedItemKey,
+            Action<string> onSelectionChanged,
+            FlowGraphCanvasState canvasState
+        )
+        {
+            VisualElement panel = new();
+            DxMessagingEditorTheme.ApplyCompleteBorder(panel, DxMessagingEditorPalette.BorderPanel);
+            panel.style.marginBottom = 8;
+            panel.style.paddingTop = 8;
+            panel.style.paddingRight = 8;
+            panel.style.paddingBottom = 8;
+            panel.style.paddingLeft = 8;
+
+            VisualElement legend = new() { name = GraphLegendName };
+            legend.style.flexDirection = FlexDirection.Row;
+            legend.style.alignItems = Align.Center;
+            legend.style.marginBottom = 6;
+
+            Label title = new("Live Route Graph");
+            title.style.unityFontStyleAndWeight = FontStyle.Bold;
+            title.style.marginRight = 12;
+            legend.Add(title);
+            legend.Add(CreateGraphLegendBadge("MESSAGE", DxMessagingEditorPalette.AmberSoft));
+
+            Label direction = new("routes ->");
+            direction.style.marginLeft = 6;
+            direction.style.marginRight = 6;
+            legend.Add(direction);
+            legend.Add(CreateGraphLegendBadge("RECEIVER", DxMessagingEditorPalette.Amber));
+
+            Label controls = new("Drag empty space to pan | Scroll to zoom | Select to inspect");
+            controls.style.flexGrow = 1;
+            controls.style.unityTextAlign = TextAnchor.MiddleRight;
+            legend.Add(controls);
+            panel.Add(legend);
+
+            GraphConnectionDescriptor[] connections = CreateGraphConnections(visibleSnapshot);
+            string[] messageNames = visibleSnapshot
+                .MessageNodes.Select(message => message.MessageTypeName)
+                .Concat(connections.Select(connection => connection.MessageTypeName))
+                .Where(messageTypeName => !string.IsNullOrWhiteSpace(messageTypeName))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(messageTypeName => messageTypeName, StringComparer.Ordinal)
+                .ToArray();
+            string[] receiverIds = visibleSnapshot
+                .ComponentNodes.Select(component => component.Id)
+                .Concat(connections.Select(connection => connection.TargetComponentId))
+                .Where(componentId => !string.IsNullOrWhiteSpace(componentId))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+
+            Dictionary<string, int> messageIndexes = messageNames
+                .Select((messageTypeName, index) => new { messageTypeName, index })
+                .ToDictionary(
+                    item => item.messageTypeName,
+                    item => item.index,
+                    StringComparer.Ordinal
+                );
+            receiverIds = receiverIds
+                .OrderBy(componentId =>
+                {
+                    int[] indexes = connections
+                        .Where(connection =>
+                            string.Equals(
+                                connection.TargetComponentId,
+                                componentId,
+                                StringComparison.Ordinal
+                            ) && messageIndexes.ContainsKey(connection.MessageTypeName)
+                        )
+                        .Select(connection => messageIndexes[connection.MessageTypeName])
+                        .ToArray();
+                    return indexes.Length == 0 ? float.MaxValue : indexes.Average();
+                })
+                .ThenBy(
+                    componentId => CreateReceiverPath(visibleSnapshot, connections, componentId),
+                    StringComparer.Ordinal
+                )
+                .ThenBy(componentId => componentId, StringComparer.Ordinal)
+                .ToArray();
+
+            int rowCount = Math.Max(messageNames.Length, receiverIds.Length);
+            float graphHeight = Math.Max(
+                GraphCanvasHeight,
+                80f + rowCount * (GraphNodeHeight + GraphNodeGap)
+            );
+            const float contentWidth = 990f;
+            const float messageX = 60f;
+            const float receiverX = 680f;
+            Dictionary<string, Vector2> messagePositions = new(StringComparer.Ordinal);
+            Dictionary<string, Vector2> receiverPositions = new(StringComparer.Ordinal);
+            for (int index = 0; index < messageNames.Length; index++)
+            {
+                messagePositions[messageNames[index]] = new Vector2(
+                    messageX,
+                    CreateGraphNodeY(index, messageNames.Length, rowCount)
+                );
+            }
+            for (int index = 0; index < receiverIds.Length; index++)
+            {
+                receiverPositions[receiverIds[index]] = new Vector2(
+                    receiverX,
+                    CreateGraphNodeY(index, receiverIds.Length, rowCount)
+                );
+            }
+
+            string layoutSignature = CreateGraphLayoutSignature(
+                messageNames,
+                receiverIds,
+                connections
+            );
+            if (
+                !string.Equals(
+                    canvasState.LayoutSignature,
+                    layoutSignature,
+                    StringComparison.Ordinal
+                )
+            )
+            {
+                canvasState.LayoutSignature = layoutSignature;
+                canvasState.Initialized = false;
+                canvasState.Pan = Vector2.zero;
+                canvasState.Zoom = 1f;
+            }
+
+            VisualElement viewport = new() { name = GraphCanvasName, userData = canvasState };
+            viewport.focusable = true;
+            viewport.style.height = GraphCanvasHeight;
+            viewport.style.flexShrink = 0;
+            viewport.style.overflow = Overflow.Hidden;
+            viewport.style.backgroundColor = EditorGUIUtility.isProSkin
+                ? new Color(0.07f, 0.08f, 0.1f, 1f)
+                : new Color(0.91f, 0.92f, 0.94f, 1f);
+            DxMessagingEditorTheme.ApplyCompleteBorder(
+                viewport,
+                DxMessagingEditorPalette.BorderStrong
+            );
+
+            VisualElement graphContent = new();
+            graphContent.style.position = Position.Absolute;
+            graphContent.style.left = 0;
+            graphContent.style.top = 0;
+            graphContent.style.width = contentWidth;
+            graphContent.style.height = graphHeight;
+            viewport.Add(graphContent);
+
+            List<GraphCurveDescriptor> curves = new();
+            List<(GraphConnectionDescriptor connection, GraphCurveDescriptor curve)> markers =
+                new();
+            foreach (
+                IGrouping<string, GraphConnectionDescriptor> pair in connections.GroupBy(
+                    connection => connection.MessageTypeName + "\n" + connection.TargetComponentId,
+                    StringComparer.Ordinal
+                )
+            )
+            {
+                GraphConnectionDescriptor[] parallelConnections = pair.OrderBy(
+                        connection => connection.RouteKind,
+                        StringComparer.Ordinal
+                    )
+                    .ToArray();
+                for (int index = 0; index < parallelConnections.Length; index++)
+                {
+                    GraphConnectionDescriptor connection = parallelConnections[index];
+                    if (
+                        !messagePositions.TryGetValue(
+                            connection.MessageTypeName,
+                            out Vector2 messagePosition
+                        )
+                        || !receiverPositions.TryGetValue(
+                            connection.TargetComponentId,
+                            out Vector2 receiverPosition
+                        )
+                    )
+                    {
+                        continue;
+                    }
+
+                    float parallelIndex = index - (parallelConnections.Length - 1) * 0.5f;
+                    float portOffset = parallelIndex * 16f;
+                    float curveOffset = parallelIndex * 38f;
+                    Color edgeColor = connection.TraceOnly
+                        ? DxMessagingEditorPalette.Trace
+                        : DxMessagingEditorPalette.RouteKindColor(connection.RouteKind);
+                    GraphCurveDescriptor curve = new(
+                        new Vector2(
+                            messagePosition.x + GraphNodeWidth + 7f,
+                            messagePosition.y + GraphNodeHeight * 0.5f + portOffset
+                        ),
+                        new Vector2(
+                            receiverPosition.x - 7f,
+                            receiverPosition.y + GraphNodeHeight * 0.5f + portOffset
+                        ),
+                        curveOffset,
+                        edgeColor,
+                        string.Equals(
+                            connection.SelectionKey,
+                            selectedItemKey,
+                            StringComparison.Ordinal
+                        )
+                    );
+                    curves.Add(curve);
+                    markers.Add((connection, curve));
+                }
+            }
+
+            FlowGraphEdgeLayer edgeLayer = new(curves);
+            edgeLayer.style.position = Position.Absolute;
+            edgeLayer.style.left = 0;
+            edgeLayer.style.top = 0;
+            edgeLayer.style.width = contentWidth;
+            edgeLayer.style.height = graphHeight;
+            graphContent.Add(edgeLayer);
+
+            foreach (string messageTypeName in messageNames)
+            {
+                FlowGraphMessageNode? message = visibleSnapshot
+                    .MessageNodes.Where(candidate =>
+                        string.Equals(
+                            candidate.MessageTypeName,
+                            messageTypeName,
+                            StringComparison.Ordinal
+                        )
+                    )
+                    .Cast<FlowGraphMessageNode?>()
+                    .FirstOrDefault();
+                GraphConnectionDescriptor[] messageConnections = connections
+                    .Where(connection =>
+                        string.Equals(
+                            connection.MessageTypeName,
+                            messageTypeName,
+                            StringComparison.Ordinal
+                        )
+                    )
+                    .ToArray();
+                int activityCount = message.HasValue
+                    ? message.Value.CallCount
+                    : messageConnections.Sum(connection => connection.ActivityCount);
+                string selectionKey = message.HasValue
+                    ? CreateMessageSelectionKey(message.Value)
+                    : string.Empty;
+                graphContent.Add(
+                    CreateGraphNode(
+                        CreateCompactGraphLabel(messageTypeName),
+                        $"{FormatCount(messageConnections.Length, "route")} | {FormatCount(messageConnections.Select(connection => connection.TargetComponentId).Distinct(StringComparer.Ordinal).Count(), "receiver")} | {FormatCount(activityCount, "call")}",
+                        messageTypeName,
+                        GraphMessageNodeClassName,
+                        DxMessagingEditorPalette.AmberSoft,
+                        messagePositions[messageTypeName],
+                        outputPort: true,
+                        string.Equals(selectionKey, selectedItemKey, StringComparison.Ordinal),
+                        selectionKey,
+                        onSelectionChanged
+                    )
+                );
+            }
+
+            foreach (string componentId in receiverIds)
+            {
+                FlowGraphComponentNode? component = visibleSnapshot
+                    .ComponentNodes.Where(candidate =>
+                        string.Equals(candidate.Id, componentId, StringComparison.Ordinal)
+                    )
+                    .Cast<FlowGraphComponentNode?>()
+                    .FirstOrDefault();
+                GraphConnectionDescriptor[] receiverConnections = connections
+                    .Where(connection =>
+                        string.Equals(
+                            connection.TargetComponentId,
+                            componentId,
+                            StringComparison.Ordinal
+                        )
+                    )
+                    .ToArray();
+                string receiverPath = component.HasValue
+                    ? component.Value.HierarchyPath
+                    : receiverConnections
+                        .Select(connection => connection.TargetComponentPath)
+                        .FirstOrDefault(path => !string.IsNullOrWhiteSpace(path))
+                        ?? componentId;
+                int activityCount = component.HasValue
+                    ? component.Value.CallCount
+                    : receiverConnections.Sum(connection => connection.ActivityCount);
+                string stateText =
+                    !component.HasValue || component.Value.ActiveInHierarchy
+                        ? "active"
+                        : "inactive";
+                string selectionKey = component.HasValue
+                    ? CreateComponentSelectionKey(component.Value)
+                    : string.Empty;
+                graphContent.Add(
+                    CreateGraphNode(
+                        CreateCompactReceiverLabel(receiverPath),
+                        $"{FormatCount(receiverConnections.Length, "route")} | {FormatCount(receiverConnections.Select(connection => connection.MessageTypeName).Distinct(StringComparer.Ordinal).Count(), "message")} | {FormatCount(activityCount, "call")} | {stateText}",
+                        receiverPath,
+                        GraphReceiverNodeClassName,
+                        DxMessagingEditorPalette.Amber,
+                        receiverPositions[componentId],
+                        outputPort: false,
+                        string.Equals(selectionKey, selectedItemKey, StringComparison.Ordinal),
+                        selectionKey,
+                        onSelectionChanged
+                    )
+                );
+            }
+
+            foreach ((GraphConnectionDescriptor connection, GraphCurveDescriptor curve) in markers)
+            {
+                graphContent.Add(
+                    CreateGraphConnectionMarker(connection, curve, onSelectionChanged)
+                );
+            }
+
+            ConfigureGraphViewport(
+                viewport,
+                graphContent,
+                canvasState,
+                new Vector2(contentWidth, graphHeight)
+            );
+            panel.Add(viewport);
+            return panel;
+        }
+
+        private static GraphConnectionDescriptor[] CreateGraphConnections(
+            FlowGraphVisibleSnapshot visibleSnapshot
+        )
+        {
+            if (visibleSnapshot.Edges.Count > 0)
+            {
+                return visibleSnapshot
+                    .Edges.Select(edge => new GraphConnectionDescriptor(
+                        edge.MessageTypeName,
+                        edge.TargetComponentId,
+                        edge.TargetComponentPath,
+                        edge.RegistrationTypeName,
+                        edge.CallCount,
+                        CreateEdgeSelectionKey(edge),
+                        traceOnly: false
+                    ))
+                    .ToArray();
+            }
+
+            return visibleSnapshot
+                .TracePaths.GroupBy(path => new
+                {
+                    path.MessageTypeName,
+                    path.TargetComponentId,
+                    path.TargetComponentPath,
+                    path.RegistrationTypeName,
+                })
+                .Select(group => new GraphConnectionDescriptor(
+                    group.Key.MessageTypeName,
+                    group.Key.TargetComponentId,
+                    group.Key.TargetComponentPath,
+                    group.Key.RegistrationTypeName,
+                    group.Sum(path => path.RecentTracedDeliveryCount),
+                    string.Empty,
+                    traceOnly: true
+                ))
+                .OrderBy(connection => connection.MessageTypeName, StringComparer.Ordinal)
+                .ThenBy(connection => connection.TargetComponentPath, StringComparer.Ordinal)
+                .ThenBy(connection => connection.RouteKind, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static VisualElement CreateGraphNode(
+            string title,
+            string summary,
+            string tooltip,
+            string className,
+            Color accent,
+            Vector2 position,
+            bool outputPort,
+            bool selected,
+            string selectionKey,
+            Action<string> onSelectionChanged
+        )
+        {
+            VisualElement node = new() { tooltip = tooltip };
+            node.AddToClassList(className);
+            node.AddToClassList(DxMessagingEditorTheme.CardClassName);
+            node.style.position = Position.Absolute;
+            node.style.left = position.x;
+            node.style.top = position.y;
+            node.style.width = GraphNodeWidth;
+            node.style.height = GraphNodeHeight;
+            node.style.paddingTop = 8;
+            node.style.paddingRight = 10;
+            node.style.paddingBottom = 8;
+            node.style.paddingLeft = 10;
+            DxMessagingEditorTheme.ApplyCompleteBorder(node, accent);
+            if (selected)
+            {
+                node.AddToClassList(SelectedRowClassName);
+                node.style.backgroundColor = DxMessagingEditorPalette.SelectedWash;
+            }
+
+            Label titleLabel = new(title);
+            titleLabel.style.unityFontStyleAndWeight = FontStyle.Bold;
+            titleLabel.style.fontSize = 13;
+            node.Add(titleLabel);
+
+            Label summaryLabel = new(summary);
+            summaryLabel.style.marginTop = 5;
+            summaryLabel.style.whiteSpace = WhiteSpace.Normal;
+            node.Add(summaryLabel);
+
+            VisualElement port = new();
+            port.pickingMode = PickingMode.Ignore;
+            port.style.position = Position.Absolute;
+            port.style.top = GraphNodeHeight * 0.5f - 6f;
+            if (outputPort)
+            {
+                port.style.right = -7f;
+            }
+            else
+            {
+                port.style.left = -7f;
+            }
+            port.style.width = 12;
+            port.style.height = 12;
+            port.style.borderTopLeftRadius = 6;
+            port.style.borderTopRightRadius = 6;
+            port.style.borderBottomLeftRadius = 6;
+            port.style.borderBottomRightRadius = 6;
+            port.style.backgroundColor = accent;
+            DxMessagingEditorTheme.ApplyCompleteBorder(port, DxMessagingEditorPalette.BorderStrong);
+            node.Add(port);
+
+            node.RegisterCallback<MouseDownEvent>(evt => evt.StopPropagation());
+            if (onSelectionChanged != null && !string.IsNullOrWhiteSpace(selectionKey))
+            {
+                node.RegisterCallback<ClickEvent>(evt =>
+                {
+                    evt.StopPropagation();
+                    onSelectionChanged.Invoke(selectionKey);
+                });
+            }
+            return node;
+        }
+
+        private static VisualElement CreateGraphConnectionMarker(
+            GraphConnectionDescriptor connection,
+            GraphCurveDescriptor curve,
+            Action<string> onSelectionChanged
+        )
+        {
+            Vector2 midpoint = curve.Evaluate(0.5f);
+            float size = curve.Selected ? 18f : 14f;
+            VisualElement marker = new()
+            {
+                tooltip =
+                    $"{connection.MessageTypeName} -> {connection.TargetComponentPath}\n{connection.RouteKind} | {connection.ActivityCount} {(connection.TraceOnly ? "deliveries" : "calls")}",
+            };
+            marker.AddToClassList(GraphConnectionClassName);
+            if (curve.Selected)
+            {
+                marker.AddToClassList(SelectedRowClassName);
+            }
+            marker.style.position = Position.Absolute;
+            marker.style.left = midpoint.x - size * 0.5f;
+            marker.style.top = midpoint.y - size * 0.5f;
+            marker.style.width = size;
+            marker.style.height = size;
+            marker.style.borderTopLeftRadius = size * 0.5f;
+            marker.style.borderTopRightRadius = size * 0.5f;
+            marker.style.borderBottomLeftRadius = size * 0.5f;
+            marker.style.borderBottomRightRadius = size * 0.5f;
+            marker.style.backgroundColor = curve.Color;
+            DxMessagingEditorTheme.ApplyCompleteBorder(
+                marker,
+                curve.Selected
+                    ? DxMessagingEditorPalette.AmberSoft
+                    : DxMessagingEditorPalette.BorderStrong
+            );
+            marker.RegisterCallback<MouseDownEvent>(evt => evt.StopPropagation());
+            if (onSelectionChanged != null && !string.IsNullOrWhiteSpace(connection.SelectionKey))
+            {
+                string selectionKey = connection.SelectionKey;
+                marker.RegisterCallback<ClickEvent>(evt =>
+                {
+                    evt.StopPropagation();
+                    onSelectionChanged.Invoke(selectionKey);
+                });
+            }
+            return marker;
+        }
+
+        private static void ConfigureGraphViewport(
+            VisualElement viewport,
+            VisualElement graphContent,
+            FlowGraphCanvasState canvasState,
+            Vector2 contentSize
+        )
+        {
+            void ApplyTransform()
+            {
+                graphContent.transform.position = new Vector3(
+                    canvasState.Pan.x,
+                    canvasState.Pan.y,
+                    0f
+                );
+                graphContent.transform.scale = new Vector3(canvasState.Zoom, canvasState.Zoom, 1f);
+            }
+
+            ApplyTransform();
+            bool panning = false;
+            Vector2 lastMousePosition = Vector2.zero;
+            viewport.RegisterCallback<MouseDownEvent>(evt =>
+            {
+                if (evt.button != 0)
+                {
+                    return;
+                }
+
+                panning = true;
+                lastMousePosition = evt.localMousePosition;
+                viewport.CaptureMouse();
+                evt.StopPropagation();
+            });
+            viewport.RegisterCallback<MouseMoveEvent>(evt =>
+            {
+                if (!panning || !viewport.HasMouseCapture())
+                {
+                    return;
+                }
+
+                Vector2 currentPosition = evt.localMousePosition;
+                canvasState.Pan += currentPosition - lastMousePosition;
+                lastMousePosition = currentPosition;
+                ApplyTransform();
+                evt.StopPropagation();
+            });
+            viewport.RegisterCallback<MouseUpEvent>(evt =>
+            {
+                if (!panning || evt.button != 0)
+                {
+                    return;
+                }
+
+                panning = false;
+                if (viewport.HasMouseCapture())
+                {
+                    viewport.ReleaseMouse();
+                }
+                evt.StopPropagation();
+            });
+            viewport.RegisterCallback<WheelEvent>(evt =>
+            {
+                float previousZoom = canvasState.Zoom;
+                float zoomFactor = evt.delta.y > 0f ? 0.88f : 1.14f;
+                float nextZoom = Mathf.Clamp(previousZoom * zoomFactor, 0.02f, 2f);
+                Vector2 contentCenter = contentSize * 0.5f;
+                Vector2 mousePosition = evt.localMousePosition;
+                Vector2 contentPoint =
+                    (mousePosition - contentCenter - canvasState.Pan) / previousZoom
+                    + contentCenter;
+                canvasState.Zoom = nextZoom;
+                canvasState.Pan =
+                    mousePosition - contentCenter - (contentPoint - contentCenter) * nextZoom;
+                canvasState.Initialized = true;
+                ApplyTransform();
+                evt.StopPropagation();
+            });
+
+            if (!canvasState.Initialized)
+            {
+                EventCallback<GeometryChangedEvent> frameCallback = null;
+                frameCallback = evt =>
+                {
+                    if (evt.newRect.width <= Mathf.Epsilon || evt.newRect.height <= Mathf.Epsilon)
+                    {
+                        return;
+                    }
+
+                    canvasState.Zoom = CalculateGraphFrameScale(evt.newRect.size, contentSize);
+                    canvasState.Pan = evt.newRect.size * 0.5f - contentSize * 0.5f;
+                    canvasState.Initialized = true;
+                    ApplyTransform();
+                    viewport.UnregisterCallback(frameCallback);
+                };
+                viewport.RegisterCallback(frameCallback);
+            }
+        }
+
+        internal static float CalculateGraphFrameScale(Vector2 viewportSize, Vector2 contentSize)
+        {
+            if (contentSize.x <= Mathf.Epsilon || contentSize.y <= Mathf.Epsilon)
+            {
+                return 1f;
+            }
+
+            float horizontalScale = Math.Max(0f, viewportSize.x - 32f) / contentSize.x;
+            float verticalScale = Math.Max(0f, viewportSize.y - 32f) / contentSize.y;
+            return Mathf.Clamp(Math.Min(horizontalScale, verticalScale), 0.02f, 1f);
+        }
+
+        private static string CreateGraphLayoutSignature(
+            IEnumerable<string> messageNames,
+            IEnumerable<string> receiverIds,
+            IEnumerable<GraphConnectionDescriptor> connections
+        )
+        {
+            StringBuilder signature = new();
+            foreach (string messageName in messageNames)
+            {
+                signature.Append("m|").Append(messageName).Append('\n');
+            }
+            foreach (string receiverId in receiverIds)
+            {
+                signature.Append("r|").Append(receiverId).Append('\n');
+            }
+            foreach (GraphConnectionDescriptor connection in connections)
+            {
+                signature
+                    .Append("e|")
+                    .Append(connection.MessageTypeName)
+                    .Append('|')
+                    .Append(connection.TargetComponentId)
+                    .Append('|')
+                    .Append(connection.RouteKind)
+                    .Append('\n');
+            }
+            return signature.ToString();
+        }
+
+        private static Label CreateGraphLegendBadge(string text, Color color)
+        {
+            Label badge = new(text);
+            DxMessagingEditorTheme.ApplyCompleteBorder(badge, color);
+            badge.style.paddingTop = 2;
+            badge.style.paddingRight = 6;
+            badge.style.paddingBottom = 2;
+            badge.style.paddingLeft = 6;
+            badge.style.unityFontStyleAndWeight = FontStyle.Bold;
+            return badge;
+        }
+
+        private static string CreateReceiverPath(
+            FlowGraphVisibleSnapshot visibleSnapshot,
+            IReadOnlyList<GraphConnectionDescriptor> connections,
+            string componentId
+        )
+        {
+            foreach (FlowGraphComponentNode component in visibleSnapshot.ComponentNodes)
+            {
+                if (string.Equals(component.Id, componentId, StringComparison.Ordinal))
+                {
+                    return component.HierarchyPath;
+                }
+            }
+
+            return connections
+                    .Where(connection =>
+                        string.Equals(
+                            connection.TargetComponentId,
+                            componentId,
+                            StringComparison.Ordinal
+                        )
+                    )
+                    .Select(connection => connection.TargetComponentPath)
+                    .FirstOrDefault(path => !string.IsNullOrWhiteSpace(path))
+                ?? componentId;
+        }
+
+        private static float CreateGraphNodeY(int index, int count, int rowCount)
+        {
+            float centeredOffset = (rowCount - count) * (GraphNodeHeight + GraphNodeGap) * 0.5f;
+            return 54f + centeredOffset + index * (GraphNodeHeight + GraphNodeGap);
+        }
+
+        private static string CreateCompactGraphLabel(string messageTypeName)
+        {
+            string typeName = messageTypeName ?? string.Empty;
+            int assemblyStart = typeName.LastIndexOf(" [", StringComparison.Ordinal);
+            if (assemblyStart >= 0)
+            {
+                typeName = typeName.Substring(0, assemblyStart);
+            }
+            int namespaceSeparator = Math.Max(typeName.LastIndexOf('.'), typeName.LastIndexOf('+'));
+            return namespaceSeparator >= 0 && namespaceSeparator < typeName.Length - 1
+                ? typeName.Substring(namespaceSeparator + 1)
+                : typeName;
+        }
+
+        private static string CreateCompactReceiverLabel(string hierarchyPath)
+        {
+            string path = hierarchyPath ?? string.Empty;
+            int separator = path.LastIndexOf('/');
+            return separator >= 0 && separator < path.Length - 1
+                ? path.Substring(separator + 1)
+                : path;
         }
 
         private static VisualElement CreateRouteMap(

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -2271,8 +2271,8 @@ namespace DxMessaging.Editor.Windows
                                     )
                                 )
                                 .ThenBy(candidate => candidate.RouteKind, StringComparer.Ordinal)
-                                .ThenBy(candidate => candidate.Context, StringComparer.Ordinal)
                                 .ThenBy(candidate => candidate.ContextId)
+                                .ThenBy(candidate => candidate.Context, StringComparer.Ordinal)
                                 .ToArray(),
                         StringComparer.Ordinal
                     );
@@ -2290,8 +2290,8 @@ namespace DxMessaging.Editor.Windows
                                     )
                                 )
                                 .ThenBy(candidate => candidate.RouteKind, StringComparer.Ordinal)
-                                .ThenBy(candidate => candidate.Context, StringComparer.Ordinal)
                                 .ThenBy(candidate => candidate.ContextId)
+                                .ThenBy(candidate => candidate.Context, StringComparer.Ordinal)
                                 .ToArray(),
                         StringComparer.Ordinal
                     );
@@ -2369,8 +2369,8 @@ namespace DxMessaging.Editor.Windows
                         connection => connection.RouteKind,
                         StringComparer.Ordinal
                     )
-                    .ThenBy(connection => connection.Context, StringComparer.Ordinal)
                     .ThenBy(connection => connection.ContextId)
+                    .ThenBy(connection => connection.Context, StringComparer.Ordinal)
                     .ToArray();
                 for (int index = 0; index < parallelConnections.Length; index++)
                 {
@@ -2730,7 +2730,6 @@ namespace DxMessaging.Editor.Windows
                 connection.MessageTypeName,
                 connection.TargetComponentId,
                 connection.RouteKind,
-                connection.Context,
                 connection.ContextId.ToString(CultureInfo.InvariantCulture)
             );
         }
@@ -3159,7 +3158,13 @@ namespace DxMessaging.Editor.Windows
             {
                 signature.Append("r|").Append(receiverId).Append('\n');
             }
-            foreach (GraphConnectionDescriptor connection in connections)
+            foreach (
+                GraphConnectionDescriptor connection in connections
+                    .OrderBy(candidate => candidate.MessageTypeName, StringComparer.Ordinal)
+                    .ThenBy(candidate => candidate.TargetComponentId, StringComparer.Ordinal)
+                    .ThenBy(candidate => candidate.RouteKind, StringComparer.Ordinal)
+                    .ThenBy(candidate => candidate.ContextId)
+            )
             {
                 signature
                     .Append("e|")
@@ -3168,8 +3173,6 @@ namespace DxMessaging.Editor.Windows
                     .Append(connection.TargetComponentId)
                     .Append('|')
                     .Append(connection.RouteKind)
-                    .Append('|')
-                    .Append(connection.Context)
                     .Append('|')
                     .Append(connection.ContextId)
                     .Append('\n');
@@ -5443,7 +5446,6 @@ namespace DxMessaging.Editor.Windows
                 edge.MessageTypeName,
                 edge.TargetComponentId,
                 edge.RegistrationTypeName,
-                edge.Context,
                 edge.ContextId
             );
         }
@@ -5664,7 +5666,6 @@ namespace DxMessaging.Editor.Windows
             string messageTypeName,
             string targetComponentId,
             string registrationTypeName,
-            string context,
             int contextId
         )
         {
@@ -5674,7 +5675,6 @@ namespace DxMessaging.Editor.Windows
                 messageTypeName ?? string.Empty,
                 targetComponentId ?? string.Empty,
                 registrationTypeName ?? string.Empty,
-                context ?? string.Empty,
                 contextId.ToString(CultureInfo.InvariantCulture)
             );
         }

--- a/README.md
+++ b/README.md
@@ -633,7 +633,18 @@ dedicated Unity editor tools under **Tools > Wallstop Studios > DxMessaging**.
 
 #### Flow Graph
 
-- Component nodes, message-type nodes, and registration edges
+- Crossing-aware layered message and receiver nodes with ordered connection
+  ports, arrowhead direction, and unobtrusive shape-and-color route selectors
+- Named node metrics for sources or targets, receivers, handlers, calls, and
+  state instead of compact `+N` overflow summaries; multi-kind message types
+  use neutral `MIXED` metrics until filtered to one route kind
+- Responsive route details split into route, activity, emission-evidence, and
+  trace-evidence cards; dense technical diagnostics start collapsed
+- Recent registration-exact delivery call sites for targeted and broadcast
+  routes; call sites identify the script and method when token diagnostics are
+  enabled without leaking evidence across components or message buses
+- Global accept-all registrations shown as `ANY MESSAGE` observer scope rather
+  than as an `IMessage` message type
 - Route-map route-kind mix, call shares, widest-message target-component
   fan-out, most-routed target, inactive routed-target, hottest-route, and
   no-call route summaries, recent traced-route coverage, busiest traced-route,

--- a/Runtime/Core/MessageBus/MessageBus.cs
+++ b/Runtime/Core/MessageBus/MessageBus.cs
@@ -4016,25 +4016,33 @@ namespace DxMessaging.Core.MessageBus
                 GameObject go;
                 bool found;
                 UnityEngine.Object targetObject = target.Object;
-                switch (targetObject)
+                if (targetObject == null)
                 {
-                    case GameObject gameObject:
+                    go = null;
+                    found = false;
+                }
+                else
+                {
+                    switch (targetObject)
                     {
-                        found = true;
-                        go = gameObject;
-                        break;
-                    }
-                    case Component component:
-                    {
-                        found = true;
-                        go = component.gameObject;
-                        break;
-                    }
-                    default:
-                    {
-                        go = null;
-                        found = false;
-                        break;
+                        case GameObject gameObject:
+                        {
+                            found = true;
+                            go = gameObject;
+                            break;
+                        }
+                        case Component component:
+                        {
+                            found = true;
+                            go = component.gameObject;
+                            break;
+                        }
+                        default:
+                        {
+                            go = null;
+                            found = false;
+                            break;
+                        }
                     }
                 }
 

--- a/Samples~/Diagnostics Tooling Exerciser/DiagnosticsToolingExerciser.cs
+++ b/Samples~/Diagnostics Tooling Exerciser/DiagnosticsToolingExerciser.cs
@@ -2,6 +2,7 @@ namespace WallstopStudios.DxMessagingSamples.DiagnosticsToolingExerciser
 {
     using System;
     using System.Collections;
+    using System.Collections.Generic;
     using DxMessaging.Core;
     using DxMessaging.Core.Extensions;
     using DxMessaging.Core.MessageBus;
@@ -37,12 +38,70 @@ namespace WallstopStudios.DxMessagingSamples.DiagnosticsToolingExerciser
         [SerializeField]
         private string lastRunSummary = "Not run yet";
 
+        private static readonly HashSet<int> InitializedRunnerIds = new();
+
         public int Sequence => sequence;
 
         public string LastRunSummary => lastRunSummary;
 
-        private void Start()
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void BeginPlayGeneration()
         {
+            InitializedRunnerIds.Clear();
+        }
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void InitializeAfterSceneLoad()
+        {
+#if UNITY_2023_1_OR_NEWER
+            DiagnosticsToolingExerciser[] runners = FindObjectsByType<DiagnosticsToolingExerciser>(
+                FindObjectsInactive.Exclude,
+                FindObjectsSortMode.None
+            );
+#else
+            DiagnosticsToolingExerciser[] runners =
+                FindObjectsOfType<DiagnosticsToolingExerciser>();
+#endif
+            foreach (DiagnosticsToolingExerciser runner in runners)
+            {
+                if (runner != null && runner.isActiveAndEnabled)
+                {
+                    runner.BeginPlaySession();
+                }
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (Application.isPlaying)
+            {
+                BeginPlaySession();
+            }
+        }
+
+        private void OnDisable()
+        {
+            _ = InitializedRunnerIds.Remove(GetInstanceID());
+            CancelInvoke(nameof(EmitBurst));
+            StopAllCoroutines();
+        }
+
+        private void BeginPlaySession()
+        {
+            if (!InitializedRunnerIds.Add(GetInstanceID()))
+            {
+                return;
+            }
+
+            CancelInvoke(nameof(EmitBurst));
+            StopAllCoroutines();
+            sequence = 0;
+            lastRunSummary = "Not run yet";
+            foreach (DiagnosticsToolingReceiver receiver in receivers)
+            {
+                receiver?.ResetCounts();
+            }
+
             ConfigureDiagnostics();
 
             if (emitOnStart)
@@ -83,7 +142,6 @@ namespace WallstopStudios.DxMessagingSamples.DiagnosticsToolingExerciser
         [ContextMenu("Emit One Of Each")]
         public void EmitOneOfEach()
         {
-            EnsureReceiversReady();
             sequence++;
 
             ToolingPulse pulse = new(
@@ -160,14 +218,6 @@ namespace WallstopStudios.DxMessagingSamples.DiagnosticsToolingExerciser
         private string CreateTraceId(string route)
         {
             return $"sample-{route}-{sequence:000}";
-        }
-
-        private void EnsureReceiversReady()
-        {
-            foreach (DiagnosticsToolingReceiver receiver in receivers)
-            {
-                receiver?.EnsureToolingRegistrations();
-            }
         }
     }
 }

--- a/Samples~/Diagnostics Tooling Exerciser/DiagnosticsToolingReceiver.cs
+++ b/Samples~/Diagnostics Tooling Exerciser/DiagnosticsToolingReceiver.cs
@@ -1,5 +1,6 @@
 namespace WallstopStudios.DxMessagingSamples.DiagnosticsToolingExerciser
 {
+    using System.Collections.Generic;
     using DxMessaging.Core;
     using DxMessaging.Core.Messages;
     using DxMessaging.Unity;
@@ -44,7 +45,7 @@ namespace WallstopStudios.DxMessagingSamples.DiagnosticsToolingExerciser
         [SerializeField]
         private string lastPayload = "None";
 
-        private bool toolingRegistrationsEnsured;
+        private static readonly HashSet<int> PreparedReceiverIds = new();
 
         public string ListenerLabel => listenerLabel;
 
@@ -61,11 +62,7 @@ namespace WallstopStudios.DxMessagingSamples.DiagnosticsToolingExerciser
         protected override void Awake()
         {
             base.Awake();
-        }
-
-        protected override void OnEnable()
-        {
-            base.OnEnable();
+            _ = PreparedReceiverIds.Add(GetInstanceID());
         }
 
         protected override void OnDisable()
@@ -73,25 +70,60 @@ namespace WallstopStudios.DxMessagingSamples.DiagnosticsToolingExerciser
             base.OnDisable();
         }
 
-        private void Start()
+        protected override void OnDestroy()
         {
-            EnsureToolingRegistrations();
+            _ = PreparedReceiverIds.Remove(GetInstanceID());
+            base.OnDestroy();
         }
 
-        public void EnsureToolingRegistrations()
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void BeginPlayGeneration()
         {
-            if (Token == null)
+            PreparedReceiverIds.Clear();
+        }
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void RestoreRegistrationsAfterSceneLoad()
+        {
+#if UNITY_2023_1_OR_NEWER
+            DiagnosticsToolingReceiver[] receivers = FindObjectsByType<DiagnosticsToolingReceiver>(
+                FindObjectsInactive.Exclude,
+                FindObjectsSortMode.None
+            );
+#else
+            DiagnosticsToolingReceiver[] receivers =
+                FindObjectsOfType<DiagnosticsToolingReceiver>();
+#endif
+            foreach (DiagnosticsToolingReceiver receiver in receivers)
+            {
+                if (receiver != null && receiver.isActiveAndEnabled)
+                {
+                    receiver.EnsureToolingRegistrations(force: true);
+                    receiver.Token.Enable();
+                }
+            }
+        }
+
+        protected override void OnEnable()
+        {
+            EnsureToolingRegistrations();
+            base.OnEnable();
+        }
+
+        private void EnsureToolingRegistrations(bool force = false)
+        {
+            if (!force && !PreparedReceiverIds.Add(GetInstanceID()))
             {
                 return;
             }
 
-            if (!toolingRegistrationsEnsured)
-            {
-                RegisterMessageHandlers();
-                toolingRegistrationsEnsured = true;
-            }
-
-            Token.Enable();
+            _ = PreparedReceiverIds.Add(GetInstanceID());
+            MessagingComponent messagingComponent = GetComponent<MessagingComponent>();
+            messagingComponent.Release(this);
+            MessageRegistrationToken liveToken = messagingComponent.Create(this);
+            _messagingComponent = messagingComponent;
+            _messageRegistrationToken = liveToken;
+            RegisterMessageHandlers();
         }
 
         protected override void RegisterMessageHandlers()

--- a/Samples~/Diagnostics Tooling Exerciser/README.md
+++ b/Samples~/Diagnostics Tooling Exerciser/README.md
@@ -28,6 +28,14 @@ the package editor tools.
 1. Select `Player Ship`, `Enemy Drone`, and `HUD Console` to inspect local
    diagnostics counters.
 
+The active runner starts its burst after the initial scene load and again from
+`OnEnable` instead of relying on a one-shot `Start` callback. Consecutive Play
+entries therefore reset and repopulate the tooling data when **Enter Play Mode
+Options** disables domain and scene reload. A per-activation guard deduplicates
+the runner's `OnEnable` and post-scene-load callbacks. Active receivers
+deliberately replace their token after the initial scene load so a stale enabled
+flag cannot hide reset bus state.
+
 The runner also exposes context-menu commands:
 
 - **Emit One Of Each** sends one untargeted, targeted, and broadcast pass.
@@ -42,9 +50,11 @@ After the default play-start burst:
 - `DiagnosticsToolingExerciser.Sequence` is `3`.
 - Message Monitor global history includes `ToolingPulse`, `ToolingCommand`, and
   `ToolingSignal` entries with trace IDs like `sample-pulse-001`.
-- Flow Graph shows three receiver components, three message types, targeted
-  routes to each receiver, exact-source broadcast routes for `Player Ship` and
-  `Enemy Drone`, and broadcast-without-source routes for all receivers.
+- Flow Graph shows three receiver components, four message nodes (the three
+  concrete messages plus `IMessage`), 15 routes, and 33 recent trace paths.
+  Concrete routes appear before the `IMessage` accept-all routes. The first
+  eight routes stay visible while the remaining seven start in the collapsed
+  **7 more routes** section.
 - The component diagnostics panel shows enabled listener diagnostics and local
   emissions for each receiver.
 

--- a/Samples~/Diagnostics Tooling Exerciser/README.md
+++ b/Samples~/Diagnostics Tooling Exerciser/README.md
@@ -52,9 +52,9 @@ After the default play-start burst:
   `ToolingSignal` entries with trace IDs like `sample-pulse-001`.
 - Flow Graph shows three receiver components, four message nodes (the three
   concrete messages plus `IMessage`), 15 routes, and 33 recent trace paths.
-  Concrete routes appear before the `IMessage` accept-all routes. The first
-  eight routes stay visible while the remaining seven start in the collapsed
-  **7 more routes** section.
+  Its primary canvas places the four messages on the left, the three receivers
+  on the right, and draws all 15 live connections. The textual route and trace
+  reports remain inside the collapsed **Analysis and Raw Data** section.
 - The component diagnostics panel shows enabled listener diagnostics and local
   emissions for each receiver.
 

--- a/Tests/Editor/DiagnosticsToolingSampleContractTests.cs
+++ b/Tests/Editor/DiagnosticsToolingSampleContractTests.cs
@@ -84,11 +84,47 @@ namespace DxMessaging.Tests.Editor
             Assert.That(receiver, Does.Contain("RegisterBroadcast<ToolingSignal>"));
             Assert.That(receiver, Does.Contain("RegisterGlobalAcceptAll"));
             Assert.That(receiver, Does.Contain("Token.DiagnosticMode = true"));
-            Assert.That(receiver, Does.Contain("EnsureToolingRegistrations()"));
-            Assert.That(runner, Does.Contain("EnsureReceiversReady();"));
+        }
+
+        [Test]
+        public void SampleLifecycleRestoresRegistrationsAcrossPlayStartupAndActivation()
+        {
+            string runner = ReadSampleFile(RunnerScriptFileName);
+            string receiver = ReadSampleFile(ReceiverScriptFileName);
+
+            Assert.That(receiver, Does.Contain("protected override void OnEnable()"));
+            Assert.That(receiver, Does.Contain("EnsureToolingRegistrations();"));
+            Assert.That(receiver, Does.Contain("EnsureToolingRegistrations(force: true);"));
+            Assert.That(receiver, Does.Contain("PreparedReceiverIds.Add(GetInstanceID())"));
+            Assert.That(receiver, Does.Contain("messagingComponent.Release(this);"));
+            Assert.That(receiver, Does.Contain("messagingComponent.Create(this)"));
+            Assert.That(
+                receiver.IndexOf(
+                    "messagingComponent.Release(this);",
+                    System.StringComparison.Ordinal
+                ),
+                Is.LessThan(
+                    receiver.IndexOf(
+                        "messagingComponent.Create(this)",
+                        System.StringComparison.Ordinal
+                    )
+                ),
+                "The sample must discard a possibly stale enabled token before creating its live token."
+            );
+            Assert.That(receiver, Does.Not.Contain("_messageRegistrationToken.Enabled"));
+            Assert.That(receiver, Does.Contain("RestoreRegistrationsAfterSceneLoad"));
+            Assert.That(runner, Does.Contain("private void OnEnable()"));
+            Assert.That(runner, Does.Contain("InitializeAfterSceneLoad"));
+            Assert.That(runner, Does.Contain("InitializedRunnerIds.Add(GetInstanceID())"));
+            Assert.That(runner, Does.Contain("InitializedRunnerIds.Remove(GetInstanceID())"));
+            Assert.That(runner, Does.Contain("BeginPlaySession"));
+            Assert.That(runner, Does.Not.Contain("private void Start()"));
+            Assert.That(runner, Does.Not.Contain("EnsureReceiversReady"));
             Assert.That(receiver, Does.Contain("base.Awake();"));
             Assert.That(receiver, Does.Contain("base.OnEnable();"));
             Assert.That(receiver, Does.Contain("base.OnDisable();"));
+            Assert.That(receiver, Does.Contain("PreparedReceiverIds.Remove(GetInstanceID())"));
+            Assert.That(receiver, Does.Contain("base.OnDestroy();"));
         }
 
         [Test]

--- a/Tests/Editor/DxMessagingEditorThemeTests.cs
+++ b/Tests/Editor/DxMessagingEditorThemeTests.cs
@@ -295,6 +295,27 @@ namespace DxMessaging.Tests.Editor
             AssertColor(element.style.borderLeftColor.value, DxMessagingEditorPalette.Amber);
         }
 
+        [Test]
+        public void ApplyCompleteBorderSupportsUniformCustomWidth()
+        {
+            VisualElement element = new();
+
+            DxMessagingEditorTheme.ApplyCompleteBorder(
+                element,
+                DxMessagingEditorPalette.AmberSoft,
+                3f
+            );
+
+            Assert.That(element.style.borderTopWidth.value, Is.EqualTo(3f));
+            Assert.That(element.style.borderRightWidth.value, Is.EqualTo(3f));
+            Assert.That(element.style.borderBottomWidth.value, Is.EqualTo(3f));
+            Assert.That(element.style.borderLeftWidth.value, Is.EqualTo(3f));
+            AssertColor(element.style.borderTopColor.value, DxMessagingEditorPalette.AmberSoft);
+            AssertColor(element.style.borderRightColor.value, DxMessagingEditorPalette.AmberSoft);
+            AssertColor(element.style.borderBottomColor.value, DxMessagingEditorPalette.AmberSoft);
+            AssertColor(element.style.borderLeftColor.value, DxMessagingEditorPalette.AmberSoft);
+        }
+
         private static void AssertIconLoads(string fileName, int expectedSize)
         {
             Texture2D icon = DxMessagingEditorTheme.LoadIcon(fileName);

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -204,6 +204,49 @@ namespace DxMessaging.Tests.Editor
                     .ClassListContains(DxMessagingEditorTheme.ToolButtonClassName),
                 Is.True
             );
+            VisualElement graph = root.Q<VisualElement>(DxMessagingFlowGraphWindow.GraphCanvasName);
+            Assert.That(graph, Is.Not.Null, "The primary surface should be a graph canvas.");
+            Assert.That(
+                graph
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.GraphMessageNodeClassName
+                    )
+                    .ToList(),
+                Has.Count.EqualTo(1)
+            );
+            Assert.That(
+                graph
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.GraphReceiverNodeClassName
+                    )
+                    .ToList(),
+                Has.Count.EqualTo(1)
+            );
+            Assert.That(
+                graph
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.GraphConnectionClassName
+                    )
+                    .ToList(),
+                Has.Count.EqualTo(1)
+            );
+            VisualElement graphMessage = graph
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.GraphMessageNodeClassName
+                )
+                .First();
+            VisualElement graphReceiver = graph
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.GraphReceiverNodeClassName
+                )
+                .First();
+            Assert.That(
+                graphMessage.style.left.value.value,
+                Is.LessThan(graphReceiver.style.left.value.value),
+                "Message nodes should be laid out to the left of receiver nodes."
+            );
+            AssertCompleteBorder(graphMessage, DxMessagingEditorPalette.AmberSoft);
+            AssertCompleteBorder(graphReceiver, DxMessagingEditorPalette.Amber);
             Label routeMapKind = root.Q<VisualElement>(DxMessagingFlowGraphWindow.RouteMapName)
                 .Query<VisualElement>(className: DxMessagingFlowGraphWindow.RouteMapRouteClassName)
                 .First()
@@ -242,7 +285,7 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
-        public void BuildGraphUiPrioritizesRoutesAndCollapsesAdvancedData()
+        public void BuildGraphUiLeadsWithInteractiveCanvasAndCollapsesTextAnalysis()
         {
             FlowGraphSnapshot snapshot = CreateTwoEdgeSnapshot();
             VisualElement root = new();
@@ -258,11 +301,50 @@ namespace DxMessaging.Tests.Editor
             );
             Foldout topology = root.Q<Foldout>(DxMessagingFlowGraphWindow.TopologyFoldoutName);
             Label detailsTitle = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsTitleLabelName);
+            VisualElement graph = root.Q<VisualElement>(DxMessagingFlowGraphWindow.GraphCanvasName);
+            Foldout analysis = root.Q<Foldout>(DxMessagingFlowGraphWindow.AnalysisFoldoutName);
 
+            Assert.That(
+                graph,
+                Is.Not.Null,
+                "The primary surface should render a node-and-edge graph."
+            );
+            Assert.That(
+                graph
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.GraphMessageNodeClassName
+                    )
+                    .ToList(),
+                Has.Count.EqualTo(2),
+                "Every visible message should be represented as a graph node."
+            );
+            Assert.That(
+                graph
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.GraphReceiverNodeClassName
+                    )
+                    .ToList(),
+                Has.Count.EqualTo(2),
+                "Every visible receiver should be represented as a graph node."
+            );
+            Assert.That(
+                graph
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.GraphConnectionClassName
+                    )
+                    .ToList(),
+                Has.Count.EqualTo(2),
+                "Every visible route should be represented as a graph connection."
+            );
+            Assert.That(
+                analysis.value,
+                Is.False,
+                "Text reports should default collapsed beneath the graph."
+            );
             Assert.That(
                 overview,
                 Is.Not.Null,
-                "The visible route overview should be rendered above advanced analytics."
+                "The collapsed analysis should retain the route overview for inspection."
             );
             Assert.That(
                 overview.text,
@@ -412,7 +494,7 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
-        public void BuildGraphUiPrioritizesConcreteRoutesAndCollapsesOverflow()
+        public void BuildGraphUiPlacesEveryRouteOnCanvasAndKeepsTextOverflowCollapsed()
         {
             FlowGraphComponentNode[] components = Enumerable
                 .Range(0, 10)
@@ -459,6 +541,8 @@ namespace DxMessaging.Tests.Editor
             DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot);
 
             VisualElement routeMap = root.Q<VisualElement>(DxMessagingFlowGraphWindow.RouteMapName);
+            VisualElement graph = root.Q<VisualElement>(DxMessagingFlowGraphWindow.GraphCanvasName);
+            Foldout analysis = root.Q<Foldout>(DxMessagingFlowGraphWindow.AnalysisFoldoutName);
             Foldout moreRoutes = root.Q<Foldout>(
                 DxMessagingFlowGraphWindow.RouteMapMoreRoutesFoldoutName
             );
@@ -474,6 +558,38 @@ namespace DxMessaging.Tests.Editor
             string detailsTitle = root.Q<Label>(
                 DxMessagingFlowGraphWindow.DetailsTitleLabelName
             ).text;
+
+            Assert.That(
+                graph
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.GraphMessageNodeClassName
+                    )
+                    .ToList(),
+                Has.Count.EqualTo(10),
+                "Message types should remain navigable nodes instead of a text overflow list."
+            );
+            Assert.That(
+                graph
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.GraphReceiverNodeClassName
+                    )
+                    .ToList(),
+                Has.Count.EqualTo(10)
+            );
+            Assert.That(
+                graph
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.GraphConnectionClassName
+                    )
+                    .ToList(),
+                Has.Count.EqualTo(10),
+                "The graph should retain all routes without a visible-route cap."
+            );
+            Assert.That(
+                analysis.value,
+                Is.False,
+                "Route-row overflow should stay hidden until the secondary analysis is opened."
+            );
 
             Assert.That(
                 initiallyVisibleRouteCount,
@@ -492,6 +608,7 @@ namespace DxMessaging.Tests.Editor
                 $"A concrete route should be selected ahead of GlobalAcceptAll, but was '{detailsTitle}'."
             );
 
+            analysis.value = true;
             root.Q<Foldout>(DxMessagingFlowGraphWindow.RouteMapInsightsFoldoutName).value = true;
             moreRoutes.value = true;
             root.Q<Foldout>(DxMessagingFlowGraphWindow.TopologyFoldoutName).value = true;
@@ -514,6 +631,10 @@ namespace DxMessaging.Tests.Editor
                 Is.True
             );
             Assert.That(
+                root.Q<Foldout>(DxMessagingFlowGraphWindow.AnalysisFoldoutName).value,
+                Is.True
+            );
+            Assert.That(
                 root.Q<Foldout>(DxMessagingFlowGraphWindow.RouteMapInsightsFoldoutName).value,
                 Is.True
             );
@@ -525,6 +646,103 @@ namespace DxMessaging.Tests.Editor
                 root.Q<Foldout>(DxMessagingFlowGraphWindow.TopologyFoldoutName).value,
                 Is.True
             );
+        }
+
+        [Test]
+        public void GraphFrameScaleFitsLargeNodeSetsBelowLegacyZoomFloor()
+        {
+            float scale = DxMessagingFlowGraphWindow.CalculateGraphFrameScale(
+                new Vector2(520f, 520f),
+                new Vector2(990f, 80f + 100f * (92f + 34f))
+            );
+
+            Assert.That(
+                scale,
+                Is.LessThan(0.15f).And.GreaterThanOrEqualTo(0.02f),
+                $"A 100-row graph should frame below the former 0.15 zoom floor, but used {scale}."
+            );
+        }
+
+        [Test]
+        public void GraphMeshNormalizesZeroLengthSegmentsToDefinedDirection()
+        {
+            Assert.That(
+                DxMessagingFlowGraphWindow.NormalizeGraphDirection(Vector2.zero),
+                Is.EqualTo(Vector2.right),
+                "Degenerate sampled segments must still write their allocated mesh quad."
+            );
+            Assert.That(
+                DxMessagingFlowGraphWindow.NormalizeGraphDirection(new Vector2(3f, 4f)),
+                Is.EqualTo(new Vector2(0.6f, 0.8f))
+            );
+        }
+
+        [Test]
+        public void BuildGraphUiPreservesViewportWhenGraphConnectionIsSelected()
+        {
+            FlowGraphSnapshot snapshot = CreateTwoEdgeSnapshot();
+            EditorWindow window = CreateTrackedEditorWindow();
+            EditorWindowTestUtility.ShowWindow(window);
+            VisualElement root = window.rootVisualElement;
+            string selectedItemKey = string.Empty;
+            Action<string> select = null;
+            select = key =>
+            {
+                selectedItemKey = key;
+                DxMessagingFlowGraphWindow.RefreshGraphContent(
+                    root,
+                    snapshot,
+                    new FlowGraphViewState(selectedItemKey: key),
+                    onSelectionChanged: select
+                );
+            };
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                FlowGraphViewState.Default,
+                onSelectionChanged: select
+            );
+
+            VisualElement graph = root.Q<VisualElement>(DxMessagingFlowGraphWindow.GraphCanvasName);
+            DxMessagingFlowGraphWindow.FlowGraphCanvasState canvasState =
+                (DxMessagingFlowGraphWindow.FlowGraphCanvasState)graph.userData;
+            canvasState.Initialized = true;
+            canvasState.Pan = new Vector2(123f, -47f);
+            canvasState.Zoom = 0.42f;
+            VisualElement unselectedConnection = graph
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.GraphConnectionClassName
+                )
+                .ToList()
+                .Single(connection =>
+                    !connection.ClassListContains(DxMessagingFlowGraphWindow.SelectedRowClassName)
+                );
+
+            using (ClickEvent click = ClickEvent.GetPooled())
+            {
+                click.target = unselectedConnection;
+                unselectedConnection.SendEvent(click);
+            }
+
+            VisualElement refreshedGraph = root.Q<VisualElement>(
+                DxMessagingFlowGraphWindow.GraphCanvasName
+            );
+            DxMessagingFlowGraphWindow.FlowGraphCanvasState refreshedState =
+                (DxMessagingFlowGraphWindow.FlowGraphCanvasState)refreshedGraph.userData;
+            VisualElement selectedConnection = refreshedGraph
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.GraphConnectionClassName
+                )
+                .ToList()
+                .Single(connection =>
+                    connection.ClassListContains(DxMessagingFlowGraphWindow.SelectedRowClassName)
+                );
+
+            Assert.That(selectedItemKey, Is.Not.Empty);
+            Assert.That(refreshedState, Is.SameAs(canvasState));
+            Assert.That(refreshedState.Pan, Is.EqualTo(new Vector2(123f, -47f)));
+            Assert.That(refreshedState.Zoom, Is.EqualTo(0.42f));
+            Assert.That(selectedConnection.style.width.value.value, Is.EqualTo(18f));
         }
 
         [Test]
@@ -588,6 +806,32 @@ namespace DxMessaging.Tests.Editor
                 .text;
             Assert.That(targetLaneSummary, Does.Contain("Route kinds: Broadcast, Targeted"));
             Assert.That(targetLaneSummary, Does.Not.Contain("BroadcastPostProcessor"));
+
+            Dictionary<string, VisualElement> graphEdgesByKind = root.Q<VisualElement>(
+                    DxMessagingFlowGraphWindow.GraphCanvasName
+                )
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.GraphConnectionClassName
+                )
+                .ToList()
+                .ToDictionary(
+                    edge =>
+                        edge.tooltip.Contains("BroadcastPostProcessor") ? "Broadcast" : "Targeted",
+                    StringComparer.Ordinal
+                );
+            AssertColor(
+                graphEdgesByKind["Targeted"].style.backgroundColor.value,
+                DxMessagingEditorPalette.Targeted
+            );
+            AssertColor(
+                graphEdgesByKind["Broadcast"].style.backgroundColor.value,
+                DxMessagingEditorPalette.Broadcast
+            );
+            Assert.That(
+                graphEdgesByKind["Targeted"].style.top.value.value,
+                Is.Not.EqualTo(graphEdgesByKind["Broadcast"].style.top.value.value),
+                "Parallel route kinds need distinct rendered geometry and hit targets."
+            );
 
             Dictionary<string, VisualElement> edgesByKind = root.Query<VisualElement>(
                     className: DxMessagingFlowGraphWindow.EdgeRowClassName

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -9,6 +9,7 @@ namespace DxMessaging.Tests.Editor
     using Core.MessageBus;
     using Core.Messages;
     using DxMessaging.Editor;
+    using DxMessaging.Editor.Testing;
     using DxMessaging.Editor.Windows;
     using DxMessaging.Unity;
     using NUnit.Framework;
@@ -654,18 +655,29 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
-        public void GraphFrameScaleFitsLargeNodeSetsBelowLegacyZoomFloor()
+        public void GraphFrameScaleKeepsLargeNodeSetsReadableForPanning()
         {
             float scale = DxMessagingFlowGraphWindow.CalculateGraphFrameScale(
                 new Vector2(520f, 520f),
-                new Vector2(990f, 80f + 100f * (92f + 34f))
+                new Vector2(1100f, 80f + 100f * (132f + 42f))
             );
 
             Assert.That(
                 scale,
-                Is.LessThan(0.15f).And.GreaterThanOrEqualTo(0.02f),
-                $"A 100-row graph should frame below the former 0.15 zoom floor, but used {scale}."
+                Is.EqualTo(0.8f),
+                $"A 100-row graph should preserve readable nodes and pan instead of shrinking them, but used {scale}."
             );
+        }
+
+        [Test]
+        public void GraphMarkerPositionsSeparateCrossingRoutesBySourceLayer()
+        {
+            float first = DxMessagingFlowGraphWindow.CreateGraphMarkerPosition(0, 2, 0f);
+            float second = DxMessagingFlowGraphWindow.CreateGraphMarkerPosition(1, 2, 0f);
+
+            Assert.That(first, Is.EqualTo(0.38f).Within(0.001f));
+            Assert.That(second, Is.EqualTo(0.62f).Within(0.001f));
+            Assert.That(second - first, Is.GreaterThanOrEqualTo(0.2f));
         }
 
         [Test]
@@ -747,7 +759,595 @@ namespace DxMessaging.Tests.Editor
             Assert.That(refreshedState, Is.SameAs(canvasState));
             Assert.That(refreshedState.Pan, Is.EqualTo(new Vector2(123f, -47f)));
             Assert.That(refreshedState.Zoom, Is.EqualTo(0.42f));
-            Assert.That(selectedConnection.style.width.value.value, Is.EqualTo(18f));
+            Assert.That(selectedConnection.style.width.value.value, Is.EqualTo(30f));
+            Assert.That(
+                selectedConnection.Children().Single().style.width.value.value,
+                Is.EqualTo(18f)
+            );
+        }
+
+        [Test]
+        public void BuildGraphUiMakesBroadcastSourceAndReceiverDirectionExplicit()
+        {
+            FlowGraphMessageNode message = new(
+                "Combat.DamageApplied",
+                registrationCount: 1,
+                callCount: 3,
+                recentGlobalEmissionCount: 3,
+                messageKindName: "BROADCAST",
+                recentEmissionSites: new[] { "Archer.Fire" },
+                recentContexts: new[] { "Arena/Archer" }
+            );
+            FlowGraphSnapshot snapshot = new(
+                new[]
+                {
+                    new FlowGraphComponentNode(
+                        "component:receiver",
+                        "Arena/Health",
+                        "MessagingComponent",
+                        activeInHierarchy: true,
+                        listenerCount: 1,
+                        registrationCount: 1,
+                        callCount: 3,
+                        localMessageCount: 0
+                    ),
+                },
+                new[] { message },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        message.MessageTypeName,
+                        "component:receiver",
+                        "Arena/Health",
+                        "Broadcast",
+                        registrationCount: 1,
+                        callCount: 3,
+                        context: "Arena/Archer"
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot);
+
+            VisualElement messageNode = root.Q<VisualElement>(
+                className: DxMessagingFlowGraphWindow.GraphMessageNodeClassName
+            );
+            VisualElement marker = root.Q<VisualElement>(
+                className: DxMessagingFlowGraphWindow.GraphConnectionClassName
+            );
+            Assert.That(
+                messageNode.Query<Label>().ToList().Select(label => label.text),
+                Does.Contain("BROADCAST")
+            );
+            Assert.That(
+                messageNode
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.GraphNodeMetricClassName
+                    )
+                    .ToList()
+                    .Select(row =>
+                        string.Join(": ", row.Query<Label>().ToList().Select(label => label.text))
+                    ),
+                Does.Contain("Sources: Archer")
+            );
+            Assert.That(marker.Query<Label>().ToList(), Is.Empty);
+            Assert.That(
+                marker.tooltip,
+                Does.Contain("Arena/Archer -> Combat.DamageApplied -> Arena/Health")
+            );
+            Assert.That(marker.tooltip, Does.Not.Contain("FROM").And.Not.Contain(" TO "));
+        }
+
+        [Test]
+        public void BuildGraphUiExposesTargetedEmitSiteWithoutInventingSenderObject()
+        {
+            FlowGraphMessageNode message = new(
+                "Combat.ApplyKnockback",
+                registrationCount: 1,
+                callCount: 2,
+                recentGlobalEmissionCount: 2,
+                messageKindName: "TARGETED",
+                recentEmissionSites: new[] { "CombatController.FireAtTarget" },
+                recentContexts: new[] { "Arena/Target" }
+            );
+            FlowGraphSnapshot snapshot = new(
+                new[]
+                {
+                    new FlowGraphComponentNode(
+                        "component:target",
+                        "Arena/Target/Receiver",
+                        "MessagingComponent",
+                        activeInHierarchy: true,
+                        listenerCount: 1,
+                        registrationCount: 1,
+                        callCount: 2,
+                        localMessageCount: 0
+                    ),
+                },
+                new[] { message },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        message.MessageTypeName,
+                        "component:target",
+                        "Arena/Target/Receiver",
+                        "Targeted",
+                        registrationCount: 1,
+                        callCount: 2,
+                        context: "Arena/Target",
+                        recentEmissionSites: new[] { "CombatController.FireAtTarget" }
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(
+                        snapshot.Edges[0]
+                    )
+                )
+            );
+
+            VisualElement marker = root.Q<VisualElement>(
+                className: DxMessagingFlowGraphWindow.GraphConnectionClassName
+            );
+            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            Assert.That(marker.Query<Label>().ToList(), Is.Empty);
+            Assert.That(
+                marker.tooltip,
+                Does.Contain("Combat.ApplyKnockback -> Arena/Target -> Arena/Target/Receiver")
+            );
+            Assert.That(marker.tooltip, Does.Not.Contain("AT "));
+            Assert.That(marker.tooltip, Does.Contain("EMITTED BY CombatController.FireAtTarget"));
+            Assert.That(details, Does.Contain("Route context: Arena/Target"));
+            Assert.That(details, Does.Contain("Recent emit sites: CombatController.FireAtTarget"));
+            Assert.That(details, Does.Contain("CombatController.FireAtTarget"));
+            Assert.That(
+                root.Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.DetailsSectionClassName
+                    )
+                    .ToList()
+                    .Count,
+                Is.GreaterThanOrEqualTo(4)
+            );
+            Assert.That(
+                root.Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.DetailsMetricClassName
+                    )
+                    .ToList()
+                    .Count,
+                Is.EqualTo(5)
+            );
+            Assert.That(
+                root.Q<Foldout>(DxMessagingFlowGraphWindow.DetailsTechnicalFoldoutName).value,
+                Is.False
+            );
+            string structuredDetails = string.Join(
+                "\n",
+                root.Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.DetailsSectionClassName
+                    )
+                    .ToList()
+                    .SelectMany(section => section.Query<Label>().ToList())
+                    .Select(label => label.text)
+            );
+            Assert.That(structuredDetails, Does.Contain("MESSAGE"));
+            Assert.That(structuredDetails, Does.Contain("TARGET"));
+            Assert.That(structuredDetails, Does.Contain("HANDLER"));
+            Assert.That(structuredDetails, Does.Contain("EMISSION EVIDENCE"));
+            Assert.That(structuredDetails, Does.Contain("CombatController.FireAtTarget"));
+            FlowGraphExportPayload export = JsonUtility.FromJson<FlowGraphExportPayload>(
+                DxMessagingFlowGraphWindow.CreateExportText(snapshot)
+            );
+            Assert.That(export.schemaVersion, Is.EqualTo(6));
+            Assert.That(export.messages[0].messageKind, Is.EqualTo("TARGETED"));
+            Assert.That(
+                export.messages[0].recentEmissionSites,
+                Does.Contain("CombatController.FireAtTarget")
+            );
+            Assert.That(export.edges[0].context, Is.EqualTo("Arena/Target"));
+            Assert.That(
+                export.edges[0].recentEmissionSites,
+                Does.Contain("CombatController.FireAtTarget")
+            );
+        }
+
+        [Test]
+        public void BuildGraphUiOrdersBothLayersToAvoidSimpleCrossing()
+        {
+            FlowGraphSnapshot snapshot = new(
+                new[]
+                {
+                    new FlowGraphComponentNode("x", "Root/X", "Receiver", true, 1, 1, 1, 0),
+                    new FlowGraphComponentNode("y", "Root/Y", "Receiver", true, 1, 1, 1, 0),
+                },
+                new[] { new FlowGraphMessageNode("A", 1, 1), new FlowGraphMessageNode("B", 1, 1) },
+                new[]
+                {
+                    new FlowGraphEdge("A", "y", "Root/Y", "Untargeted", 1, 1),
+                    new FlowGraphEdge("B", "x", "Root/X", "Untargeted", 1, 1),
+                },
+                Array.Empty<string>()
+            );
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot);
+
+            Dictionary<string, VisualElement> messages = root.Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.GraphMessageNodeClassName
+                )
+                .ToList()
+                .ToDictionary(node => node.Q<Label>().text, StringComparer.Ordinal);
+            Dictionary<string, VisualElement> receivers = root.Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.GraphReceiverNodeClassName
+                )
+                .ToList()
+                .ToDictionary(node => node.Q<Label>().text, StringComparer.Ordinal);
+            Assert.That(
+                messages["A"].style.top.value.value,
+                Is.LessThan(messages["B"].style.top.value.value)
+            );
+            Assert.That(
+                receivers["Y"].style.top.value.value,
+                Is.LessThan(receivers["X"].style.top.value.value)
+            );
+        }
+
+        [Test]
+        public void BuildGraphUiUsesNamedNodeMetricsWithoutPlusCountShorthand()
+        {
+            FlowGraphMessageNode message = new(
+                "Combat.DamageApplied",
+                registrationCount: 2,
+                callCount: 7,
+                messageKindName: "BROADCAST",
+                recentContexts: new[] { "Arena/Archer", "Arena/Mage" }
+            );
+            FlowGraphSnapshot snapshot = new(
+                new[]
+                {
+                    new FlowGraphComponentNode(
+                        "component:alpha-only",
+                        "Arena/A",
+                        "Receiver",
+                        true,
+                        1,
+                        1,
+                        3,
+                        0
+                    ),
+                    new FlowGraphComponentNode(
+                        "component:beta-only",
+                        "Arena/B",
+                        "Receiver",
+                        true,
+                        1,
+                        1,
+                        4,
+                        0
+                    ),
+                },
+                new[] { message },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        message.MessageTypeName,
+                        "component:alpha-only",
+                        "Arena/A",
+                        "Broadcast",
+                        1,
+                        3,
+                        context: "Arena/Archer"
+                    ),
+                    new FlowGraphEdge(
+                        message.MessageTypeName,
+                        "component:beta-only",
+                        "Arena/B",
+                        "Broadcast",
+                        1,
+                        4,
+                        context: "Arena/Mage"
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot);
+
+            VisualElement messageNode = root.Q<VisualElement>(
+                className: DxMessagingFlowGraphWindow.GraphMessageNodeClassName
+            );
+            string metricText = string.Join(
+                "\n",
+                messageNode
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.GraphNodeMetricClassName
+                    )
+                    .ToList()
+                    .SelectMany(row => row.Query<Label>().ToList())
+                    .Select(label => label.text)
+            );
+            Assert.That(metricText, Does.Contain("Sources"));
+            Assert.That(metricText, Does.Contain("2 observed"));
+            Assert.That(metricText, Does.Contain("Receivers"));
+            Assert.That(metricText, Does.Contain("Calls"));
+            Assert.That(metricText, Does.Not.Contain("+"));
+            Assert.That(messageNode.focusable, Is.True);
+            Assert.That(
+                root.Q<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.GraphConnectionClassName
+                ).focusable,
+                Is.True
+            );
+            VisualElement marker = root.Q<VisualElement>(
+                className: DxMessagingFlowGraphWindow.GraphConnectionClassName
+            );
+            VisualElement glyph = marker.Children().Single();
+            DxMessagingFlowGraphWindow.ApplyGraphFocusIndicator(
+                glyph,
+                DxMessagingEditorPalette.BorderStrong,
+                focused: true
+            );
+            Assert.That(glyph.style.borderTopWidth.value, Is.EqualTo(3f));
+            DxMessagingFlowGraphWindow.ApplyGraphFocusIndicator(
+                glyph,
+                DxMessagingEditorPalette.BorderStrong,
+                focused: false
+            );
+            Assert.That(glyph.style.borderTopWidth.value, Is.EqualTo(1f));
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(filterText: "component:alpha-only")
+            );
+            messageNode = root.Q<VisualElement>(
+                className: DxMessagingFlowGraphWindow.GraphMessageNodeClassName
+            );
+            Dictionary<string, string> filteredMetrics = messageNode
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.GraphNodeMetricClassName
+                )
+                .ToList()
+                .ToDictionary(
+                    row => row.Query<Label>().First().text,
+                    row => row.Query<Label>().Last().text,
+                    StringComparer.Ordinal
+                );
+            Assert.That(filteredMetrics["Calls"], Is.EqualTo("3"));
+        }
+
+        [Test]
+        public void BuildGraphUiUsesMixedMetricsUntilFilteringToOneRouteKind()
+        {
+            FlowGraphMessageNode message = new(
+                "Combat.MultiRouteMessage",
+                registrationCount: 2,
+                callCount: 7,
+                messageKindName: "BROADCAST"
+            );
+            FlowGraphSnapshot snapshot = new(
+                new[]
+                {
+                    new FlowGraphComponentNode(
+                        "component:target-only",
+                        "Arena/Target",
+                        "Receiver",
+                        true,
+                        1,
+                        1,
+                        3,
+                        0
+                    ),
+                    new FlowGraphComponentNode(
+                        "component:broadcast-only",
+                        "Arena/Broadcast",
+                        "Receiver",
+                        true,
+                        1,
+                        1,
+                        4,
+                        0
+                    ),
+                },
+                new[] { message },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        message.MessageTypeName,
+                        "component:target-only",
+                        "Arena/Target",
+                        "Targeted",
+                        1,
+                        3,
+                        context: "Arena/Target",
+                        recentEmissionSites: new[] { "TargetController.Send" }
+                    ),
+                    new FlowGraphEdge(
+                        message.MessageTypeName,
+                        "component:broadcast-only",
+                        "Arena/Broadcast",
+                        "Broadcast",
+                        1,
+                        4,
+                        context: "Arena/Source",
+                        recentEmissionSites: new[] { "BroadcastController.Send" }
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot);
+
+            VisualElement messageNode = root.Q<VisualElement>(
+                className: DxMessagingFlowGraphWindow.GraphMessageNodeClassName
+            );
+            Assert.That(
+                messageNode.Query<Label>().ToList().Select(label => label.text),
+                Does.Contain("MIXED")
+            );
+            Assert.That(
+                messageNode
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.GraphNodeMetricClassName
+                    )
+                    .ToList()
+                    .Select(row => row.Query<Label>().ToList().First().text),
+                Is.EquivalentTo(new[] { "Routes", "Receivers", "Calls" })
+            );
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(
+                    filterText: "component:target-only",
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateMessageSelectionKey(message)
+                )
+            );
+            messageNode = root.Q<VisualElement>(
+                className: DxMessagingFlowGraphWindow.GraphMessageNodeClassName
+            );
+            Assert.That(
+                messageNode.Query<Label>().ToList().Select(label => label.text),
+                Does.Contain("TARGETED").And.Not.Contain("MIXED")
+            );
+            Assert.That(
+                messageNode
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.GraphNodeMetricClassName
+                    )
+                    .ToList()
+                    .Select(row => row.Query<Label>().ToList().First().text),
+                Is.EquivalentTo(new[] { "Targets", "Handlers", "Call sites" })
+            );
+            Dictionary<string, string> targetedMetrics = messageNode
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.GraphNodeMetricClassName
+                )
+                .ToList()
+                .ToDictionary(
+                    row => row.Query<Label>().ToList().First().text,
+                    row => row.Query<Label>().ToList().Last().text,
+                    StringComparer.Ordinal
+                );
+            Assert.That(targetedMetrics["Call sites"], Is.EqualTo("1"));
+            string selectedDetails = string.Join(
+                "\n",
+                root.Q<VisualElement>(DxMessagingFlowGraphWindow.DetailsPaneName)
+                    .Query<Label>()
+                    .ToList()
+                    .Select(label => label.text)
+            );
+            Assert.That(selectedDetails, Does.Contain("TARGETED"));
+            Assert.That(selectedDetails, Does.Not.Contain("Message kind: MIXED"));
+            Assert.That(
+                root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text,
+                Does.Contain("Message kind: TARGETED")
+            );
+        }
+
+        [Test]
+        public void BuildGraphUiNamesGlobalAcceptAllAsObserverScopeInsteadOfIMessage()
+        {
+            FlowGraphMessageNode message = new(
+                DxMessagingFlowGraphWindow.GlobalObserverMessageName,
+                registrationCount: 1,
+                callCount: 2,
+                recentTracedDeliveryCount: 0,
+                messageKindName: "GLOBAL OBSERVER"
+            );
+            FlowGraphSnapshot snapshot = new(
+                new[]
+                {
+                    new FlowGraphComponentNode(
+                        "component:observer",
+                        "Root/Observer",
+                        "MessagingComponent",
+                        activeInHierarchy: true,
+                        listenerCount: 1,
+                        registrationCount: 1,
+                        callCount: 2,
+                        localMessageCount: 2
+                    ),
+                },
+                new[] { message },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        message.MessageTypeName,
+                        "component:observer",
+                        "Root/Observer",
+                        "GlobalAcceptAll",
+                        registrationCount: 1,
+                        callCount: 2
+                    ),
+                },
+                new[]
+                {
+                    new FlowGraphTracePath(
+                        "Combat.DamageApplied",
+                        "<none>",
+                        "component:observer",
+                        "Root/Observer",
+                        "GlobalAcceptAll",
+                        recentTracedDeliveryCount: 2
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateMessageSelectionKey(message)
+                )
+            );
+
+            VisualElement graphMessage = root.Q<VisualElement>(
+                className: DxMessagingFlowGraphWindow.GraphMessageNodeClassName
+            );
+            string[] graphLabels = graphMessage
+                .Query<Label>()
+                .ToList()
+                .Select(label => label.text)
+                .ToArray();
+            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            Assert.That(graphLabels, Does.Contain("GLOBAL OBSERVER"));
+            Assert.That(graphLabels, Does.Contain("ANY MESSAGE"));
+            Assert.That(string.Join("\n", graphLabels), Does.Not.Contain("IMessage"));
+            Assert.That(details, Does.Contain("Combat.DamageApplied"));
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(
+                        snapshot.Edges[0]
+                    )
+                )
+            );
+            string structuredRouteDetails = string.Join(
+                "\n",
+                root.Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.DetailsSectionClassName
+                    )
+                    .ToList()
+                    .SelectMany(section => section.Query<Label>().ToList())
+                    .Select(label => label.text)
+            );
+            Assert.That(structuredRouteDetails, Does.Contain("GLOBAL OBSERVER"));
+            Assert.That(structuredRouteDetails, Does.Contain("Combat.DamageApplied"));
+            Assert.That(structuredRouteDetails, Does.Contain("2"));
         }
 
         [Test]
@@ -824,12 +1424,14 @@ namespace DxMessaging.Tests.Editor
                         edge.tooltip.Contains("BroadcastPostProcessor") ? "Broadcast" : "Targeted",
                     StringComparer.Ordinal
                 );
+            Assert.That(graphEdgesByKind["Broadcast"].Query<Label>().ToList(), Is.Empty);
+            Assert.That(graphEdgesByKind["Targeted"].Query<Label>().ToList(), Is.Empty);
             AssertColor(
-                graphEdgesByKind["Targeted"].style.backgroundColor.value,
+                graphEdgesByKind["Targeted"].Children().Single().style.backgroundColor.value,
                 DxMessagingEditorPalette.Targeted
             );
             AssertColor(
-                graphEdgesByKind["Broadcast"].style.backgroundColor.value,
+                graphEdgesByKind["Broadcast"].Children().Single().style.backgroundColor.value,
                 DxMessagingEditorPalette.Broadcast
             );
             Assert.That(
@@ -845,7 +1447,7 @@ namespace DxMessaging.Tests.Editor
                 .ToDictionary(
                     row =>
                         row.Q<Label>(DxMessagingFlowGraphWindow.EdgeLabelName)
-                            .text.Contains("BroadcastPostProcessor")
+                            .text.Contains("| FROM")
                             ? "Broadcast"
                             : "Targeted",
                     StringComparer.Ordinal
@@ -1229,7 +1831,7 @@ namespace DxMessaging.Tests.Editor
                 Does.Contain("Recent diagnostics: 5 global emissions | 3 listener messages")
             );
             Assert.That(details, Does.Contain("Traced deliveries: 2"));
-            Assert.That(exportPayload.schemaVersion, Is.EqualTo(5));
+            Assert.That(exportPayload.schemaVersion, Is.EqualTo(6));
             Assert.That(
                 exportPayload.captureMode,
                 Is.EqualTo("registration-topology-with-recent-diagnostics")
@@ -1339,7 +1941,7 @@ namespace DxMessaging.Tests.Editor
                 traceRows[0].Q<Label>(DxMessagingFlowGraphWindow.TracePathTargetLabelName).text,
                 Does.Contain("Root/Beta")
             );
-            Assert.That(exportPayload.schemaVersion, Is.EqualTo(5));
+            Assert.That(exportPayload.schemaVersion, Is.EqualTo(6));
             Assert.That(exportPayload.tracePathCount, Is.EqualTo(1));
             Assert.That(exportPayload.tracePaths, Has.Length.EqualTo(1));
             Assert.That(exportPayload.tracePaths[0].messageType, Is.EqualTo("ScoreChanged"));
@@ -1501,7 +2103,7 @@ namespace DxMessaging.Tests.Editor
             Assert.That(summary, Does.Contain("Trace ids: 2"));
             Assert.That(summary, Does.Not.Contain("Trace ids: 3"));
             Assert.That(rowSummary, Does.Contain("Trace ids: 2"));
-            Assert.That(exportPayload.schemaVersion, Is.EqualTo(5));
+            Assert.That(exportPayload.schemaVersion, Is.EqualTo(6));
             Assert.That(exportPayload.tracePathCount, Is.EqualTo(1));
             Assert.That(exportPayload.tracePaths[0].recentTraceIdCount, Is.EqualTo(2));
             Assert.That(exportText, Does.Contain("Root/Beta"));
@@ -1755,7 +2357,7 @@ namespace DxMessaging.Tests.Editor
                 exportText
             );
 
-            Assert.That(exportPayload.schemaVersion, Is.EqualTo(5));
+            Assert.That(exportPayload.schemaVersion, Is.EqualTo(6));
             Assert.That(exportText, Does.Not.Contain("messageLanes"));
             Assert.That(exportText, Does.Not.Contain("visibleMessageLanes"));
         }
@@ -2059,7 +2661,7 @@ namespace DxMessaging.Tests.Editor
                 exportText
             );
 
-            Assert.That(exportPayload.schemaVersion, Is.EqualTo(5));
+            Assert.That(exportPayload.schemaVersion, Is.EqualTo(6));
             Assert.That(exportText, Does.Not.Contain("targetLanes"));
             Assert.That(exportText, Does.Not.Contain("visibleTargetLanes"));
         }
@@ -2306,12 +2908,17 @@ namespace DxMessaging.Tests.Editor
                 new[]
                 {
                     new FlowGraphMessageNode("ConcreteMessage", 0, 0, recentTracedDeliveryCount: 1),
-                    new FlowGraphMessageNode("DxMessaging.Core.IMessage", 1, 1),
+                    new FlowGraphMessageNode(
+                        DxMessagingFlowGraphWindow.GlobalObserverMessageName,
+                        1,
+                        1,
+                        messageKindName: "GLOBAL OBSERVER"
+                    ),
                 },
                 new[]
                 {
                     new FlowGraphEdge(
-                        "DxMessaging.Core.IMessage",
+                        DxMessagingFlowGraphWindow.GlobalObserverMessageName,
                         "component:beta",
                         "Root/Beta",
                         "GlobalAcceptAll",
@@ -2376,7 +2983,7 @@ namespace DxMessaging.Tests.Editor
                 exportText
             );
 
-            Assert.That(exportPayload.schemaVersion, Is.EqualTo(5));
+            Assert.That(exportPayload.schemaVersion, Is.EqualTo(6));
             Assert.That(exportText, Does.Not.Contain("flowCorridors"));
             Assert.That(exportText, Does.Not.Contain("visibleCorridors"));
         }
@@ -2697,7 +3304,7 @@ namespace DxMessaging.Tests.Editor
                 exportText
             );
 
-            Assert.That(exportPayload.schemaVersion, Is.EqualTo(5));
+            Assert.That(exportPayload.schemaVersion, Is.EqualTo(6));
             Assert.That(exportText, Does.Not.Contain("contextLanes"));
             Assert.That(exportText, Does.Not.Contain("traceContextLanes"));
             Assert.That(exportText, Does.Not.Contain("visibleContextLanes"));
@@ -3064,7 +3671,7 @@ namespace DxMessaging.Tests.Editor
                 exportText
             );
 
-            Assert.That(exportPayload.schemaVersion, Is.EqualTo(5));
+            Assert.That(exportPayload.schemaVersion, Is.EqualTo(6));
             Assert.That(exportText, Does.Not.Contain("messageTraceLanes"));
             Assert.That(exportText, Does.Not.Contain("traceMessageLanes"));
             Assert.That(exportText, Does.Not.Contain("visibleTraceMessageLanes"));
@@ -3394,7 +4001,7 @@ namespace DxMessaging.Tests.Editor
                 exportText
             );
 
-            Assert.That(exportPayload.schemaVersion, Is.EqualTo(5));
+            Assert.That(exportPayload.schemaVersion, Is.EqualTo(6));
             Assert.That(exportText, Does.Not.Contain("targetTraceLanes"));
             Assert.That(exportText, Does.Not.Contain("traceTargetLanes"));
             Assert.That(exportText, Does.Not.Contain("visibleTraceTargetLanes"));
@@ -3865,7 +4472,7 @@ namespace DxMessaging.Tests.Editor
                 exportText
             );
 
-            Assert.That(exportPayload.schemaVersion, Is.EqualTo(5));
+            Assert.That(exportPayload.schemaVersion, Is.EqualTo(6));
             Assert.That(exportText, Does.Not.Contain("traceRouteKindLanes"));
             Assert.That(exportText, Does.Not.Contain("routeKindTraceLanes"));
             Assert.That(exportText, Does.Not.Contain("visibleTraceRouteKindLanes"));
@@ -4181,7 +4788,7 @@ namespace DxMessaging.Tests.Editor
                 exportText
             );
 
-            Assert.That(exportPayload.schemaVersion, Is.EqualTo(5));
+            Assert.That(exportPayload.schemaVersion, Is.EqualTo(6));
             Assert.That(exportText, Does.Not.Contain("traceIdLanes"));
             Assert.That(exportText, Does.Not.Contain("visibleTraceIdLanes"));
         }
@@ -4245,7 +4852,7 @@ namespace DxMessaging.Tests.Editor
             Assert.That(summary, Does.Contain("Trace ids: 2"));
             Assert.That(summary, Does.Contain("Widest trace: 205 (2 paths)"));
             Assert.That(summary, Does.Not.Contain("201"));
-            Assert.That(exportPayload.schemaVersion, Is.EqualTo(5));
+            Assert.That(exportPayload.schemaVersion, Is.EqualTo(6));
             Assert.That(exportPayload.tracePathCount, Is.EqualTo(2));
             Assert.That(exportText, Does.Not.Contain("contextVolume"));
             Assert.That(exportText, Does.Not.Contain("busiestContext"));
@@ -7176,7 +7783,7 @@ namespace DxMessaging.Tests.Editor
                 node.MessageTypeName.Contains(nameof(FlowGraphMessage), StringComparison.Ordinal)
             );
             FlowGraphMessageNode catchAllNode = snapshot.MessageNodes.Single(node =>
-                node.MessageTypeName.Contains("DxMessaging.Core.IMessage", StringComparison.Ordinal)
+                node.MessageTypeName == DxMessagingFlowGraphWindow.GlobalObserverMessageName
             );
             FlowGraphEdge catchAllEdge = snapshot.Edges.Single(edge =>
                 edge.RegistrationTypeName == "GlobalAcceptAll"
@@ -7186,12 +7793,14 @@ namespace DxMessaging.Tests.Editor
             Assert.That(concreteNode.RecentTracedDeliveryCount, Is.EqualTo(1));
             Assert.That(catchAllNode.RegistrationCount, Is.EqualTo(1));
             Assert.That(catchAllNode.CallCount, Is.EqualTo(1));
+            Assert.That(catchAllNode.MessageKindName, Is.EqualTo("GLOBAL OBSERVER"));
             Assert.That(
                 catchAllNode.RecentTracedDeliveryCount,
                 Is.EqualTo(0),
-                "The IMessage registration node is a catch-all route, not the concrete delivered message."
+                "The ANY MESSAGE scope node is a catch-all route, not the concrete delivered message."
             );
             Assert.That(catchAllEdge.RecentTracedDeliveryCount, Is.EqualTo(1));
+            Assert.That(catchAllEdge.MessageTypeName, Is.EqualTo("ANY MESSAGE"));
 
             messagingComponent.EditorResetRuntimeState();
         }
@@ -7237,8 +7846,203 @@ namespace DxMessaging.Tests.Editor
             Assert.That(snapshot.TracePaths[0].RegistrationTypeName, Is.EqualTo("Broadcast"));
             Assert.That(snapshot.TracePaths[0].RecentTracedDeliveryCount, Is.EqualTo(1));
             Assert.That(snapshot.TracePaths[0].RecentTraceIdCount, Is.EqualTo(1));
+            FlowGraphEdge broadcastEdge = snapshot.Edges.Single(edge =>
+                edge.RegistrationTypeName == "Broadcast"
+            );
+            FlowGraphMessageNode broadcastNode = snapshot.MessageNodes.Single(node =>
+                node.MessageTypeName.Contains(
+                    nameof(FlowGraphBroadcastMessage),
+                    StringComparison.Ordinal
+                )
+            );
+            Assert.That(broadcastEdge.Context, Does.Contain("998877"));
+            Assert.That(
+                string.Join("\n", broadcastEdge.RecentEmissionSites),
+                Does.Contain(nameof(CaptureSnapshotBuildsRecentTracePathsFromJoinedDiagnostics))
+            );
+            Assert.That(broadcastNode.MessageKindName, Is.EqualTo("BROADCAST"));
+            Assert.That(broadcastNode.RecentContexts.Single(), Does.Contain("998877"));
+            Assert.That(
+                string.Join("\n", broadcastNode.RecentEmissionSites),
+                Does.Contain(nameof(CaptureSnapshotBuildsRecentTracePathsFromJoinedDiagnostics))
+            );
 
             messagingComponent.EditorResetRuntimeState();
+        }
+
+        [Test]
+        public void CaptureSnapshotKeepsTargetedEmitSitesScopedToTheirTargets()
+        {
+            GameObject host = CreateTrackedObject("FlowGraphTargetedEvidenceHost");
+            MessagingComponent messagingComponent = host.AddComponent<MessagingComponent>();
+            TestListener listener = host.AddComponent<TestListener>();
+            MessageBus messageBus = MessageHandler.MessageBus as MessageBus;
+            Assert.That(messageBus, Is.Not.Null);
+
+            InstanceId firstTarget = host;
+            InstanceId secondTarget = listener;
+            MessageRegistrationToken token = messagingComponent.Create(listener);
+            token.DiagnosticMode = true;
+            token.RegisterTargeted<FlowGraphTargetedMessage>(
+                firstTarget,
+                listener.OnFlowGraphTargeted
+            );
+            token.RegisterTargeted<FlowGraphTargetedMessage>(
+                secondTarget,
+                listener.OnFlowGraphTargeted
+            );
+            token.Enable();
+
+            messageBus.DiagnosticsMode = true;
+            messageBus._emissionBuffer.Clear();
+            FlowGraphTargetedMessage deliveredMessage = default;
+            messageBus.TargetedBroadcast(ref firstTarget, ref deliveredMessage);
+            messageBus.TargetedBroadcast(ref secondTarget, ref deliveredMessage);
+
+            MessagingComponentInspectorState evidenceState =
+                MessagingComponentEditorHarness.Capture(
+                    messagingComponent,
+                    resolveSerializedProviderBus: false
+                );
+            ListenerDiagnosticsView diagnosticsListener = evidenceState.Listeners.Single();
+            MessageRegistrationHandle firstHandle = diagnosticsListener
+                .Registrations.Single(registration =>
+                    registration.Metadata.context?.Id == firstTarget.Id
+                )
+                .Handle;
+            MessageRegistrationHandle secondHandle = diagnosticsListener
+                .Registrations.Single(registration =>
+                    registration.Metadata.context?.Id == secondTarget.Id
+                )
+                .Handle;
+            MessageEmissionData firstDelivery = diagnosticsListener.EmissionHistory.Single(
+                emission => emission.registrationHandle == firstHandle
+            );
+            MessageEmissionData secondDelivery = diagnosticsListener.EmissionHistory.Single(
+                emission => emission.registrationHandle == secondHandle
+            );
+
+            FlowGraphSnapshot snapshot = DxMessagingFlowGraphWindow.CaptureSnapshot(
+                new[] { messagingComponent }
+            );
+
+            FlowGraphEdge firstEdge = snapshot.Edges.Single(edge =>
+                edge.Context.Contains("GameObject", StringComparison.Ordinal)
+            );
+            FlowGraphEdge secondEdge = snapshot.Edges.Single(edge =>
+                edge.Context.Contains(nameof(TestListener), StringComparison.Ordinal)
+            );
+            string firstSites = string.Join("\n", firstEdge.RecentEmissionSites);
+            string secondSites = string.Join("\n", secondEdge.RecentEmissionSites);
+            string expectedFirstSite = DxMessagingFlowGraphWindow.CreateEmissionSite(
+                firstDelivery.stackTrace
+            );
+            string expectedSecondSite = DxMessagingFlowGraphWindow.CreateEmissionSite(
+                secondDelivery.stackTrace
+            );
+            Assert.That(firstSites, Does.Contain(expectedFirstSite), firstSites);
+            Assert.That(firstSites, Does.Not.Contain(expectedSecondSite));
+            Assert.That(secondSites, Does.Contain(expectedSecondSite));
+            Assert.That(secondSites, Does.Not.Contain(expectedFirstSite));
+            Assert.That(firstEdge.ContextId, Is.EqualTo(firstTarget.Id));
+            Assert.That(secondEdge.ContextId, Is.EqualTo(secondTarget.Id));
+            Assert.That(
+                snapshot.TracePaths.Select(path => path.ContextId),
+                Is.EquivalentTo(new[] { firstTarget.Id, secondTarget.Id })
+            );
+            FlowGraphExportPayload export = JsonUtility.FromJson<FlowGraphExportPayload>(
+                DxMessagingFlowGraphWindow.CreateExportText(snapshot)
+            );
+            Assert.That(
+                export.tracePaths.Select(path => path.contextId),
+                Is.EquivalentTo(new[] { firstTarget.Id, secondTarget.Id })
+            );
+            Assert.That(
+                DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(firstEdge),
+                Is.Not.EqualTo(DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(secondEdge))
+            );
+
+            messagingComponent.EditorResetRuntimeState();
+        }
+
+        [Test]
+        public void CaptureSnapshotClassifiesMultiKindMessageTypesAsMixed()
+        {
+            GameObject host = CreateTrackedObject("FlowGraphMixedKindHost");
+            MessagingComponent messagingComponent = host.AddComponent<MessagingComponent>();
+            TestListener listener = host.AddComponent<TestListener>();
+            MessageRegistrationToken token = messagingComponent.Create(listener);
+            InstanceId context = host;
+            token.RegisterBroadcast<FlowGraphMixedMessage>(context, listener.OnFlowGraphMixed);
+            token.RegisterTargeted<FlowGraphMixedMessage>(context, listener.OnFlowGraphMixed);
+            token.Enable();
+
+            FlowGraphSnapshot snapshot = DxMessagingFlowGraphWindow.CaptureSnapshot(
+                new[] { messagingComponent }
+            );
+
+            Assert.That(snapshot.MessageNodes.Single().MessageKindName, Is.EqualTo("MIXED"));
+            Assert.That(
+                snapshot.Edges.Select(edge => edge.RegistrationTypeName),
+                Is.EquivalentTo(new[] { "Broadcast", "Targeted" })
+            );
+
+            messagingComponent.EditorResetRuntimeState();
+        }
+
+        [Test]
+        public void CaptureSnapshotDoesNotLeakEmitSitesAcrossComponentsOrBuses()
+        {
+            GameObject firstHost = CreateTrackedObject("FlowGraphDefaultBusHost");
+            MessagingComponent firstComponent = firstHost.AddComponent<MessagingComponent>();
+            TestListener firstListener = firstHost.AddComponent<TestListener>();
+            GameObject secondHost = CreateTrackedObject("FlowGraphCustomBusHost");
+            MessagingComponent secondComponent = secondHost.AddComponent<MessagingComponent>();
+            TestListener secondListener = secondHost.AddComponent<TestListener>();
+            MessageBus defaultBus = MessageHandler.MessageBus as MessageBus;
+            Assert.That(defaultBus, Is.Not.Null);
+            MessageBus customBus = new();
+            secondComponent.Configure(customBus, MessageBusRebindMode.PreserveRegistrations);
+            InstanceId sharedTarget = new(24680);
+
+            MessageRegistrationToken firstToken = firstComponent.Create(firstListener);
+            firstToken.DiagnosticMode = true;
+            firstToken.RegisterTargeted<FlowGraphTargetedMessage>(
+                sharedTarget,
+                firstListener.OnFlowGraphTargeted
+            );
+            firstToken.Enable();
+            MessageRegistrationToken secondToken = secondComponent.Create(secondListener);
+            secondToken.DiagnosticMode = true;
+            secondToken.RegisterTargeted<FlowGraphTargetedMessage>(
+                sharedTarget,
+                secondListener.OnFlowGraphTargeted
+            );
+            secondToken.Enable();
+
+            defaultBus.DiagnosticsMode = true;
+            customBus.DiagnosticsMode = true;
+            FlowGraphTargetedMessage message = default;
+            defaultBus.TargetedBroadcast(ref sharedTarget, ref message);
+
+            FlowGraphSnapshot snapshot = DxMessagingFlowGraphWindow.CaptureSnapshot(
+                new[] { firstComponent, secondComponent }
+            );
+            FlowGraphEdge deliveredEdge = snapshot.Edges.Single(edge =>
+                edge.TargetComponentPath.Contains(firstHost.name, StringComparison.Ordinal)
+            );
+            FlowGraphEdge otherBusEdge = snapshot.Edges.Single(edge =>
+                edge.TargetComponentPath.Contains(secondHost.name, StringComparison.Ordinal)
+            );
+
+            Assert.That(deliveredEdge.RecentEmissionSites, Is.Not.Empty);
+            Assert.That(otherBusEdge.RecentEmissionSites, Is.Empty);
+            Assert.That(deliveredEdge.ContextId, Is.EqualTo(sharedTarget.Id));
+            Assert.That(otherBusEdge.ContextId, Is.EqualTo(sharedTarget.Id));
+
+            firstComponent.EditorResetRuntimeState();
+            secondComponent.EditorResetRuntimeState();
+            defaultBus._emissionBuffer.Clear();
         }
 
         [Test]
@@ -7316,6 +8120,8 @@ namespace DxMessaging.Tests.Editor
             Assert.That(snapshot.MessageNodes[0].CallCount, Is.EqualTo(0));
             Assert.That(snapshot.MessageNodes[0].RecentGlobalEmissionCount, Is.EqualTo(1));
             Assert.That(snapshot.MessageNodes[0].RecentLocalMessageCount, Is.EqualTo(0));
+            Assert.That(snapshot.MessageNodes[0].MessageKindName, Is.EqualTo("GLOBAL"));
+            Assert.That(snapshot.MessageNodes[0].RecentEmissionSites, Is.Not.Empty);
         }
 
         [Test]
@@ -8183,6 +8989,10 @@ namespace DxMessaging.Tests.Editor
 
         private readonly struct FlowGraphBroadcastMessage : IBroadcastMessage { }
 
+        private readonly struct FlowGraphTargetedMessage : ITargetedMessage { }
+
+        private readonly struct FlowGraphMixedMessage : IBroadcastMessage, ITargetedMessage { }
+
         private readonly struct EvidenceOnlyFlowGraphMessage : IUntargetedMessage { }
 
         [Serializable]
@@ -8196,6 +9006,7 @@ namespace DxMessaging.Tests.Editor
             public int edgeCount;
             public int tracePathCount;
             public FlowGraphExportMessage[] messages;
+            public FlowGraphExportEdge[] edges;
             public FlowGraphExportTracePath[] tracePaths;
         }
 
@@ -8203,11 +9014,29 @@ namespace DxMessaging.Tests.Editor
         private sealed class FlowGraphExportMessage
         {
             public string messageType;
+            public string messageKind;
             public int registrationCount;
             public int callCount;
             public int recentGlobalEmissionCount;
             public int recentLocalMessageCount;
             public int recentTracedDeliveryCount;
+            public string[] recentEmissionSites;
+            public string[] recentContexts;
+        }
+
+        [Serializable]
+        private sealed class FlowGraphExportEdge
+        {
+            public string messageType;
+            public string targetComponentId;
+            public string targetComponentPath;
+            public string registrationType;
+            public string context;
+            public int contextId;
+            public int registrationCount;
+            public int callCount;
+            public int recentTracedDeliveryCount;
+            public string[] recentEmissionSites;
         }
 
         [Serializable]
@@ -8215,6 +9044,7 @@ namespace DxMessaging.Tests.Editor
         {
             public string messageType;
             public string context;
+            public int contextId;
             public string targetComponentId;
             public string targetComponentPath;
             public string registrationType;
@@ -8228,6 +9058,10 @@ namespace DxMessaging.Tests.Editor
             public void OnFlowGraphMessage(ref FlowGraphMessage message) { }
 
             public void OnFlowGraphBroadcast(ref FlowGraphBroadcastMessage message) { }
+
+            public void OnFlowGraphTargeted(ref FlowGraphTargetedMessage message) { }
+
+            public void OnFlowGraphMixed(ref FlowGraphMixedMessage message) { }
 
             public void PostProcessFlowGraphMessage(ref FlowGraphMessage message) { }
 

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -7994,9 +7994,12 @@ namespace DxMessaging.Tests.Editor
                 Is.Empty,
                 "A destroyed context must use its stable ID without producing a capture warning."
             );
+            // Unity 2021.3's NUnit resolves Has.Count against the runtime array, which has no
+            // public Count property. Read Count through the IReadOnlyList contract directly so
+            // the regression runs on every supported editor version.
             Assert.That(
-                snapshot.Edges,
-                Has.Count.EqualTo(1),
+                snapshot.Edges.Count,
+                Is.EqualTo(1),
                 "The targeted registration must remain present after its context object is destroyed."
             );
             FlowGraphEdge edge = snapshot.Edges.Single();

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -767,6 +767,99 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
+        public void BuildGraphUiPreservesSelectedRouteAndViewportWhenContextDisplayChanges()
+        {
+            FlowGraphSnapshot initialSnapshot = CreateStableContextRouteSnapshot("Arena/Alpha");
+            FlowGraphSnapshot refreshedSnapshot = CreateStableContextRouteSnapshot("Instance 4242");
+            string selectionKey = DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(
+                initialSnapshot.Edges.Single(edge => edge.ContextId == 4242)
+            );
+            Assert.That(
+                DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(
+                    refreshedSnapshot.Edges.Single(edge => edge.ContextId == 4242)
+                ),
+                Is.EqualTo(selectionKey),
+                "A route's stable selection identity must not depend on its mutable context label."
+            );
+            Assert.That(
+                initialSnapshot.Edges.Select(edge => edge.ContextId),
+                Is.EqualTo(new[] { 4242, 5252 }),
+                "The initial labels must place the selected route first."
+            );
+            Assert.That(
+                refreshedSnapshot.Edges.Select(edge => edge.ContextId),
+                Is.EqualTo(new[] { 5252, 4242 }),
+                "The refreshed labels must reverse input order to exercise signature stability."
+            );
+
+            EditorWindow window = CreateTrackedEditorWindow();
+            EditorWindowTestUtility.ShowWindow(window);
+            VisualElement root = window.rootVisualElement;
+            FlowGraphViewState viewState = new(selectedItemKey: selectionKey);
+            DxMessagingFlowGraphWindow.BuildGraphUi(root, initialSnapshot, viewState);
+
+            VisualElement graph = root.Q<VisualElement>(DxMessagingFlowGraphWindow.GraphCanvasName);
+            DxMessagingFlowGraphWindow.FlowGraphCanvasState canvasState =
+                (DxMessagingFlowGraphWindow.FlowGraphCanvasState)graph.userData;
+            canvasState.Initialized = true;
+            canvasState.Pan = new Vector2(91f, -23f);
+            canvasState.Zoom = 0.9f;
+            string layoutSignature = canvasState.LayoutSignature;
+
+            DxMessagingFlowGraphWindow.RefreshGraphContent(root, refreshedSnapshot, viewState);
+
+            VisualElement refreshedGraph = root.Q<VisualElement>(
+                DxMessagingFlowGraphWindow.GraphCanvasName
+            );
+            DxMessagingFlowGraphWindow.FlowGraphCanvasState refreshedState =
+                (DxMessagingFlowGraphWindow.FlowGraphCanvasState)refreshedGraph.userData;
+            int selectedConnectionCount = refreshedGraph
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.GraphConnectionClassName
+                )
+                .ToList()
+                .Count(connection =>
+                    connection.ClassListContains(DxMessagingFlowGraphWindow.SelectedRowClassName)
+                );
+
+            Assert.That(
+                refreshedState,
+                Is.SameAs(canvasState),
+                "Refresh must reuse the existing canvas state."
+            );
+            Assert.That(
+                refreshedState.LayoutSignature,
+                Is.EqualTo(layoutSignature),
+                "A display-only context change must not invalidate the graph layout."
+            );
+            Assert.That(
+                refreshedState.Initialized,
+                Is.True,
+                "A display-only context change must not request automatic reframing."
+            );
+            Assert.That(
+                refreshedState.Pan,
+                Is.EqualTo(new Vector2(91f, -23f)),
+                "A display-only context change must preserve the user's pan position."
+            );
+            Assert.That(
+                refreshedState.Zoom,
+                Is.EqualTo(0.9f),
+                "A display-only context change must preserve the user's zoom level."
+            );
+            Assert.That(
+                selectedConnectionCount,
+                Is.EqualTo(1),
+                "The same stable route must remain selected after its display label changes."
+            );
+            Assert.That(
+                root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text,
+                Does.Contain("Route context: Instance 4242"),
+                "The preserved selection must resolve to the refreshed route details."
+            );
+        }
+
+        [Test]
         public void BuildGraphUiMakesBroadcastSourceAndReceiverDirectionExplicit()
         {
             FlowGraphMessageNode message = new(
@@ -8552,6 +8645,53 @@ namespace DxMessaging.Tests.Editor
                     ?.Q<Label>(TargetLanesSummaryLabelName)
                     ?.text
                 ?? string.Empty;
+        }
+
+        private static FlowGraphSnapshot CreateStableContextRouteSnapshot(string context)
+        {
+            return new FlowGraphSnapshot(
+                new[]
+                {
+                    new FlowGraphComponentNode(
+                        "component:target",
+                        "Arena/Receiver",
+                        "MessagingComponent",
+                        activeInHierarchy: true,
+                        listenerCount: 1,
+                        registrationCount: 2,
+                        callCount: 6,
+                        localMessageCount: 0
+                    ),
+                },
+                new[] { new FlowGraphMessageNode("DamageApplied", 2, 6) },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        "DamageApplied",
+                        "component:target",
+                        "Arena/Receiver",
+                        "Targeted",
+                        registrationCount: 1,
+                        callCount: 3,
+                        context: context,
+                        contextId: 4242
+                    ),
+                    new FlowGraphEdge(
+                        "DamageApplied",
+                        "component:target",
+                        "Arena/Receiver",
+                        "Targeted",
+                        registrationCount: 1,
+                        callCount: 3,
+                        context: "Arena/Zulu",
+                        contextId: 5252
+                    ),
+                }
+                    .OrderBy(edge => edge.Context, StringComparer.Ordinal)
+                    .ThenBy(edge => edge.ContextId)
+                    .ToArray(),
+                Array.Empty<string>()
+            );
         }
 
         private static FlowGraphSnapshot CreateTwoEdgeSnapshot()

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -103,6 +103,11 @@ namespace DxMessaging.Tests.Editor
         [TearDown]
         public void TearDown()
         {
+            // The viewport-selection test keeps a shown host window open until teardown.
+            // Unity resets LogAssert tolerance between the test body and teardown, so
+            // re-enable the shared headless-only suppression before closing that window.
+            EditorWindowTestUtility.SuppressHeadlessWindowRenderErrors();
+
             foreach (Object instance in _createdObjects)
             {
                 if (instance != null)

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -242,6 +242,292 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
+        public void BuildGraphUiPrioritizesRoutesAndCollapsesAdvancedData()
+        {
+            FlowGraphSnapshot snapshot = CreateTwoEdgeSnapshot();
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot);
+
+            Label overview = root.Q<Label>(DxMessagingFlowGraphWindow.RouteMapOverviewLabelName);
+            Foldout routeInsights = root.Q<Foldout>(
+                DxMessagingFlowGraphWindow.RouteMapInsightsFoldoutName
+            );
+            Foldout traceActivity = root.Q<Foldout>(
+                DxMessagingFlowGraphWindow.TraceActivityFoldoutName
+            );
+            Foldout topology = root.Q<Foldout>(DxMessagingFlowGraphWindow.TopologyFoldoutName);
+            Label detailsTitle = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsTitleLabelName);
+
+            Assert.That(
+                overview,
+                Is.Not.Null,
+                "The visible route overview should be rendered above advanced analytics."
+            );
+            Assert.That(
+                overview.text,
+                Is.EqualTo("2 routes | 2 messages | 2 receivers | 6 calls"),
+                $"Unexpected visible overview text: {overview.text}"
+            );
+            Assert.That(
+                routeInsights.value,
+                Is.False,
+                "Route insights should default collapsed so the route map remains scannable."
+            );
+            Assert.That(
+                traceActivity,
+                Is.Null,
+                "Trace activity should be omitted when the capture has no trace paths."
+            );
+            Assert.That(
+                topology.value,
+                Is.False,
+                "Raw topology should default collapsed so components, messages, and edges do not duplicate the route map."
+            );
+            Assert.That(
+                detailsTitle.text,
+                Does.StartWith("Route:"),
+                $"The default selection should explain a route, but was '{detailsTitle.text}'."
+            );
+
+            FlowGraphSnapshot tracedSnapshot = new(
+                snapshot.ComponentNodes,
+                snapshot.MessageNodes,
+                snapshot.Edges,
+                new[]
+                {
+                    new FlowGraphTracePath(
+                        "InventoryChanged",
+                        "<none>",
+                        "component:alpha",
+                        "Root/Alpha",
+                        "Untargeted",
+                        recentTracedDeliveryCount: 1
+                    ),
+                },
+                snapshot.Warnings
+            );
+            VisualElement tracedRoot = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(tracedRoot, tracedSnapshot);
+
+            Foldout tracedActivity = tracedRoot.Q<Foldout>(
+                DxMessagingFlowGraphWindow.TraceActivityFoldoutName
+            );
+            Assert.That(
+                tracedActivity.value,
+                Is.False,
+                "Trace activity should default collapsed so secondary analysis does not bury routes."
+            );
+
+            tracedActivity.value = true;
+            Assert.That(
+                DxMessagingFlowGraphWindow.RefreshGraphContent(
+                    tracedRoot,
+                    tracedSnapshot,
+                    new FlowGraphViewState("missing")
+                ),
+                Is.True
+            );
+            Assert.That(
+                tracedRoot.Q<Foldout>(DxMessagingFlowGraphWindow.TraceActivityFoldoutName),
+                Is.Null
+            );
+            Assert.That(
+                DxMessagingFlowGraphWindow.RefreshGraphContent(
+                    tracedRoot,
+                    tracedSnapshot,
+                    FlowGraphViewState.Default
+                ),
+                Is.True
+            );
+            Assert.That(
+                tracedRoot.Q<Foldout>(DxMessagingFlowGraphWindow.TraceActivityFoldoutName).value,
+                Is.True,
+                "Refreshing graph content should preserve an expanded trace section."
+            );
+        }
+
+        [Test]
+        public void BuildGraphUiExplainsMissingLiveRoutesWithoutRenderingZeroValueTopology()
+        {
+            FlowGraphSnapshot snapshot = new(
+                new[]
+                {
+                    new FlowGraphComponentNode(
+                        "component:listener",
+                        "Root/Listener",
+                        "MessagingComponent",
+                        activeInHierarchy: true,
+                        listenerCount: 0,
+                        registrationCount: 0,
+                        callCount: 0,
+                        localMessageCount: 0
+                    ),
+                },
+                new[]
+                {
+                    new FlowGraphMessageNode(
+                        "ObservedMessage",
+                        registrationCount: 0,
+                        callCount: 0,
+                        recentGlobalEmissionCount: 3,
+                        recentLocalMessageCount: 0,
+                        recentTracedDeliveryCount: 0
+                    ),
+                },
+                Array.Empty<FlowGraphEdge>(),
+                Array.Empty<string>()
+            );
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot);
+
+            Label emptyTitle = root.Q<Label>(DxMessagingFlowGraphWindow.EmptyStateTitleLabelName);
+            Label emptyBody = root.Q<Label>(DxMessagingFlowGraphWindow.EmptyStateLabelName);
+
+            Assert.That(
+                emptyTitle.text,
+                Is.EqualTo("No live routes"),
+                $"Unexpected no-route title: {emptyTitle.text}"
+            );
+            Assert.That(
+                emptyBody.text,
+                Does.Contain("Enter Play mode"),
+                $"The no-route guidance should name the next action, but was '{emptyBody.text}'."
+            );
+            Assert.That(
+                root.Q<VisualElement>(DxMessagingFlowGraphWindow.RouteMapName),
+                Is.Null,
+                "A zero-route capture should not render a zero-value route summary."
+            );
+            Assert.That(
+                root.Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.ComponentNodeClassName
+                    )
+                    .ToList(),
+                Is.Empty,
+                "A zero-route capture should not dump raw component rows below the guidance."
+            );
+        }
+
+        [Test]
+        public void BuildGraphUiPrioritizesConcreteRoutesAndCollapsesOverflow()
+        {
+            FlowGraphComponentNode[] components = Enumerable
+                .Range(0, 10)
+                .Select(index => new FlowGraphComponentNode(
+                    $"component:{index}",
+                    $"Root/Listener {index}",
+                    "MessagingComponent",
+                    activeInHierarchy: true,
+                    listenerCount: 1,
+                    registrationCount: 1,
+                    callCount: index == 9 ? 100 : 9 - index,
+                    localMessageCount: 0
+                ))
+                .ToArray();
+            FlowGraphMessageNode[] messages = Enumerable
+                .Range(0, 9)
+                .Select(index => new FlowGraphMessageNode($"ConcreteMessage{index}", 1, 9 - index))
+                .Append(new FlowGraphMessageNode("IMessage", 1, 100))
+                .ToArray();
+            FlowGraphEdge[] edges = Enumerable
+                .Range(0, 9)
+                .Select(index => new FlowGraphEdge(
+                    $"ConcreteMessage{index}",
+                    $"component:{index}",
+                    $"Root/Listener {index}",
+                    "Untargeted",
+                    registrationCount: 1,
+                    callCount: 9 - index
+                ))
+                .Append(
+                    new FlowGraphEdge(
+                        "IMessage",
+                        "component:9",
+                        "Root/Listener 9",
+                        "GlobalAcceptAll",
+                        registrationCount: 1,
+                        callCount: 100
+                    )
+                )
+                .ToArray();
+            FlowGraphSnapshot snapshot = new(components, messages, edges, Array.Empty<string>());
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot);
+
+            VisualElement routeMap = root.Q<VisualElement>(DxMessagingFlowGraphWindow.RouteMapName);
+            Foldout moreRoutes = root.Q<Foldout>(
+                DxMessagingFlowGraphWindow.RouteMapMoreRoutesFoldoutName
+            );
+            int initiallyVisibleRouteCount = routeMap
+                .Children()
+                .Count(child =>
+                    child.ClassListContains(DxMessagingFlowGraphWindow.RouteMapRouteClassName)
+                );
+            int overflowRouteCount = moreRoutes
+                .Query<VisualElement>(className: DxMessagingFlowGraphWindow.RouteMapRouteClassName)
+                .ToList()
+                .Count;
+            string detailsTitle = root.Q<Label>(
+                DxMessagingFlowGraphWindow.DetailsTitleLabelName
+            ).text;
+
+            Assert.That(
+                initiallyVisibleRouteCount,
+                Is.EqualTo(8),
+                $"Expected 8 initially visible routes, but found {initiallyVisibleRouteCount}."
+            );
+            Assert.That(
+                overflowRouteCount,
+                Is.EqualTo(2),
+                $"Expected 2 overflow routes, but found {overflowRouteCount}."
+            );
+            Assert.That(moreRoutes.value, Is.False, "Overflow routes should default collapsed.");
+            Assert.That(
+                detailsTitle,
+                Does.Contain("ConcreteMessage0"),
+                $"A concrete route should be selected ahead of GlobalAcceptAll, but was '{detailsTitle}'."
+            );
+
+            root.Q<Foldout>(DxMessagingFlowGraphWindow.RouteMapInsightsFoldoutName).value = true;
+            moreRoutes.value = true;
+            root.Q<Foldout>(DxMessagingFlowGraphWindow.TopologyFoldoutName).value = true;
+
+            Assert.That(
+                DxMessagingFlowGraphWindow.RefreshGraphContent(
+                    root,
+                    snapshot,
+                    new FlowGraphViewState("missing")
+                ),
+                Is.True
+            );
+            Assert.That(root.Q<VisualElement>(DxMessagingFlowGraphWindow.RouteMapName), Is.Null);
+            Assert.That(
+                DxMessagingFlowGraphWindow.RefreshGraphContent(
+                    root,
+                    snapshot,
+                    FlowGraphViewState.Default
+                ),
+                Is.True
+            );
+            Assert.That(
+                root.Q<Foldout>(DxMessagingFlowGraphWindow.RouteMapInsightsFoldoutName).value,
+                Is.True
+            );
+            Assert.That(
+                root.Q<Foldout>(DxMessagingFlowGraphWindow.RouteMapMoreRoutesFoldoutName).value,
+                Is.True
+            );
+            Assert.That(
+                root.Q<Foldout>(DxMessagingFlowGraphWindow.TopologyFoldoutName).value,
+                Is.True
+            );
+        }
+
+        [Test]
         public void BuildGraphUiColorsRouteRowsByRegistrationTaxonomy()
         {
             FlowGraphSnapshot snapshot = new(
@@ -551,7 +837,7 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
-        public void BuildGraphUiRendersSelectionDetailsAndHighlightsFirstComponent()
+        public void BuildGraphUiRendersSelectionDetailsAndHighlightsFirstRoute()
         {
             FlowGraphSnapshot snapshot = CreateTwoEdgeSnapshot();
             VisualElement root = new();
@@ -564,27 +850,27 @@ namespace DxMessaging.Tests.Editor
             Assert.That(details, Is.Not.Null);
             Assert.That(
                 details.Q<Label>(DxMessagingFlowGraphWindow.DetailsTitleLabelName).text,
-                Does.Contain("Root/Alpha")
+                Does.Contain("InventoryChanged -> Root/Alpha")
             );
             Assert.That(
                 details.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text,
-                Does.Contain("Inbound visible routes: 1 from 1 message types")
+                Does.Contain("Registration type: Untargeted")
             );
             Assert.That(
                 details.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text,
                 Does.Contain("Visible call share: 4/6 (67%)")
             );
 
-            List<VisualElement> components = root.Query<VisualElement>(
-                    className: DxMessagingFlowGraphWindow.ComponentNodeClassName
+            List<VisualElement> routes = root.Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.RouteMapRouteClassName
                 )
                 .ToList();
             Assert.That(
-                components[0].ClassListContains(DxMessagingFlowGraphWindow.SelectedRowClassName),
+                routes[0].ClassListContains(DxMessagingFlowGraphWindow.SelectedRowClassName),
                 Is.True
             );
             Assert.That(
-                components[1].ClassListContains(DxMessagingFlowGraphWindow.SelectedRowClassName),
+                routes[1].ClassListContains(DxMessagingFlowGraphWindow.SelectedRowClassName),
                 Is.False
             );
         }
@@ -6194,6 +6480,7 @@ namespace DxMessaging.Tests.Editor
 
                 TextField filter = root.Q<TextField>(DxMessagingFlowGraphWindow.FilterFieldName);
                 ScrollView content = root.Q<ScrollView>(DxMessagingFlowGraphWindow.ContentName);
+                root.Q<Foldout>(DxMessagingFlowGraphWindow.TopologyFoldoutName).value = true;
                 List<VisualElement> messages = root.Query<VisualElement>(
                         className: DxMessagingFlowGraphWindow.MessageNodeClassName
                     )
@@ -6226,6 +6513,11 @@ namespace DxMessaging.Tests.Editor
                 Assert.That(
                     root.Q<Label>(DxMessagingFlowGraphWindow.DetailsTitleLabelName).text,
                     Does.Contain("ScoreChanged")
+                );
+                Assert.That(
+                    root.Q<Foldout>(DxMessagingFlowGraphWindow.TopologyFoldoutName).value,
+                    Is.True,
+                    "Selecting a topology row should not collapse the section around it."
                 );
             }
             finally
@@ -6972,13 +7264,7 @@ namespace DxMessaging.Tests.Editor
 
         private static string RenderRouteMapSummary(FlowGraphSnapshot snapshot)
         {
-            VisualElement root = new();
-
-            DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot);
-
-            return root.Q<VisualElement>(DxMessagingFlowGraphWindow.RouteMapName)
-                .Q<Label>(DxMessagingFlowGraphWindow.RouteMapSummaryLabelName)
-                .text;
+            return DxMessagingFlowGraphWindow.CreateRouteMapSummaryText(snapshot);
         }
 
         private static string RenderTracePathsSummary(params FlowGraphTracePath[] tracePaths)

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -7966,6 +7966,55 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
+        public void CaptureSnapshotKeepsRoutesWhenContextObjectWasDestroyed()
+        {
+            GameObject host = CreateTrackedObject("FlowGraphDestroyedContextHost");
+            MessagingComponent messagingComponent = host.AddComponent<MessagingComponent>();
+            TestListener listener = host.AddComponent<TestListener>();
+            GameObject contextHost = CreateTrackedObject("FlowGraphDestroyedContext");
+            InstanceId context = contextHost;
+            int contextId = context.Id;
+            MessageRegistrationToken token = messagingComponent.Create(listener);
+            token.RegisterTargeted<FlowGraphTargetedMessage>(context, listener.OnFlowGraphTargeted);
+            token.Enable();
+            Object.DestroyImmediate(contextHost);
+
+            FlowGraphSnapshot snapshot = null;
+            Assert.DoesNotThrow(
+                () =>
+                    snapshot = DxMessagingFlowGraphWindow.CaptureSnapshot(
+                        new[] { messagingComponent }
+                    ),
+                "Capture must not dereference a destroyed Unity context reference."
+            );
+
+            Assert.That(snapshot, Is.Not.Null, "Capture must return a snapshot after destruction.");
+            Assert.That(
+                snapshot.Warnings,
+                Is.Empty,
+                "A destroyed context must use its stable ID without producing a capture warning."
+            );
+            Assert.That(
+                snapshot.Edges,
+                Has.Count.EqualTo(1),
+                "The targeted registration must remain present after its context object is destroyed."
+            );
+            FlowGraphEdge edge = snapshot.Edges.Single();
+            Assert.That(
+                edge.Context,
+                Is.EqualTo("Instance " + contextId),
+                "Destroyed contexts must fall back to readable stable-ID text."
+            );
+            Assert.That(
+                edge.ContextId,
+                Is.EqualTo(contextId),
+                "Destroyed contexts must retain their exact registration identity."
+            );
+
+            messagingComponent.EditorResetRuntimeState();
+        }
+
+        [Test]
         public void CaptureSnapshotClassifiesMultiKindMessageTypesAsMixed()
         {
             GameObject host = CreateTrackedObject("FlowGraphMixedKindHost");

--- a/Tests/Runtime/Core/ReflexiveErrorTests.cs
+++ b/Tests/Runtime/Core/ReflexiveErrorTests.cs
@@ -3,13 +3,95 @@ namespace DxMessaging.Tests.Runtime.Core
 {
     using DxMessaging.Core;
     using DxMessaging.Core.Extensions;
+    using DxMessaging.Core.MessageBus;
     using DxMessaging.Core.Messages;
+    using DxMessaging.Tests.Runtime;
     using DxMessaging.Tests.Runtime.Scripts.Components;
     using NUnit.Framework;
     using UnityEngine;
 
     public sealed class ReflexiveErrorTests : MessagingTestBase
     {
+        public enum DestroyedTargetKind
+        {
+            GameObject,
+            Component,
+        }
+
+        /// <remarks>
+        /// Investigation (2026-08-03): Unity's overloaded null comparison is required before
+        /// pattern matching a retained object reference. A destroyed reference still matches its
+        /// managed GameObject or Component type, but dereferencing it throws. These cases prove
+        /// hierarchy delivery skips both destroyed target shapes while ordinary bus handlers keep
+        /// running.
+        /// </remarks>
+        [TestCase(DestroyedTargetKind.GameObject)]
+        [TestCase(DestroyedTargetKind.Component)]
+        public void DestroyedUnityTargetSkipsHierarchyAndContinuesBusDelivery(
+            DestroyedTargetKind targetKind
+        )
+        {
+            GameObject host = new(
+                nameof(DestroyedUnityTargetSkipsHierarchyAndContinuesBusDelivery),
+                typeof(SimpleMessageAwareComponent)
+            );
+            _spawned.Add(host);
+            SimpleMessageAwareComponent component =
+                host.GetComponent<SimpleMessageAwareComponent>();
+            InstanceId target =
+                targetKind == DestroyedTargetKind.GameObject
+                    ? (InstanceId)host
+                    : (InstanceId)component;
+            Object.DestroyImmediate(host);
+            Assert.That(
+                target.Object == null,
+                Is.True,
+                $"[{targetKind}] Test setup must retain a destroyed Unity object reference."
+            );
+
+            MessageBus messageBus = new();
+            MessageHandler handler = new(new InstanceId(9173), messageBus) { active = true };
+            MessageRegistrationToken token = MessageRegistrationToken.Create(handler, messageBus);
+            int busHandlerCalls = 0;
+            ReflexiveMessage message = new(
+                nameof(SimpleMessageAwareComponent.HandleReflexiveMessageTwoArguments),
+                ReflexiveSendMode.Flat,
+                1,
+                2
+            );
+
+            using (
+                LeakWatcher watcher = new(
+                    messageBus,
+                    label: $"Destroyed reflexive {targetKind} target"
+                )
+            )
+            {
+                try
+                {
+                    _ = token.RegisterTargeted<ReflexiveMessage>(
+                        target,
+                        (ref ReflexiveMessage _) => ++busHandlerCalls
+                    );
+                    token.Enable();
+
+                    Assert.DoesNotThrow(
+                        () => DispatchReflexive(messageBus, target, message),
+                        $"[{targetKind}] Hierarchy delivery must not dereference a destroyed Unity target."
+                    );
+                    Assert.That(
+                        busHandlerCalls,
+                        Is.EqualTo(1),
+                        $"[{targetKind}] Normal targeted bus delivery must continue after hierarchy delivery is skipped."
+                    );
+                }
+                finally
+                {
+                    token.Disable();
+                }
+            }
+        }
+
         [Test]
         public void UnknownMethodDoesNotThrowOrInvoke()
         {
@@ -141,6 +223,15 @@ namespace DxMessaging.Tests.Runtime.Core
                 twoArgCount,
                 "Control failed: the correctly-typed reflexive dispatch must invoke the method."
             );
+        }
+
+        private static void DispatchReflexive(
+            MessageBus messageBus,
+            InstanceId target,
+            ReflexiveMessage message
+        )
+        {
+            messageBus.TargetedBroadcast(ref target, ref message);
         }
     }
 }

--- a/Tests/Runtime/Unity/MessageAwareComponentReregistrationTests.cs
+++ b/Tests/Runtime/Unity/MessageAwareComponentReregistrationTests.cs
@@ -167,6 +167,75 @@ namespace DxMessaging.Tests.Runtime.Unity
         }
 
         [Test]
+        public void OptInReplacesEnabledTokenWhoseBusWasReset()
+        {
+            GameObject host = new(
+                nameof(OptInReplacesEnabledTokenWhoseBusWasReset),
+                typeof(MessagingComponent),
+                typeof(ReregisteringMessageAwareComponent)
+            );
+            _spawned.Add(host);
+            MessagingComponent messaging = host.GetComponent<MessagingComponent>();
+            ReregisteringMessageAwareComponent listener =
+                host.GetComponent<ReregisteringMessageAwareComponent>();
+            int count = 0;
+            listener.untargetedHandler = () => ++count;
+            SimpleUntargetedMessage message = new();
+
+            message.EmitUntargeted();
+            Assert.AreEqual(1, count, "Positive control: the original token should deliver.");
+            MessageRegistrationToken originalToken = listener.Token;
+
+            using (LeakWatcher watcher = LeakWatcher.Watch(label: "EnabledTokenResetRecovery"))
+            {
+                DxMessagingStaticState.Reset();
+
+                Assert.IsTrue(
+                    originalToken.Enabled,
+                    "The reset reproducer requires a token whose enabled flag outlives its bus sinks."
+                );
+                Assert.AreEqual(
+                    0,
+                    MessageHandler.MessageBus.RegisteredUntargeted,
+                    "Static reset must clear the live bus registration beneath the enabled token."
+                );
+                message.EmitUntargeted();
+                Assert.AreEqual(1, count, "The stale enabled token must not deliver after reset.");
+
+                Assert.IsTrue(
+                    messaging.Release(listener),
+                    "The stale token must remain safely releasable after the bus generation changes."
+                );
+                listener.enabled = false;
+                listener.enabled = true;
+
+                Assert.AreNotSame(
+                    originalToken,
+                    listener.Token,
+                    "Recovery must replace the stale enabled token."
+                );
+                Assert.IsTrue(listener.Token.Enabled, "The replacement token should be enabled.");
+                Assert.AreEqual(
+                    1,
+                    MessageHandler.MessageBus.RegisteredUntargeted,
+                    "The replacement token should restore one live registration."
+                );
+                message.EmitUntargeted();
+                Assert.AreEqual(2, count, "Delivery should resume through the replacement token.");
+                Assert.AreEqual(
+                    2,
+                    listener.registerInvocationCount,
+                    "Recovery should replay registrations exactly once."
+                );
+            }
+
+            Assert.IsTrue(
+                messaging.Release(listener),
+                "Releasing the replacement token should succeed."
+            );
+        }
+
+        [Test]
         public void OptInDoesNotReplayRegistrationsWithoutARelease()
         {
             GameObject host = new(

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -126,18 +126,39 @@ safe editor capture and avoid mutating provider state.
 Open **Tools > Wallstop Studios > DxMessaging > Flow Graph** to inspect loaded
 scene `MessagingComponent` registration topology. The primary surface is an
 interactive graph: message nodes occupy the left column, receiver nodes occupy
-the right column, and registration edges connect them. Drag to pan, scroll to
-zoom, and select a node or connection to inspect it. The canvas frames all
-filtered nodes automatically and renders every filtered message, receiver, and
-route instead of moving extra message types into a text overflow list.
+the right column, and arrowheads carry direction without placing text labels on
+the lines. The layout alternates crossing-reduction sweeps across both columns,
+then orders each node's connection ports by the opposite column. Small
+shape-and-color route selectors use a 30-pixel canvas target. The readable zoom
+floor keeps that target at least 24 screen pixels while avoiding nearby arrows.
+Nodes use named metric rows instead of compact `+N` summaries.
 
-The selected item details sit directly below the canvas. Expand **Analysis and
-Raw Data** only when you need the textual route map, message and target lanes,
-trace activity, or topology lists. Inside that section, concrete routes sort
-before `GlobalAcceptAll`; call volume, recent traced deliveries, and stable names
-determine the remaining order. The textual route map keeps its first eight rows
-outside its nested **more routes** foldout, but the graph itself has no
-eight-route cap.
+Broadcast nodes identify source scope, targeted nodes identify target scope,
+and untargeted nodes identify the global bus. A type with more than one visible
+route kind uses a `MIXED` node with neutral route, receiver, and call metrics;
+filtering it to one route kind restores that kind's focused metrics. Targeted
+and broadcast route details list recent call sites from the exact component
+registration delivery record when token diagnostics captured them. A call site
+identifies the emitting script, method, file, and line; it does not invent a
+sender object because targeted emission APIs carry a target, not a sender.
+Global accept-all registrations appear as
+`GLOBAL OBSERVER / ANY MESSAGE`, and their details list the concrete message
+types observed in recent trace evidence. Drag to pan, scroll to zoom, and select
+a node or connection to inspect it. Automatic framing keeps a readable zoom
+floor; large filtered graphs remain pannable instead of shrinking their text
+and interaction targets into an unreadable overview. The canvas renders every
+filtered message, receiver, and route instead of moving extra message types
+into a text overflow list.
+
+The selected item inspector sits directly below the canvas. Route selections
+use responsive cards for the route path, activity metrics, emission evidence,
+and trace evidence. Its newline-oriented technical report starts collapsed.
+Expand **Analysis and Raw Data** only when you need the textual route map,
+message and target lanes, trace activity, or topology lists. Inside that
+section, concrete routes sort before `GlobalAcceptAll`; call volume, recent
+traced deliveries, and stable names determine the remaining order. The textual
+route map keeps its first eight rows outside its nested **more routes** foldout,
+but the graph itself has no eight-route cap.
 
 If the snapshot sees components or messages but no registration routes, the
 window explains how to recover: enter Play mode, restart Play mode if it is
@@ -148,7 +169,10 @@ The graph aggregates:
 
 - component nodes,
 - message-type nodes,
-- registration edges by message type, target component, and registration kind,
+- registration edges by message type, target component, registration kind, and
+  source or target context where applicable,
+- recent component- and registration-exact delivery call sites for broadcast
+  and targeted edges when token diagnostics captured them,
 - route-map call shares,
 - visible message lanes by message type,
 - visible target lanes by target component,
@@ -233,10 +257,17 @@ and selected message details name the busiest trace target and its matching
 trace-path delivery share. Selected route details also report the exact route's
 share of visible recent route-edge traced deliveries.
 The current export uses
-`schemaVersion: 5`, `captureMode` set to
+`schemaVersion: 6`, `captureMode` set to
 `registration-topology-with-recent-diagnostics`, and a `traceSemantics` field
 that explains how trace ids, per-trace-path trace-id counts, and exact
-per-trace-path trace-id arrays are interpreted.
+per-trace-path trace-id arrays are interpreted. Message rows include semantic
+kind, recent call sites, and recent contexts. Edge rows include exact route
+context identity and recent component- and registration-scoped call sites.
+`contextId` is the captured Unity instance ID for a source or target; `0` means
+that the route has no specific source or target context. These IDs distinguish
+same-named objects inside one capture, but they are local to the running Unity
+session and are not durable identifiers. Trace-path rows use the same
+`contextId` convention.
 
 Trace paths are recent evidence aggregates built from token-side delivery
 records that carry a positive `traceId`. They group by concrete delivered

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -124,20 +124,20 @@ safe editor capture and avoid mutating provider state.
 ### Flow Graph
 
 Open **Tools > Wallstop Studios > DxMessaging > Flow Graph** to inspect loaded
-scene `MessagingComponent` registration topology. The window starts with the
-route map and selects its first concrete route. Routes with a concrete
-registration kind appear before `GlobalAcceptAll`; within each group, routes
-with more calls and recent traced deliveries appear first. The first eight
-routes remain visible, and additional routes start in a collapsed **more
-routes** section.
+scene `MessagingComponent` registration topology. The primary surface is an
+interactive graph: message nodes occupy the left column, receiver nodes occupy
+the right column, and registration edges connect them. Drag to pan, scroll to
+zoom, and select a node or connection to inspect it. The canvas frames all
+filtered nodes automatically and renders every filtered message, receiver, and
+route instead of moving extra message types into a text overflow list.
 
-The route map header reports route, message, receiver, and call totals. Expand
-**Route Insights** for route-kind mix, fan-out, fan-in, inactive-target,
-no-call, and traced-delivery analysis. **Trace Activity** contains the recent
-trace paths and trace lanes. **Topology Details** contains the raw component,
-message, and registration-edge lists. These analysis sections start collapsed
-so the active routes and selected-route details remain visible in a normal
-window height.
+The selected item details sit directly below the canvas. Expand **Analysis and
+Raw Data** only when you need the textual route map, message and target lanes,
+trace activity, or topology lists. Inside that section, concrete routes sort
+before `GlobalAcceptAll`; call volume, recent traced deliveries, and stable names
+determine the remaining order. The textual route map keeps its first eight rows
+outside its nested **more routes** foldout, but the graph itself has no
+eight-route cap.
 
 If the snapshot sees components or messages but no registration routes, the
 window explains how to recover: enter Play mode, restart Play mode if it is
@@ -162,9 +162,10 @@ The graph aggregates:
 - recent trace-path/context evidence when diagnostics captured token delivery
   records with positive trace ids.
 
-The graph supports filtering, stable row selection, details for selected
-components/messages/routes, and **Copy JSON** export. The Visible Message Lanes
-panel groups visible registration edges by message type, then reports route
+The graph supports filtering, pan and zoom, automatic framing, stable node and
+edge selection, details for selected components/messages/routes, and **Copy
+JSON** export. The collapsed Visible Message Lanes panel groups visible
+registration edges by message type, then reports route
 count, distinct target count, registration count, calls, recent traced
 deliveries, no-call routes, route kinds, call share, target paths, and inactive
 target breadth for each lane. The Visible Target Lanes panel groups visible

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -145,7 +145,7 @@ Global accept-all registrations appear as
 `GLOBAL OBSERVER / ANY MESSAGE`, and their details list the concrete message
 types observed in recent trace evidence. Drag to pan, scroll to zoom, and select
 a node or connection to inspect it. Automatic framing keeps a readable zoom
-floor; large filtered graphs remain pannable instead of shrinking their text
+floor; large filtered graphs remain available through panning instead of shrinking their text
 and interaction targets into an unreadable overview. The canvas renders every
 filtered message, receiver, and route instead of moving extra message types
 into a text overflow list.

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -124,7 +124,27 @@ safe editor capture and avoid mutating provider state.
 ### Flow Graph
 
 Open **Tools > Wallstop Studios > DxMessaging > Flow Graph** to inspect loaded
-scene `MessagingComponent` registration topology. The graph aggregates:
+scene `MessagingComponent` registration topology. The window starts with the
+route map and selects its first concrete route. Routes with a concrete
+registration kind appear before `GlobalAcceptAll`; within each group, routes
+with more calls and recent traced deliveries appear first. The first eight
+routes remain visible, and additional routes start in a collapsed **more
+routes** section.
+
+The route map header reports route, message, receiver, and call totals. Expand
+**Route Insights** for route-kind mix, fan-out, fan-in, inactive-target,
+no-call, and traced-delivery analysis. **Trace Activity** contains the recent
+trace paths and trace lanes. **Topology Details** contains the raw component,
+message, and registration-edge lists. These analysis sections start collapsed
+so the active routes and selected-route details remain visible in a normal
+window height.
+
+If the snapshot sees components or messages but no registration routes, the
+window explains how to recover: enter Play mode, restart Play mode if it is
+already active, enable the listeners, and refresh. It does not render a list of
+zero-value topology summaries.
+
+The graph aggregates:
 
 - component nodes,
 - message-type nodes,
@@ -177,7 +197,8 @@ message list, and normalized context list for each trace target lane. The
 Visible Trace Context Lanes panel groups visible trace paths by normalized trace
 context, then reports path count, distinct message and target counts, distinct
 trace ids, route kinds, traced deliveries, delivery share, message list, and
-target list for each context lane. The Route Map summary reports the visible
+target list for each context lane. The expanded Route Insights summary reports
+the visible
 route-kind mix, the widest visible message by distinct target components, the
 target component with the most visible inbound routes, inactive routed targets,
 the hottest visible route by call share, and visible routes with no calls. It
@@ -185,7 +206,7 @@ also reports how many visible routes have at least one recent traced delivery an
 which visible route accounts for the largest share of recent traced deliveries,
 plus which visible message accounts for the largest share of recent route-edge
 traced deliveries and which visible target accounts for the largest share. Both
-the Route Map and Recent Trace Paths summaries report the visible trace context
+the Route Insights and Recent Trace Paths summaries report the visible trace context
 count, busiest context by recent traced deliveries, distinct visible trace ids,
 widest visible trace id by path count, and busiest visible trace message,
 target, and trace path plus each one's trace-path delivery share. The Message

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -266,8 +266,9 @@ context identity and recent component- and registration-scoped call sites.
 `contextId` is the captured Unity instance ID for a source or target; `0` means
 that the route has no specific source or target context. These IDs distinguish
 same-named objects inside one capture, but they are local to the running Unity
-session and are not durable identifiers. Trace-path rows use the same
-`contextId` convention.
+session and are not durable identifiers. If the Unity context object was
+destroyed after registration, the graph preserves the route and displays
+`Instance <id>`. Trace-path rows use the same `contextId` convention.
 
 Trace paths are recent evidence aggregates built from token-side delivery
 records that carry a positive `traceId`. They group by concrete delivered

--- a/progress/session-187-flow-graph-clarity.md
+++ b/progress/session-187-flow-graph-clarity.md
@@ -128,3 +128,17 @@ Play entries when Unity disables domain and scene reload.
   contract across supported Unity versions.
 - Full Node.js script suite: **406 passed / 0 failed**; `npm run validate:all`,
   all pre-commit hooks, markdownlint, and `git diff --check` passed.
+- Final PR-head CI passed every applicable check, including all nine Unity
+  2021.3, 2022.3, and 6000.3 EditMode, PlayMode, and standalone legs, the
+  performance workflow, and the static aggregate gate.
+- A later Cursor review found that route selection and layout identity included
+  the mutable context display label. Stable identities now use message,
+  receiver, route kind, and context ID only; connection signature generation
+  also canonicalizes input by those stable fields. A two-route regression
+  reverses the labels' lexical order and proves selection, pan, zoom, and layout
+  initialization survive the refresh while the selected route shows its new
+  label.
+- The Unity MCP endpoint remained reachable, but the host editor timed out while
+  servicing the compile-freshness command for the final review correction.
+  CSharpier, `git diff --check`, and `npm run validate:all` passed locally; the
+  pushed Unity matrix supplies the fresh-assembly result for this correction.

--- a/progress/session-187-flow-graph-clarity.md
+++ b/progress/session-187-flow-graph-clarity.md
@@ -121,5 +121,10 @@ Play entries when Unity disables domain and scene reload.
   remained healthy. The result above is the completed post-recompile run; no
   timeout, retry policy, or production behavior changed to mask the host-runner
   condition.
+- The first final-head Unity 2021.3 EditMode run exposed an NUnit compatibility
+  error in the destroyed-context regression: `Has.Count` reflects a `Count`
+  property that arrays do not expose on that runner. The assertion now compares
+  the `IReadOnlyList.Count` value directly, preserving the same exact-one-route
+  contract across supported Unity versions.
 - Full Node.js script suite: **406 passed / 0 failed**; `npm run validate:all`,
   all pre-commit hooks, markdownlint, and `git diff --check` passed.

--- a/progress/session-187-flow-graph-clarity.md
+++ b/progress/session-187-flow-graph-clarity.md
@@ -13,6 +13,18 @@ live route edges on a pannable, zoomable, automatically framed canvas. Selection
 opens focused details below the graph. Route reports, overflow rows, trace
 activity, and raw topology now live inside one collapsed analysis section.
 
+The canvas now expresses routing semantics without labeling every line. A
+crossing-aware layered layout orders both columns and each node's ports, while
+arrowheads carry direction. Message and receiver nodes show named metrics rather
+than `+N` shorthand. Targeted and broadcast route inspectors expose recent
+component- and registration-exact delivery call sites without claiming the
+target-aware API also supplied a sender object. Untargeted messages read as
+global, and
+`GlobalAcceptAll` registrations render as `GLOBAL OBSERVER / ANY MESSAGE`
+instead of a fake `IMessage` message node. Route selection now opens responsive
+route, activity, emission-evidence, and trace-evidence cards; the dense
+technical report starts collapsed.
+
 An empty live capture now gives recovery steps instead of rendering component
 and message rows whose route counts are all zero. The Diagnostics Tooling
 Exerciser also rebuilds receiver registrations and restarts its deterministic
@@ -24,9 +36,17 @@ Play entries when Unity disables domain and scene reload.
 - Every filtered message, receiver, and registration route appears on the
   primary graph canvas; message-type overflow is navigated by pan and zoom, not
   rendered as a text list.
-- Message nodes stay in the left column, receiver nodes stay in the right
-  column, and receiver ordering reduces crossings by following connected
-  message positions.
+- Message nodes stay in the left column and receiver nodes stay in the right.
+  Alternating barycentric sweeps reduce crossings, and opposite-layer order
+  determines each node's port order.
+- Arrowheads carry direction. Lines have no text labels; small route-kind shapes
+  provide 30-pixel mouse and keyboard-focus targets without covering the paths.
+- Nodes use named metrics and ellipsis-safe values, never `+N` shorthand.
+- Selected routes use responsive cards and rows. Dense technical diagnostics
+  start inside a collapsed foldout.
+- Recent diagnostics associate emitting script/method call sites with matching
+  broadcast-source and targeted-recipient routes. The graph does not infer a
+  sender object that targeted emission APIs do not carry.
 - The textual route map, its overflow rows, Route Insights, Trace Activity, and
   Topology Details start inside the collapsed **Analysis and Raw Data** section.
 - Components or messages without captured routes produce an actionable empty
@@ -49,11 +69,14 @@ Play entries when Unity disables domain and scene reload.
 - Live sample science on Unity 6000.4.6f1 across two reload-disabled Play
   entries: sequence 3, 3 components, 4 messages, 15 routes, 33 trace paths, 99
   calls, concrete default selection, and all advanced analysis collapsed.
-- Live graph layout science on Unity 6000.4.6f1: a 1145 x 520 canvas rendered 4
-  message nodes at x=60, 3 receiver nodes at x=680, and all 15 connections at
-  an automatically fitted 0.836 zoom. Parallel `ToolingSignal` routes to the
-  same receiver produced distinct markers at y=291 and y=334. The analysis
-  foldout remained collapsed.
+- Live graph layout science on Unity 6000.4.6f1 rendered 4 message nodes, 3
+  receiver nodes, and all 15 connections. Routes carried 0 text labels; nodes
+  rendered 24 named metrics and 0 `+N` summaries. Selecting a live route opened
+  4 structured sections and 5 activity tiles with technical diagnostics
+  collapsed. Each route retained a 30 x 30 canvas hit target; the 0.8 readable
+  zoom floor keeps it at least 24 x 24 screen pixels.
+- Constrained-window science at 640 x 900 measured 0 horizontal section
+  overflows and 0 route-endpoint overflows inside the 603-pixel details pane.
 - Same-Play deactivate/reactivate science restarted the canceled runner and
   repopulated all 15 routes and 33 trace paths. The following Play entry reset
   the sample to sequence 3 and 99 calls.
@@ -64,7 +87,8 @@ Play entries when Unity disables domain and scene reload.
 - Adversarial review covered lifecycle recovery, reset semantics, foldout
   persistence, parallel-route geometry, viewport preservation, large-graph
   framing, complete borders, Unity 2021.3 compatibility, documentation,
-  formatting, and bloat. The final pass reported zero findings.
+  formatting, and bloat. The final readability-overhaul pass reported zero
+  actionable findings.
 - Pull request CI ran the standalone IL2CPP performance suite with **408 total / 346
   passed / 0 failed / 62 skipped** and reported no measured regression.
 - Unity 2021.3 EditMode exposed a fixture teardown gap after the new viewport
@@ -74,3 +98,16 @@ Play entries when Unity disables domain and scene reload.
   suppression at teardown start, matching the existing editor-window fixtures.
   The freshly compiled focused fixture passed **140 / 140**, and the full Editor
   assembly passed **583 / 583** after the correction.
+- Final semantic-route fixture on Unity 6000.4.6f1: **143 passed / 0 failed**.
+- Final full Editor assembly after the semantic-route changes: **586 passed / 0
+  failed**.
+- Readability-overhaul Flow Graph fixture on the freshly reloaded Unity
+  6000.4.6f1 assembly: **150 passed / 0 failed**. This includes crossing-aware
+  layer ordering, staggered crossing selectors, the 0.8 readable zoom floor,
+  named and filter-scoped node metrics, mixed-kind filtering, structured route
+  cards, visible keyboard focus, exact context identity, and component- and
+  registration-exact target evidence isolation.
+- Full `WallstopStudios.DxMessaging.Tests.Editor` assembly after the readability
+  overhaul: **594 passed / 0 failed**.
+- Full Node.js script suite: **406 passed / 0 failed**; `npm run validate:all`,
+  all pre-commit hooks, markdownlint, and `git diff --check` passed.

--- a/progress/session-187-flow-graph-clarity.md
+++ b/progress/session-187-flow-graph-clarity.md
@@ -2,16 +2,16 @@
 
 Date: 2026-08-02
 Branch: `dev/wallstop/session-187-flow-graph-clarity`
-PR: pending
+PR: [#347](https://github.com/Ambiguous-Interactive/DxMessaging/pull/347)
 Issue: [#345](https://github.com/Ambiguous-Interactive/DxMessaging/issues/345)
 
 ## Outcome
 
-This session changed Flow Graph from a dense analytics report into a route-first
-inspection surface. It now selects a concrete route on first open, keeps the
-first eight routes visible, moves overflow routes into a collapsed section, and
-puts route insights, trace activity, and raw topology behind collapsed sections.
-The route header gives the immediate route, message, receiver, and call totals.
+This session changed Flow Graph from a dense analytics report into an
+interactive node-and-edge graph. Message nodes connect to receiver nodes through
+live route edges on a pannable, zoomable, automatically framed canvas. Selection
+opens focused details below the graph. Route reports, overflow rows, trace
+activity, and raw topology now live inside one collapsed analysis section.
 
 An empty live capture now gives recovery steps instead of rendering component
 and message rows whose route counts are all zero. The Diagnostics Tooling
@@ -21,12 +21,14 @@ Play entries when Unity disables domain and scene reload.
 
 ## Contract updates
 
-- Concrete registration routes sort before `GlobalAcceptAll` routes. Calls,
-  recent traced deliveries, names, paths, ids, and registration type provide a
-  deterministic order within that split.
-- The route map shows eight routes before moving the remainder into a collapsed
-  overflow section. Selecting an overflow route expands that section.
-- Route Insights, Trace Activity, and Topology Details start collapsed.
+- Every filtered message, receiver, and registration route appears on the
+  primary graph canvas; message-type overflow is navigated by pan and zoom, not
+  rendered as a text list.
+- Message nodes stay in the left column, receiver nodes stay in the right
+  column, and receiver ordering reduces crossings by following connected
+  message positions.
+- The textual route map, its overflow rows, Route Insights, Trace Activity, and
+  Topology Details start inside the collapsed **Analysis and Raw Data** section.
 - Components or messages without captured routes produce an actionable empty
   state and no zero-value topology wall.
 - Each active receiver releases a token from the previous Play generation and
@@ -37,16 +39,21 @@ Play entries when Unity disables domain and scene reload.
 
 ## Validation
 
-- Focused Flow Graph and sample contract fixtures: **143 passed / 0 failed**.
+- Focused Flow Graph and sample contract fixtures: **145 passed / 0 failed**.
 - Stale-token reset and re-registration fixture: **7 passed / 0 failed**.
-- Full `WallstopStudios.DxMessaging.Tests.Editor` assembly: **580 passed / 0
-  failed** twice back-to-back.
+- Full `WallstopStudios.DxMessaging.Tests.Editor` assembly: **582 passed / 0
+  failed** twice back-to-back, then **583 passed / 0 failed** after the final
+  degenerate-mesh regression test.
 - Full `WallstopStudios.DxMessaging.Tests.Runtime` assembly: **984 passed / 0
   failed** twice back-to-back.
 - Live sample science on Unity 6000.4.6f1 across two reload-disabled Play
   entries: sequence 3, 3 components, 4 messages, 15 routes, 33 trace paths, 99
-  calls, concrete default selection, 7 collapsed overflow routes, and all three
-  advanced sections collapsed.
+  calls, concrete default selection, and all advanced analysis collapsed.
+- Live graph layout science on Unity 6000.4.6f1: a 1145 x 520 canvas rendered 4
+  message nodes at x=60, 3 receiver nodes at x=680, and all 15 connections at
+  an automatically fitted 0.836 zoom. Parallel `ToolingSignal` routes to the
+  same receiver produced distinct markers at y=291 and y=334. The analysis
+  foldout remained collapsed.
 - Same-Play deactivate/reactivate science restarted the canceled runner and
   repopulated all 15 routes and 33 trace paths. The following Play entry reset
   the sample to sequence 3 and 99 calls.
@@ -54,6 +61,7 @@ Play entries when Unity disables domain and scene reload.
 - Full Node.js script suite: **406 passed / 0 failed**.
 - Documentation sample compilation, CSharpier, Prettier, markdownlint,
   spelling, `npm run validate:all`, ASCII checks, and `git diff --check` passed.
-- Four adversarial review rounds covered lifecycle recovery, reset semantics,
-  foldout persistence, test cleanup, Unity 2021.3 compatibility, documentation,
-  formatting, and bloat. The final review reported zero findings.
+- Adversarial review covered lifecycle recovery, reset semantics, foldout
+  persistence, parallel-route geometry, viewport preservation, large-graph
+  framing, complete borders, Unity 2021.3 compatibility, documentation,
+  formatting, and bloat. The final pass reported zero findings.

--- a/progress/session-187-flow-graph-clarity.md
+++ b/progress/session-187-flow-graph-clarity.md
@@ -102,12 +102,24 @@ Play entries when Unity disables domain and scene reload.
 - Final full Editor assembly after the semantic-route changes: **586 passed / 0
   failed**.
 - Readability-overhaul Flow Graph fixture on the freshly reloaded Unity
-  6000.4.6f1 assembly: **150 passed / 0 failed**. This includes crossing-aware
+  6000.4.6f1 assembly: **151 passed / 0 failed**. This includes crossing-aware
   layer ordering, staggered crossing selectors, the 0.8 readable zoom floor,
   named and filter-scoped node metrics, mixed-kind filtering, structured route
   cards, visible keyboard focus, exact context identity, and component- and
-  registration-exact target evidence isolation.
+  registration-exact target evidence isolation. It also covers a destroyed
+  Unity context object retaining its route through the stable instance ID.
 - Full `WallstopStudios.DxMessaging.Tests.Editor` assembly after the readability
-  overhaul: **594 passed / 0 failed**.
+  overhaul and destroyed-context review correction: **595 passed / 0 failed**.
+- Destroyed-reflexive-target regression on the freshly compiled Runtime
+  assembly: **2 passed / 0 failed**, covering both `GameObject` and `Component`
+  fake-null references. The post-review test also asserts that skipping Unity
+  hierarchy delivery does not suppress normal targeted bus handlers; the stale
+  host queue blocked its local rerun, so the PR Runtime matrix carries that
+  extended assertion.
+- A redundant immediately following MCP run left its status sidecar at
+  `running` and stopped servicing editor commands while `unity:mcp:probe`
+  remained healthy. The result above is the completed post-recompile run; no
+  timeout, retry policy, or production behavior changed to mask the host-runner
+  condition.
 - Full Node.js script suite: **406 passed / 0 failed**; `npm run validate:all`,
   all pre-commit hooks, markdownlint, and `git diff --check` passed.

--- a/progress/session-187-flow-graph-clarity.md
+++ b/progress/session-187-flow-graph-clarity.md
@@ -65,3 +65,12 @@ Play entries when Unity disables domain and scene reload.
   persistence, parallel-route geometry, viewport preservation, large-graph
   framing, complete borders, Unity 2021.3 compatibility, documentation,
   formatting, and bloat. The final pass reported zero findings.
+- Pull request CI ran the standalone IL2CPP performance suite with **408 total / 346
+  passed / 0 failed / 62 skipped** and reported no measured regression.
+- Unity 2021.3 EditMode exposed a fixture teardown gap after the new viewport
+  interaction test opened a host window: the test assertions passed, but closing
+  the window under `-nographics` emitted Unity's benign no-graphics error in the
+  separate teardown phase. The fixture now reapplies the shared headless-only log
+  suppression at teardown start, matching the existing editor-window fixtures.
+  The freshly compiled focused fixture passed **140 / 140**, and the full Editor
+  assembly passed **583 / 583** after the correction.

--- a/progress/session-187-flow-graph-clarity.md
+++ b/progress/session-187-flow-graph-clarity.md
@@ -1,0 +1,59 @@
+# Session 187 -- Flow Graph clarity and sample recovery
+
+Date: 2026-08-02
+Branch: `dev/wallstop/session-187-flow-graph-clarity`
+PR: pending
+Issue: [#345](https://github.com/Ambiguous-Interactive/DxMessaging/issues/345)
+
+## Outcome
+
+This session changed Flow Graph from a dense analytics report into a route-first
+inspection surface. It now selects a concrete route on first open, keeps the
+first eight routes visible, moves overflow routes into a collapsed section, and
+puts route insights, trace activity, and raw topology behind collapsed sections.
+The route header gives the immediate route, message, receiver, and call totals.
+
+An empty live capture now gives recovery steps instead of rendering component
+and message rows whose route counts are all zero. The Diagnostics Tooling
+Exerciser also rebuilds receiver registrations and restarts its deterministic
+burst after the initial scene load and from `OnEnable`, including consecutive
+Play entries when Unity disables domain and scene reload.
+
+## Contract updates
+
+- Concrete registration routes sort before `GlobalAcceptAll` routes. Calls,
+  recent traced deliveries, names, paths, ids, and registration type provide a
+  deterministic order within that split.
+- The route map shows eight routes before moving the remainder into a collapsed
+  overflow section. Selecting an overflow route expands that section.
+- Route Insights, Trace Activity, and Topology Details start collapsed.
+- Components or messages without captured routes produce an actionable empty
+  state and no zero-value topology wall.
+- Each active receiver releases a token from the previous Play generation and
+  creates a new one before replaying registrations. Active receivers force this
+  replay after the initial scene load so a stale enabled flag cannot suppress
+  recovery. A per-activation guard starts one sequence when `OnEnable` and the
+  post-scene-load callback both observe the same activation.
+
+## Validation
+
+- Focused Flow Graph and sample contract fixtures: **143 passed / 0 failed**.
+- Stale-token reset and re-registration fixture: **7 passed / 0 failed**.
+- Full `WallstopStudios.DxMessaging.Tests.Editor` assembly: **580 passed / 0
+  failed** twice back-to-back.
+- Full `WallstopStudios.DxMessaging.Tests.Runtime` assembly: **984 passed / 0
+  failed** twice back-to-back.
+- Live sample science on Unity 6000.4.6f1 across two reload-disabled Play
+  entries: sequence 3, 3 components, 4 messages, 15 routes, 33 trace paths, 99
+  calls, concrete default selection, 7 collapsed overflow routes, and all three
+  advanced sections collapsed.
+- Same-Play deactivate/reactivate science restarted the canceled runner and
+  repopulated all 15 routes and 33 trace paths. The following Play entry reset
+  the sample to sequence 3 and 99 calls.
+- Unity Console: **0 errors / 0 warnings** after the live verification.
+- Full Node.js script suite: **406 passed / 0 failed**.
+- Documentation sample compilation, CSharpier, Prettier, markdownlint,
+  spelling, `npm run validate:all`, ASCII checks, and `git diff --check` passed.
+- Four adversarial review rounds covered lifecycle recovery, reset semantics,
+  foldout persistence, test cleanup, Unity 2021.3 compatibility, documentation,
+  formatting, and bloat. The final review reported zero findings.

--- a/progress/session-187-flow-graph-clarity.md.meta
+++ b/progress/session-187-flow-graph-clarity.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b0e0979c2682051e6ce8facf16659a05
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

- replace the Flow Graph's text-first report with a hand-built UI Toolkit node-and-edge canvas
- render message nodes, receiver nodes, colored bezier routes, arrowheads, and distinct parallel-route hit targets
- support pan, zoom, dynamic framing for large graphs, focused selection, and viewport preservation across inspection updates
- move route rows, message/target lanes, trace analytics, topology, and overflow text into one collapsed analysis section
- make the diagnostics sample recover registrations when Enter Play Mode disables domain and scene reloads
- add editor, runtime, sample-contract, documentation, changelog, and live-science coverage

## Root cause

The Flow Graph presented topology as dense rows and analytics, so it did not render the visual graph its name promised. The revised primary surface is an actual graph: all filtered messages occupy the left column, receivers occupy the right column, and every route is drawn between them. Parallel registration kinds receive separate geometry and selectable markers rather than painting over one another.

The sample had a separate reload-disabled lifecycle gap: the bus could reset while a persisted token still reported `Enabled`, so trusting that flag left receivers detached. Startup now deliberately replaces cached registration state and activation remains idempotent.

## Validation

- focused Flow Graph fixture: 151 passed, 0 failed
- full Editor assembly: 595 passed, 0 failed
- runtime re-registration fixture: 7 passed, 0 failed
- full Runtime assembly: 984 passed, 0 failed (before the destroyed-target review correction)
- destroyed-target Runtime regression: 2 passed, 0 failed across destroyed `GameObject` and `Component` contexts; the extended handler-continuation assertion is covered by the PR Runtime matrix
- script suite: 406 passed, 0 failed
- live graph: 4 message nodes, 3 receiver nodes, 15 routes, 24 named node metrics, 0 edge text labels, and 0 `+N` summaries
- constrained 640 x 900 layout: 0 section overflows and 0 route-endpoint overflows
- selected route: 4 responsive evidence sections and 5 activity tiles; technical diagnostics collapsed
- live reload-disabled Play Mode, twice: 3 components, 4 messages, 15 routes, 33 trace paths, 99 calls each run
- exact component/registration delivery evidence, mixed-kind filtering, keyboard focus, and 0.8 readable zoom floor covered
- documentation compilation: 441 passed, 0 failed
- strict documentation build, `npm run validate:all`, all pre-commit hooks, CSharpier, Prettier, markdownlint, spelling, and `git diff --check`: passed
- final independent adversarial review: zero actionable findings

Closes #345
Supports #346 without closing its broader sample-demo scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large editor UI refactor plus a small runtime messaging path change; sample lifecycle is sample-scoped; core bus behavior for valid targets is unchanged.
> 
> **Overview**
> The **Flow Graph** window now leads with a **live route canvas**: message nodes on the left, receiver nodes on the right, colored curved edges with arrowheads, pan/zoom, auto-framing, and selectable nodes/connections. Dense route maps, trace lanes, topology lists, and overflow routes move into a collapsed **Analysis and Raw Data** section; empty states explain how to restore live routes when nothing is captured.
> 
> Capture and UI semantics improve alongside the canvas: **global accept-all** registrations appear as **`ANY MESSAGE`** observers; destroyed Unity contexts fall back to stable instance IDs instead of failing capture; edges include **context** and **registration-exact recent emission sites**; selection opens responsive route/activity/emission/trace cards with technical diagnostics collapsed by default. Export schema bumps to v6 with message kinds, contexts, and emission sites.
> 
> **Runtime:** reflexive dispatch to a destroyed `GameObject`/`Component` skips hierarchy delivery instead of throwing `MissingReferenceException`; normal targeted handlers still run.
> 
> **Diagnostics Tooling Exerciser:** runner and receivers rebuild tokens and restart deterministic emissions on each play activation via `RuntimeInitializeOnLoad` and idempotent `OnEnable`, fixing lost registrations when Enter Play Mode disables domain/scene reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61e07e1a4b841cdb2e41fceef414b162f4b43429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->