### PR TITLE
Make Flow Graph routes inspectable at scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   each assembly source file is read once, while exact nested and generic source
   links continue to appear when the index completes
   ([#345](https://github.com/Ambiguous-Interactive/DxMessaging/issues/345)).
+- Keep a selected Flow Graph route and its marker above dimmed paths at crossings
+  so the highlighted route remains visible and wins overlapping clicks
+  ([#345](https://github.com/Ambiguous-Interactive/DxMessaging/issues/345)).
 - Reflexive message dispatch to a destroyed `GameObject` or `Component` target
   now skips Unity hierarchy delivery instead of throwing
   `MissingReferenceException`; normal targeted bus handlers still run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix Flow Graph message-source links stalling the editor while scanning large
+  compilation assemblies. Source declarations now index in the background and
+  each assembly source file is read once, while exact nested and generic source
+  links continue to appear when the index completes
+  ([#345](https://github.com/Ambiguous-Interactive/DxMessaging/issues/345)).
 - Reflexive message dispatch to a destroyed `GameObject` or `Component` target
   now skips Unity hierarchy delivery instead of throwing
   `MissingReferenceException`; normal targeted bus handlers still run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   leaking evidence across message buses. Global accept-all
   registrations appear as `ANY MESSAGE` observers instead of a misleading
   `IMessage` message type. Destroyed Unity context references fall back to their
-  stable instance ID instead of aborting capture for that component
+  stable instance ID instead of aborting capture for that component. Follow-up
+  interaction work makes the full feathered route path clickable, dims unrelated
+  paths after selection, adds explicit fit and zoom controls with a 20 percent
+  overview floor, and removes the automatic default selection. Route activity
+  now leads while emission, trace, and technical evidence start collapsed.
+  Message and call-site source links open the exact declaration or captured
+  line when Unity can resolve it. Dense many-to-many coverage keeps hundreds of
+  crossing routes present and selectable in constrained layouts
   ([#345](https://github.com/Ambiguous-Interactive/DxMessaging/issues/345)).
 - Improve targeted and source-bound broadcast routing throughput and reduce the
   memory retained by their per-target lookup tables without changing the public

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -4,8 +4,10 @@ namespace DxMessaging.Editor.Windows
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.IO;
     using System.Linq;
     using System.Text;
+    using System.Text.RegularExpressions;
     using Core;
     using Core.Diagnostics;
     using Core.Messages;
@@ -13,6 +15,7 @@ namespace DxMessaging.Editor.Windows
     using DxMessaging.Editor.Testing;
     using DxMessaging.Unity;
     using UnityEditor;
+    using UnityEditor.Compilation;
     using UnityEditor.SceneManagement;
     using UnityEngine;
     using UnityEngine.UIElements;
@@ -29,7 +32,14 @@ namespace DxMessaging.Editor.Windows
         internal const string EmptyStateLabelName = "dxmessaging-flow-graph-empty";
         internal const string EmptyStateTitleLabelName = "dxmessaging-flow-graph-empty-title";
         internal const string GraphCanvasName = "dxmessaging-flow-graph-canvas";
+        internal const string GraphEdgeLayerName = "dxmessaging-flow-graph-edge-layer";
+        internal const string GraphZoomOutButtonName = "dxmessaging-flow-graph-zoom-out";
+        internal const string GraphFitButtonName = "dxmessaging-flow-graph-fit";
+        internal const string GraphZoomInButtonName = "dxmessaging-flow-graph-zoom-in";
+        internal const string GraphZoomLabelName = "dxmessaging-flow-graph-zoom-label";
         internal const string GraphLegendName = "dxmessaging-flow-graph-legend";
+        internal const string GraphInteractionHintName = "dxmessaging-flow-graph-interaction-hint";
+        internal const string GraphZoomControlsName = "dxmessaging-flow-graph-zoom-controls";
         internal const string GraphMessageNodeClassName = "dxmessaging-flow-graph-canvas-message";
         internal const string GraphReceiverNodeClassName = "dxmessaging-flow-graph-canvas-receiver";
         internal const string GraphConnectionClassName = "dxmessaging-flow-graph-canvas-connection";
@@ -164,6 +174,9 @@ namespace DxMessaging.Editor.Windows
         internal const string DetailsMetricClassName = "dxmessaging-flow-graph-details-metric";
         internal const string DetailsTechnicalFoldoutName =
             "dxmessaging-flow-graph-details-technical";
+        internal const string DetailsEvidenceFoldoutName =
+            "dxmessaging-flow-graph-details-evidence";
+        internal const string SourceLinkButtonName = "dxmessaging-flow-graph-source-link";
         internal const string GraphNodeMetricClassName = "dxmessaging-flow-graph-node-metric";
         internal const string WarningLabelName = "dxmessaging-flow-graph-warning";
         internal const string GlobalObserverMessageName = "ANY MESSAGE";
@@ -174,6 +187,9 @@ namespace DxMessaging.Editor.Windows
         private const float GraphNodeHeight = 132f;
         private const float GraphNodeGap = 42f;
         private const float GraphCanvasHeight = 520f;
+        private const float GraphMinimumZoom = 0.2f;
+        private const float GraphMaximumZoom = 2f;
+        private const float GraphRouteHitRadius = 10f;
         private const int ExportSchemaVersion = 6;
         private const string ExportCaptureMode = "registration-topology-with-recent-diagnostics";
         private const string ExportTraceSemantics =
@@ -304,21 +320,39 @@ namespace DxMessaging.Editor.Windows
             internal float Zoom = 1f;
         }
 
-        private readonly struct GraphCurveDescriptor
+        internal readonly struct FlowGraphSourceLocation
+        {
+            internal FlowGraphSourceLocation(string assetPath, int line)
+            {
+                AssetPath = assetPath ?? string.Empty;
+                Line = Math.Max(1, line);
+            }
+
+            internal string AssetPath { get; }
+
+            internal int Line { get; }
+
+            internal bool IsValid => !string.IsNullOrWhiteSpace(AssetPath);
+        }
+
+        internal readonly struct GraphCurveDescriptor
         {
             internal GraphCurveDescriptor(
                 Vector2 start,
                 Vector2 end,
                 float curveOffset,
                 Color color,
-                bool selected
+                bool selected,
+                string selectionKey = "",
+                bool dimmed = false
             )
             {
                 Start = start;
                 End = end;
                 CurveOffset = curveOffset;
-                Color = color;
+                Color = dimmed ? new Color(color.r, color.g, color.b, color.a * 0.18f) : color;
                 Selected = selected;
+                SelectionKey = selectionKey ?? string.Empty;
             }
 
             internal Vector2 Start { get; }
@@ -330,6 +364,8 @@ namespace DxMessaging.Editor.Windows
             internal Color Color { get; }
 
             internal bool Selected { get; }
+
+            internal string SelectionKey { get; }
 
             internal Vector2 Evaluate(float t)
             {
@@ -344,16 +380,68 @@ namespace DxMessaging.Editor.Windows
             }
         }
 
+        private enum SourceScopeKind
+        {
+            Namespace,
+            Type,
+        }
+
+        private readonly struct SourceScope
+        {
+            internal SourceScope(SourceScopeKind kind, string name, int bodyDepth)
+            {
+                Kind = kind;
+                Name = name ?? string.Empty;
+                BodyDepth = bodyDepth;
+            }
+
+            internal SourceScopeKind Kind { get; }
+
+            internal string Name { get; }
+
+            internal int BodyDepth { get; }
+        }
+
         private sealed class FlowGraphEdgeLayer : VisualElement
         {
             private const int SegmentCount = 28;
             private readonly IReadOnlyList<GraphCurveDescriptor> _curves;
 
-            internal FlowGraphEdgeLayer(IReadOnlyList<GraphCurveDescriptor> curves)
+            internal FlowGraphEdgeLayer(
+                IReadOnlyList<GraphCurveDescriptor> curves,
+                Action<string> onSelectionChanged
+            )
             {
                 _curves = curves ?? throw new ArgumentNullException(nameof(curves));
-                pickingMode = PickingMode.Ignore;
+                name = GraphEdgeLayerName;
+                pickingMode =
+                    onSelectionChanged == null ? PickingMode.Ignore : PickingMode.Position;
                 generateVisualContent += DrawConnections;
+                if (onSelectionChanged != null)
+                {
+                    RegisterCallback<MouseDownEvent>(evt =>
+                    {
+                        if (evt.button != 0)
+                        {
+                            return;
+                        }
+
+                        string selectionKey = FindGraphRouteAtPoint(
+                            _curves,
+                            evt.localMousePosition,
+                            CalculateLocalGraphRouteHitRadius(
+                                worldTransform.MultiplyVector(Vector3.right).magnitude
+                            )
+                        );
+                        if (string.IsNullOrWhiteSpace(selectionKey))
+                        {
+                            return;
+                        }
+
+                        evt.StopPropagation();
+                        onSelectionChanged.Invoke(selectionKey);
+                    });
+                }
             }
 
             private void DrawConnections(MeshGenerationContext context)
@@ -372,12 +460,27 @@ namespace DxMessaging.Editor.Windows
                 const int arrowVertexCount = 3;
                 const int arrowIndexCount = 3;
                 MeshWriteData mesh = context.Allocate(
-                    SegmentCount * 4 + arrowVertexCount,
-                    SegmentCount * 6 + arrowIndexCount
+                    SegmentCount * 8 + arrowVertexCount,
+                    SegmentCount * 12 + arrowIndexCount
                 );
                 float width = curve.Selected ? 4f : 2.5f;
                 ushort vertexIndex = 0;
                 Vector2 previous = curve.Evaluate(0f);
+                for (int segment = 1; segment <= SegmentCount; segment++)
+                {
+                    Vector2 next = curve.Evaluate(segment / (float)SegmentCount);
+                    AddSegment(
+                        mesh,
+                        previous,
+                        next,
+                        width + 3f,
+                        CreateGraphFeatherColor(curve.Color),
+                        ref vertexIndex
+                    );
+                    previous = next;
+                }
+
+                previous = curve.Evaluate(0f);
                 for (int segment = 1; segment <= SegmentCount; segment++)
                 {
                     Vector2 next = curve.Evaluate(segment / (float)SegmentCount);
@@ -445,14 +548,96 @@ namespace DxMessaging.Editor.Windows
             }
         }
 
+        internal static Color CreateGraphFeatherColor(Color color)
+        {
+            return new Color(color.r, color.g, color.b, color.a * 0.22f);
+        }
+
         internal static Vector2 NormalizeGraphDirection(Vector2 direction)
         {
             return direction.sqrMagnitude <= Mathf.Epsilon ? Vector2.right : direction.normalized;
         }
 
+        internal static string FindGraphRouteAtPoint(
+            IReadOnlyList<GraphCurveDescriptor> curves,
+            Vector2 point,
+            float hitRadius
+        )
+        {
+            if (curves == null || curves.Count == 0 || hitRadius <= 0f)
+            {
+                return string.Empty;
+            }
+
+            const int sampleCount = 28;
+            float nearestSquaredDistance = hitRadius * hitRadius;
+            string nearestSelectionKey = string.Empty;
+            for (int curveIndex = curves.Count - 1; curveIndex >= 0; curveIndex--)
+            {
+                GraphCurveDescriptor curve = curves[curveIndex];
+                if (string.IsNullOrWhiteSpace(curve.SelectionKey))
+                {
+                    continue;
+                }
+
+                Vector2 previous = curve.Evaluate(0f);
+                for (int sample = 1; sample <= sampleCount; sample++)
+                {
+                    Vector2 next = curve.Evaluate(sample / (float)sampleCount);
+                    float squaredDistance = DistanceToGraphSegmentSquared(point, previous, next);
+                    if (squaredDistance < nearestSquaredDistance)
+                    {
+                        nearestSquaredDistance = squaredDistance;
+                        nearestSelectionKey = curve.SelectionKey;
+                    }
+                    previous = next;
+                }
+            }
+            return nearestSelectionKey;
+        }
+
+        internal static float CalculateLocalGraphRouteHitRadius(float worldScale)
+        {
+            return worldScale <= Mathf.Epsilon
+                ? GraphRouteHitRadius
+                : GraphRouteHitRadius / worldScale;
+        }
+
+        private static float DistanceToGraphSegmentSquared(
+            Vector2 point,
+            Vector2 segmentStart,
+            Vector2 segmentEnd
+        )
+        {
+            Vector2 segment = segmentEnd - segmentStart;
+            float lengthSquared = segment.sqrMagnitude;
+            if (lengthSquared <= Mathf.Epsilon)
+            {
+                return (point - segmentStart).sqrMagnitude;
+            }
+
+            float position = Mathf.Clamp01(
+                Vector2.Dot(point - segmentStart, segment) / lengthSquared
+            );
+            Vector2 closest = segmentStart + segment * position;
+            return (point - closest).sqrMagnitude;
+        }
+
         private string _filterText = string.Empty;
         private string _selectedItemKey = string.Empty;
         private FlowGraphSnapshot _currentSnapshot = FlowGraphSnapshot.Empty;
+        private static readonly Dictionary<
+            string,
+            FlowGraphSourceLocation
+        > MessageSourceLocationCache = new(StringComparer.Ordinal);
+        private static readonly Regex SourceNamespaceDeclarationPattern = new(
+            @"^\s*namespace\s+([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\s*([;{]?)",
+            RegexOptions.CultureInvariant
+        );
+        private static readonly Regex SourceTypeDeclarationPattern = new(
+            @"^\s*(?:\[[^\]\r\n]+\]\s*)*(?:(?:public|internal|protected|private|abstract|sealed|static|partial|readonly|ref|unsafe|new|file)\s+)*(?:(?:record(?:\s+(?:class|struct))?)|class|struct|interface|enum)\s+(@?[A-Za-z_][A-Za-z0-9_]*)\b",
+            RegexOptions.CultureInvariant
+        );
 
         [MenuItem("Tools/Wallstop Studios/DxMessaging/Flow Graph")]
         public static void Open()
@@ -2176,6 +2361,7 @@ namespace DxMessaging.Editor.Windows
 
             VisualElement legend = new() { name = GraphLegendName };
             legend.style.flexDirection = FlexDirection.Row;
+            legend.style.flexWrap = Wrap.Wrap;
             legend.style.alignItems = Align.Center;
             legend.style.marginBottom = 6;
 
@@ -2193,10 +2379,34 @@ namespace DxMessaging.Editor.Windows
             legend.Add(CreateGraphLegendBadge("TARGETED", DxMessagingEditorPalette.Targeted));
             legend.Add(CreateGraphLegendBadge("GLOBAL", DxMessagingEditorPalette.Untargeted));
 
-            Label controls = new("Drag empty space to pan | Scroll to zoom | Select to inspect");
+            Label controls = new("Click a route or node to inspect. Drag empty space to pan.")
+            {
+                name = GraphInteractionHintName,
+            };
             controls.style.flexGrow = 1;
+            controls.style.flexBasis = 260;
+            controls.style.minWidth = 220;
+            controls.style.marginTop = 4;
+            controls.style.whiteSpace = WhiteSpace.Normal;
             controls.style.unityTextAlign = TextAnchor.MiddleRight;
             legend.Add(controls);
+            VisualElement zoomControls = new() { name = GraphZoomControlsName };
+            zoomControls.style.flexDirection = FlexDirection.Row;
+            zoomControls.style.flexShrink = 0;
+            zoomControls.style.alignItems = Align.Center;
+            zoomControls.style.marginLeft = 8;
+            zoomControls.style.marginTop = 4;
+            Button zoomOut = CreateGraphControlButton(GraphZoomOutButtonName, "-", "Zoom out");
+            Button fit = CreateGraphControlButton(GraphFitButtonName, "Fit", "Fit all routes");
+            Button zoomIn = CreateGraphControlButton(GraphZoomInButtonName, "+", "Zoom in");
+            Label zoomLabel = new("100%") { name = GraphZoomLabelName };
+            zoomLabel.style.minWidth = 42;
+            zoomLabel.style.unityTextAlign = TextAnchor.MiddleCenter;
+            zoomControls.Add(zoomOut);
+            zoomControls.Add(fit);
+            zoomControls.Add(zoomIn);
+            zoomControls.Add(zoomLabel);
+            legend.Add(zoomControls);
             panel.Add(legend);
 
             GraphConnectionDescriptor[] connections = CreateGraphConnections(visibleSnapshot);
@@ -2353,6 +2563,7 @@ namespace DxMessaging.Editor.Windows
             viewport.Add(graphContent);
 
             List<GraphCurveDescriptor> curves = new();
+            bool routeIsSelected = selectedItemKey.StartsWith("edge|", StringComparison.Ordinal);
             List<(
                 GraphConnectionDescriptor connection,
                 GraphCurveDescriptor curve,
@@ -2409,6 +2620,11 @@ namespace DxMessaging.Editor.Windows
                     Color edgeColor = connection.TraceOnly
                         ? DxMessagingEditorPalette.Trace
                         : DxMessagingEditorPalette.RouteKindColor(connection.RouteKind);
+                    bool selected = string.Equals(
+                        connection.SelectionKey,
+                        selectedItemKey,
+                        StringComparison.Ordinal
+                    );
                     GraphCurveDescriptor curve = new(
                         new Vector2(
                             messagePosition.x + GraphNodeWidth + 7f,
@@ -2420,11 +2636,9 @@ namespace DxMessaging.Editor.Windows
                         ),
                         curveOffset,
                         edgeColor,
-                        string.Equals(
-                            connection.SelectionKey,
-                            selectedItemKey,
-                            StringComparison.Ordinal
-                        )
+                        selected,
+                        connection.SelectionKey,
+                        dimmed: routeIsSelected && !selected
                     );
                     curves.Add(curve);
                     markers.Add(
@@ -2441,7 +2655,8 @@ namespace DxMessaging.Editor.Windows
                 }
             }
 
-            FlowGraphEdgeLayer edgeLayer = new(curves);
+            FlowGraphEdgeLayer edgeLayer = new(curves, onSelectionChanged);
+            edgeLayer.userData = curves;
             edgeLayer.style.position = Position.Absolute;
             edgeLayer.style.left = 0;
             edgeLayer.style.top = 0;
@@ -2581,10 +2796,28 @@ namespace DxMessaging.Editor.Windows
                 viewport,
                 graphContent,
                 canvasState,
-                new Vector2(contentWidth, graphHeight)
+                new Vector2(contentWidth, graphHeight),
+                zoomOut,
+                fit,
+                zoomIn,
+                zoomLabel
             );
             panel.Add(viewport);
             return panel;
+        }
+
+        private static Button CreateGraphControlButton(string name, string text, string tooltip)
+        {
+            Button button = new()
+            {
+                name = name,
+                text = text,
+                tooltip = tooltip,
+            };
+            button.AddToClassList(DxMessagingEditorTheme.ToolButtonClassName);
+            button.style.minWidth = text.Length == 1 ? 26 : 38;
+            button.style.marginLeft = 2;
+            return button;
         }
 
         private static GraphConnectionDescriptor[] CreateGraphConnections(
@@ -3038,9 +3271,14 @@ namespace DxMessaging.Editor.Windows
             VisualElement viewport,
             VisualElement graphContent,
             FlowGraphCanvasState canvasState,
-            Vector2 contentSize
+            Vector2 contentSize,
+            Button zoomOut,
+            Button fit,
+            Button zoomIn,
+            Label zoomLabel
         )
         {
+            Vector2 viewportSize = Vector2.zero;
             void ApplyTransform()
             {
                 graphContent.transform.position = new Vector3(
@@ -3049,9 +3287,51 @@ namespace DxMessaging.Editor.Windows
                     0f
                 );
                 graphContent.transform.scale = new Vector3(canvasState.Zoom, canvasState.Zoom, 1f);
+                zoomLabel.text = Mathf.RoundToInt(canvasState.Zoom * 100f) + "%";
+            }
+
+            void ZoomAround(Vector2 focus, float nextZoom)
+            {
+                float previousZoom = Math.Max(GraphMinimumZoom, canvasState.Zoom);
+                Vector2 contentCenter = contentSize * 0.5f;
+                Vector2 contentPoint =
+                    (focus - contentCenter - canvasState.Pan) / previousZoom + contentCenter;
+                canvasState.Zoom = Mathf.Clamp(nextZoom, GraphMinimumZoom, GraphMaximumZoom);
+                canvasState.Pan =
+                    focus - contentCenter - (contentPoint - contentCenter) * canvasState.Zoom;
+                canvasState.Initialized = true;
+                ApplyTransform();
+            }
+
+            void FrameGraph()
+            {
+                if (viewportSize.x <= Mathf.Epsilon || viewportSize.y <= Mathf.Epsilon)
+                {
+                    return;
+                }
+
+                canvasState.Zoom = CalculateGraphFrameScale(viewportSize, contentSize);
+                canvasState.Pan = viewportSize * 0.5f - contentSize * 0.5f;
+                canvasState.Initialized = true;
+                ApplyTransform();
             }
 
             ApplyTransform();
+            zoomOut.RegisterCallback<ClickEvent>(evt =>
+            {
+                evt.StopPropagation();
+                ZoomAround(viewportSize * 0.5f, canvasState.Zoom / 1.25f);
+            });
+            fit.RegisterCallback<ClickEvent>(evt =>
+            {
+                evt.StopPropagation();
+                FrameGraph();
+            });
+            zoomIn.RegisterCallback<ClickEvent>(evt =>
+            {
+                evt.StopPropagation();
+                ZoomAround(viewportSize * 0.5f, canvasState.Zoom * 1.25f);
+            });
             bool panning = false;
             Vector2 lastMousePosition = Vector2.zero;
             viewport.RegisterCallback<MouseDownEvent>(evt =>
@@ -3095,40 +3375,25 @@ namespace DxMessaging.Editor.Windows
             });
             viewport.RegisterCallback<WheelEvent>(evt =>
             {
-                float previousZoom = canvasState.Zoom;
                 float zoomFactor = evt.delta.y > 0f ? 0.88f : 1.14f;
-                float nextZoom = Mathf.Clamp(previousZoom * zoomFactor, 0.8f, 2f);
-                Vector2 contentCenter = contentSize * 0.5f;
-                Vector2 mousePosition = evt.localMousePosition;
-                Vector2 contentPoint =
-                    (mousePosition - contentCenter - canvasState.Pan) / previousZoom
-                    + contentCenter;
-                canvasState.Zoom = nextZoom;
-                canvasState.Pan =
-                    mousePosition - contentCenter - (contentPoint - contentCenter) * nextZoom;
-                canvasState.Initialized = true;
-                ApplyTransform();
+                ZoomAround(evt.localMousePosition, canvasState.Zoom * zoomFactor);
                 evt.StopPropagation();
             });
 
-            if (!canvasState.Initialized)
+            EventCallback<GeometryChangedEvent> frameCallback = evt =>
             {
-                EventCallback<GeometryChangedEvent> frameCallback = null;
-                frameCallback = evt =>
+                if (evt.newRect.width <= Mathf.Epsilon || evt.newRect.height <= Mathf.Epsilon)
                 {
-                    if (evt.newRect.width <= Mathf.Epsilon || evt.newRect.height <= Mathf.Epsilon)
-                    {
-                        return;
-                    }
+                    return;
+                }
 
-                    canvasState.Zoom = CalculateGraphFrameScale(evt.newRect.size, contentSize);
-                    canvasState.Pan = evt.newRect.size * 0.5f - contentSize * 0.5f;
-                    canvasState.Initialized = true;
-                    ApplyTransform();
-                    viewport.UnregisterCallback(frameCallback);
-                };
-                viewport.RegisterCallback(frameCallback);
-            }
+                viewportSize = evt.newRect.size;
+                if (!canvasState.Initialized)
+                {
+                    FrameGraph();
+                }
+            };
+            viewport.RegisterCallback(frameCallback);
         }
 
         internal static float CalculateGraphFrameScale(Vector2 viewportSize, Vector2 contentSize)
@@ -3140,7 +3405,7 @@ namespace DxMessaging.Editor.Windows
 
             float horizontalScale = Math.Max(0f, viewportSize.x - 32f) / contentSize.x;
             float verticalScale = Math.Max(0f, viewportSize.y - 32f) / contentSize.y;
-            return Mathf.Clamp(Math.Min(horizontalScale, verticalScale), 0.8f, 1f);
+            return Mathf.Clamp(Math.Min(horizontalScale, verticalScale), GraphMinimumZoom, 1f);
         }
 
         private static string CreateGraphLayoutSignature(
@@ -5883,6 +6148,16 @@ namespace DxMessaging.Editor.Windows
                     )
                 );
             }
+            string messageTypeName =
+                selectedItem.Kind == FlowGraphSelectionKind.Message
+                    ? selectedItem.Message.MessageTypeName
+                : selectedItem.Kind == FlowGraphSelectionKind.Edge
+                    ? selectedItem.Edge.MessageTypeName
+                : string.Empty;
+            if (TryResolveMessageSource(messageTypeName, out FlowGraphSourceLocation messageSource))
+            {
+                header.Add(CreateSourceLinkButton("Open message source", messageSource));
+            }
             details.Add(header);
 
             switch (selectedItem.Kind)
@@ -5985,7 +6260,9 @@ namespace DxMessaging.Editor.Windows
                     )
                 )
             );
-            details.Add(traffic);
+            Foldout evidence = CreateDetailsEvidenceFoldout();
+            evidence.Add(traffic);
+            details.Add(evidence);
         }
 
         private static void AddMessageDetailsCards(
@@ -6043,7 +6320,7 @@ namespace DxMessaging.Editor.Windows
             evidence.Add(
                 CreateDetailsKeyValue("Contexts", JoinDistinctOrNone(message.RecentContexts))
             );
-            AddDetailValues(evidence, "Emitted by", message.RecentEmissionSites);
+            AddSourceDetailValues(evidence, "Emitted by", message.RecentEmissionSites);
             if (visibleMessageKind == "GLOBAL OBSERVER")
             {
                 evidence.Add(
@@ -6063,7 +6340,9 @@ namespace DxMessaging.Editor.Windows
                     )
                 );
             }
-            details.Add(evidence);
+            Foldout evidenceFoldout = CreateDetailsEvidenceFoldout();
+            evidenceFoldout.Add(evidence);
+            details.Add(evidenceFoldout);
         }
 
         private static void AddEdgeDetailsCards(
@@ -6119,8 +6398,7 @@ namespace DxMessaging.Editor.Windows
                     "Exact component registration delivery record"
                 )
             );
-            AddDetailValues(evidence, "Matching call site", edge.RecentEmissionSites);
-            details.Add(evidence);
+            AddSourceDetailValues(evidence, "Matching call site", edge.RecentEmissionSites);
 
             VisualElement traces = CreateDetailsSection("TRACE EVIDENCE");
             traces.Add(
@@ -6151,7 +6429,22 @@ namespace DxMessaging.Editor.Windows
                         .Replace("Busiest path: ", string.Empty)
                 )
             );
-            details.Add(traces);
+            Foldout evidenceFoldout = CreateDetailsEvidenceFoldout();
+            evidenceFoldout.Add(evidence);
+            evidenceFoldout.Add(traces);
+            details.Add(evidenceFoldout);
+        }
+
+        private static Foldout CreateDetailsEvidenceFoldout()
+        {
+            Foldout evidence = new()
+            {
+                name = DetailsEvidenceFoldoutName,
+                text = "Evidence and source details",
+                value = false,
+            };
+            evidence.style.marginBottom = 6;
+            return evidence;
         }
 
         private static VisualElement CreateRoutePathSection(FlowGraphEdge edge)
@@ -6325,6 +6618,442 @@ namespace DxMessaging.Editor.Windows
                     CreateDetailsKeyValue(index == 0 ? firstLabel : string.Empty, values[index])
                 );
             }
+        }
+
+        private static void AddSourceDetailValues(
+            VisualElement section,
+            string firstLabel,
+            IReadOnlyList<string> values
+        )
+        {
+            AddDetailValues(section, firstLabel, values);
+            foreach (string value in values)
+            {
+                if (TryParseSourceLocation(value, out FlowGraphSourceLocation location))
+                {
+                    section.Add(CreateSourceLinkButton("Open call site", location));
+                }
+            }
+        }
+
+        internal static bool TryParseSourceLocation(
+            string text,
+            out FlowGraphSourceLocation location
+        )
+        {
+            location = default;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            int pathStart = text.LastIndexOf("(at ", StringComparison.Ordinal);
+            int pathEnd = text.LastIndexOf(')');
+            if (pathStart < 0 || pathEnd <= pathStart + 4)
+            {
+                return false;
+            }
+
+            int lineSeparator = text.LastIndexOf(':', pathEnd - 1);
+            if (
+                lineSeparator <= pathStart + 4
+                || !int.TryParse(
+                    text.Substring(lineSeparator + 1, pathEnd - lineSeparator - 1),
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out int line
+                )
+                || line <= 0
+            )
+            {
+                return false;
+            }
+
+            string assetPath = text.Substring(pathStart + 4, lineSeparator - pathStart - 4)
+                .Replace('\\', '/');
+            if (Path.IsPathRooted(assetPath))
+            {
+                assetPath = (FileUtil.GetProjectRelativePath(assetPath) ?? string.Empty).Replace(
+                    '\\',
+                    '/'
+                );
+            }
+            if (string.IsNullOrWhiteSpace(assetPath))
+            {
+                return false;
+            }
+
+            location = new FlowGraphSourceLocation(assetPath, line);
+            return true;
+        }
+
+        private static bool TryResolveMessageSource(
+            string messageTypeName,
+            out FlowGraphSourceLocation location
+        )
+        {
+            location = default;
+            string normalizedTypeName = NormalizeCapturedTypeName(messageTypeName);
+            if (string.IsNullOrWhiteSpace(normalizedTypeName))
+            {
+                return false;
+            }
+
+            if (MessageSourceLocationCache.TryGetValue(normalizedTypeName, out location))
+            {
+                return location.IsValid;
+            }
+
+            Type messageType = TypeCache
+                .GetTypesDerivedFrom<IMessage>()
+                .FirstOrDefault(candidate =>
+                    string.Equals(candidate.FullName, normalizedTypeName, StringComparison.Ordinal)
+                );
+            messageType ??= System
+                .AppDomain.CurrentDomain.GetAssemblies()
+                .Select(assembly => assembly.GetType(normalizedTypeName, throwOnError: false))
+                .FirstOrDefault(candidate => candidate != null);
+            if (
+                messageType == null
+                && normalizedTypeName.IndexOf('.') < 0
+                && normalizedTypeName.IndexOf('+') < 0
+            )
+            {
+                Type[] simpleNameMatches = TypeCache
+                    .GetTypesDerivedFrom<IMessage>()
+                    .Where(candidate =>
+                        string.Equals(candidate.Name, normalizedTypeName, StringComparison.Ordinal)
+                    )
+                    .Take(2)
+                    .ToArray();
+                messageType = simpleNameMatches.Length == 1 ? simpleNameMatches[0] : null;
+            }
+            if (messageType == null)
+            {
+                MessageSourceLocationCache[normalizedTypeName] = default;
+                return false;
+            }
+
+            UnityEditor.Compilation.Assembly compilationAssembly = CompilationPipeline
+                .GetAssemblies()
+                .FirstOrDefault(candidate =>
+                    string.Equals(
+                        candidate.name,
+                        messageType.Assembly.GetName().Name,
+                        StringComparison.Ordinal
+                    )
+                );
+            if (compilationAssembly == null)
+            {
+                MessageSourceLocationCache[normalizedTypeName] = default;
+                return false;
+            }
+
+            foreach (string sourceFile in compilationAssembly.sourceFiles)
+            {
+                string fullPath = Path.IsPathRooted(sourceFile)
+                    ? sourceFile
+                    : Path.GetFullPath(sourceFile);
+                if (!File.Exists(fullPath))
+                {
+                    continue;
+                }
+
+                string[] lines = File.ReadAllLines(fullPath);
+                int line = FindTypeDeclarationLine(
+                    lines,
+                    messageType.Namespace,
+                    CreateSourceTypeNameChain(messageType)
+                );
+                if (line <= 0)
+                {
+                    continue;
+                }
+
+                string assetPath = Path.IsPathRooted(sourceFile)
+                    ? FileUtil.GetProjectRelativePath(fullPath)
+                    : sourceFile;
+                assetPath = (assetPath ?? string.Empty).Replace('\\', '/');
+                if (string.IsNullOrWhiteSpace(assetPath))
+                {
+                    continue;
+                }
+
+                location = new FlowGraphSourceLocation(assetPath, line);
+                MessageSourceLocationCache[normalizedTypeName] = location;
+                return true;
+            }
+
+            MessageSourceLocationCache[normalizedTypeName] = default;
+            return false;
+        }
+
+        internal static int FindTypeDeclarationLine(
+            IReadOnlyList<string> lines,
+            string targetNamespace,
+            IReadOnlyList<string> targetTypeNames
+        )
+        {
+            if (lines == null || targetTypeNames == null || targetTypeNames.Count == 0)
+            {
+                return 0;
+            }
+
+            List<SourceScope> scopes = new();
+            string fileScopedNamespace = string.Empty;
+            bool insideBlockComment = false;
+            bool insideVerbatimString = false;
+            int braceDepth = 0;
+            bool hasPendingScope = false;
+            SourceScopeKind pendingScopeKind = SourceScopeKind.Type;
+            string pendingScopeName = string.Empty;
+            for (int index = 0; index < lines.Count; index++)
+            {
+                string code = StripSourceCommentsAndLiterals(
+                    lines[index] ?? string.Empty,
+                    ref insideBlockComment,
+                    ref insideVerbatimString
+                );
+                Match namespaceMatch = SourceNamespaceDeclarationPattern.Match(code);
+                if (
+                    namespaceMatch.Success
+                    && string.Equals(namespaceMatch.Groups[2].Value, ";", StringComparison.Ordinal)
+                )
+                {
+                    fileScopedNamespace = namespaceMatch.Groups[1].Value;
+                    hasPendingScope = false;
+                }
+                else if (namespaceMatch.Success)
+                {
+                    hasPendingScope = true;
+                    pendingScopeKind = SourceScopeKind.Namespace;
+                    pendingScopeName = namespaceMatch.Groups[1].Value;
+                }
+
+                Match typeMatch = SourceTypeDeclarationPattern.Match(code);
+                if (typeMatch.Success)
+                {
+                    string declaredTypeName = typeMatch.Groups[1].Value.TrimStart('@');
+                    string currentNamespace = CreateSourceNamespace(fileScopedNamespace, scopes);
+                    string[] currentTypeNames = scopes
+                        .Where(scope => scope.Kind == SourceScopeKind.Type)
+                        .Select(scope => scope.Name)
+                        .ToArray();
+                    if (
+                        string.Equals(
+                            currentNamespace,
+                            targetNamespace ?? string.Empty,
+                            StringComparison.Ordinal
+                        )
+                        && currentTypeNames.Length == targetTypeNames.Count - 1
+                        && currentTypeNames.SequenceEqual(
+                            targetTypeNames.Take(targetTypeNames.Count - 1),
+                            StringComparer.Ordinal
+                        )
+                        && string.Equals(
+                            declaredTypeName,
+                            targetTypeNames[targetTypeNames.Count - 1],
+                            StringComparison.Ordinal
+                        )
+                    )
+                    {
+                        return index + 1;
+                    }
+
+                    hasPendingScope = true;
+                    pendingScopeKind = SourceScopeKind.Type;
+                    pendingScopeName = declaredTypeName;
+                }
+
+                foreach (char character in code)
+                {
+                    if (character == '{')
+                    {
+                        braceDepth++;
+                        if (hasPendingScope)
+                        {
+                            scopes.Add(
+                                new SourceScope(pendingScopeKind, pendingScopeName, braceDepth)
+                            );
+                            hasPendingScope = false;
+                        }
+                    }
+                    else if (character == '}')
+                    {
+                        braceDepth = Math.Max(0, braceDepth - 1);
+                        while (scopes.Count > 0 && scopes[scopes.Count - 1].BodyDepth > braceDepth)
+                        {
+                            scopes.RemoveAt(scopes.Count - 1);
+                        }
+                    }
+                }
+
+                if (hasPendingScope && code.IndexOf(';') >= 0)
+                {
+                    hasPendingScope = false;
+                }
+            }
+            return 0;
+        }
+
+        private static IReadOnlyList<string> CreateSourceTypeNameChain(Type type)
+        {
+            List<string> names = new();
+            for (Type current = type; current != null; current = current.DeclaringType)
+            {
+                string name = current.Name;
+                int genericArity = name.IndexOf('`');
+                names.Add(genericArity < 0 ? name : name.Substring(0, genericArity));
+            }
+            names.Reverse();
+            return names;
+        }
+
+        private static string CreateSourceNamespace(
+            string fileScopedNamespace,
+            IReadOnlyList<SourceScope> scopes
+        )
+        {
+            return string.Join(
+                ".",
+                new[] { fileScopedNamespace ?? string.Empty }
+                    .Concat(
+                        scopes
+                            .Where(scope => scope.Kind == SourceScopeKind.Namespace)
+                            .Select(scope => scope.Name)
+                    )
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+            );
+        }
+
+        private static string StripSourceCommentsAndLiterals(
+            string line,
+            ref bool insideBlockComment,
+            ref bool insideVerbatimString
+        )
+        {
+            StringBuilder code = new(line.Length);
+            for (int index = 0; index < line.Length; index++)
+            {
+                if (insideVerbatimString)
+                {
+                    code.Append(' ');
+                    if (line[index] != '"')
+                    {
+                        continue;
+                    }
+                    if (index + 1 < line.Length && line[index + 1] == '"')
+                    {
+                        code.Append(' ');
+                        index++;
+                        continue;
+                    }
+
+                    insideVerbatimString = false;
+                    continue;
+                }
+
+                if (insideBlockComment)
+                {
+                    if (index + 1 < line.Length && line[index] == '*' && line[index + 1] == '/')
+                    {
+                        insideBlockComment = false;
+                        code.Append("  ");
+                        index++;
+                    }
+                    else
+                    {
+                        code.Append(' ');
+                    }
+                    continue;
+                }
+
+                if (index + 1 < line.Length && line[index] == '/' && line[index + 1] == '/')
+                {
+                    code.Append(' ', line.Length - index);
+                    break;
+                }
+                if (index + 1 < line.Length && line[index] == '/' && line[index + 1] == '*')
+                {
+                    insideBlockComment = true;
+                    code.Append("  ");
+                    index++;
+                    continue;
+                }
+                if (line[index] == '"' || line[index] == '\'')
+                {
+                    char quote = line[index];
+                    bool verbatim =
+                        quote == '"'
+                        && index > 0
+                        && (
+                            line[index - 1] == '@'
+                            || (line[index - 1] == '$' && index > 1 && line[index - 2] == '@')
+                        );
+                    code.Append(' ');
+                    if (verbatim)
+                    {
+                        insideVerbatimString = true;
+                        continue;
+                    }
+                    for (index++; index < line.Length; index++)
+                    {
+                        code.Append(' ');
+                        if (line[index] == '\\' && index + 1 < line.Length)
+                        {
+                            code.Append(' ');
+                            index++;
+                            continue;
+                        }
+                        if (line[index] == quote)
+                        {
+                            break;
+                        }
+                    }
+                    continue;
+                }
+
+                code.Append(line[index]);
+            }
+            return code.ToString();
+        }
+
+        private static string NormalizeCapturedTypeName(string typeName)
+        {
+            string normalized = typeName ?? string.Empty;
+            int assemblyStart = normalized.LastIndexOf(" [", StringComparison.Ordinal);
+            return assemblyStart < 0 ? normalized : normalized.Substring(0, assemblyStart);
+        }
+
+        private static Button CreateSourceLinkButton(string label, FlowGraphSourceLocation location)
+        {
+            Button button = new()
+            {
+                name = SourceLinkButtonName,
+                text = $"{label} - {Path.GetFileName(location.AssetPath)}:{location.Line}",
+                tooltip = $"Open {location.AssetPath}:{location.Line}",
+                userData = location,
+            };
+            button.AddToClassList(DxMessagingEditorTheme.ToolButtonClassName);
+            button.style.marginLeft = 6;
+            button.RegisterCallback<ClickEvent>(evt =>
+            {
+                evt.StopPropagation();
+                OpenSourceLocation(location);
+            });
+            return button;
+        }
+
+        private static void OpenSourceLocation(FlowGraphSourceLocation location)
+        {
+            UnityEngine.Object asset = AssetDatabase.LoadMainAssetAtPath(location.AssetPath);
+            if (asset == null)
+            {
+                return;
+            }
+
+            EditorGUIUtility.PingObject(asset);
+            _ = AssetDatabase.OpenAsset(asset, location.Line);
         }
 
         private static string CreateDetailsTitle(FlowGraphSelectedItem selectedItem)
@@ -6721,23 +7450,6 @@ namespace DxMessaging.Editor.Windows
                         return FlowGraphSelectedItem.ForEdge(edge);
                     }
                 }
-            }
-
-            if (visibleSnapshot.Edges.Count > 0)
-            {
-                return FlowGraphSelectedItem.ForEdge(
-                    OrderRoutesForDisplay(visibleSnapshot.Edges).First()
-                );
-            }
-
-            if (visibleSnapshot.ComponentNodes.Count > 0)
-            {
-                return FlowGraphSelectedItem.ForComponent(visibleSnapshot.ComponentNodes[0]);
-            }
-
-            if (visibleSnapshot.MessageNodes.Count > 0)
-            {
-                return FlowGraphSelectedItem.ForMessage(visibleSnapshot.MessageNodes[0]);
             }
 
             return FlowGraphSelectedItem.None;

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -494,7 +494,9 @@ namespace DxMessaging.Editor.Windows
                 Action<string> onSelectionChanged
             )
             {
-                _curves = curves ?? throw new ArgumentNullException(nameof(curves));
+                _curves = OrderGraphCurvesForRendering(
+                    curves ?? throw new ArgumentNullException(nameof(curves))
+                );
                 name = GraphEdgeLayerName;
                 pickingMode =
                     onSelectionChanged == null ? PickingMode.Ignore : PickingMode.Position;
@@ -525,6 +527,8 @@ namespace DxMessaging.Editor.Windows
                     });
                 }
             }
+
+            internal IReadOnlyList<GraphCurveDescriptor> Curves => _curves;
 
             private void DrawConnections(MeshGenerationContext context)
             {
@@ -676,6 +680,15 @@ namespace DxMessaging.Editor.Windows
                 }
             }
             return nearestSelectionKey;
+        }
+
+        internal static IReadOnlyList<GraphCurveDescriptor> OrderGraphCurvesForRendering(
+            IReadOnlyList<GraphCurveDescriptor> curves
+        )
+        {
+            return curves == null
+                ? Array.Empty<GraphCurveDescriptor>()
+                : curves.OrderBy(curve => curve.Selected ? 1 : 0).ToArray();
         }
 
         internal static float CalculateLocalGraphRouteHitRadius(float worldScale)
@@ -2787,7 +2800,7 @@ namespace DxMessaging.Editor.Windows
             }
 
             FlowGraphEdgeLayer edgeLayer = new(curves, onSelectionChanged);
-            edgeLayer.userData = curves;
+            edgeLayer.userData = edgeLayer.Curves;
             edgeLayer.style.position = Position.Absolute;
             edgeLayer.style.left = 0;
             edgeLayer.style.top = 0;
@@ -2915,7 +2928,7 @@ namespace DxMessaging.Editor.Windows
                     GraphConnectionDescriptor connection,
                     GraphCurveDescriptor curve,
                     float position
-                ) in markers
+                ) in markers.OrderBy(marker => marker.curve.Selected ? 1 : 0)
             )
             {
                 graphContent.Add(

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -8,6 +8,7 @@ namespace DxMessaging.Editor.Windows
     using System.Linq;
     using System.Text;
     using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
     using Core;
     using Core.Diagnostics;
     using Core.Messages;
@@ -402,6 +403,87 @@ namespace DxMessaging.Editor.Windows
             internal int BodyDepth { get; }
         }
 
+        private readonly struct SourceTypeDeclaration
+        {
+            internal SourceTypeDeclaration(
+                string sourceNamespace,
+                IReadOnlyList<string> typeNames,
+                int line
+            )
+            {
+                Namespace = sourceNamespace ?? string.Empty;
+                TypeNames = typeNames?.ToArray() ?? Array.Empty<string>();
+                Line = line;
+            }
+
+            internal string Namespace { get; }
+
+            internal IReadOnlyList<string> TypeNames { get; }
+
+            internal int Line { get; }
+        }
+
+        private readonly struct MessageSourceFile
+        {
+            internal MessageSourceFile(string fullPath, string assetPath)
+            {
+                FullPath = fullPath ?? string.Empty;
+                AssetPath = assetPath ?? string.Empty;
+            }
+
+            internal string FullPath { get; }
+
+            internal string AssetPath { get; }
+        }
+
+        private readonly struct CapturedTypeIdentity
+        {
+            internal CapturedTypeIdentity(string typeName, string assemblyName)
+            {
+                TypeName = typeName ?? string.Empty;
+                AssemblyName = assemblyName ?? string.Empty;
+            }
+
+            internal string TypeName { get; }
+
+            internal string AssemblyName { get; }
+
+            internal string CacheKey =>
+                string.IsNullOrWhiteSpace(AssemblyName) ? TypeName : $"{TypeName} [{AssemblyName}]";
+        }
+
+        private sealed class MessageSourceAssemblyIndex
+        {
+            internal MessageSourceAssemblyIndex(Task<MessageSourceIndexBuildResult> buildTask)
+            {
+                BuildTask = buildTask ?? throw new ArgumentNullException(nameof(buildTask));
+            }
+
+            internal Task<MessageSourceIndexBuildResult> BuildTask { get; set; }
+
+            internal IReadOnlyDictionary<string, FlowGraphSourceLocation> Locations { get; set; }
+
+            internal bool IsComplete { get; set; }
+
+            internal DateTime RetryAfterUtc { get; set; }
+        }
+
+        private readonly struct MessageSourceIndexBuildResult
+        {
+            internal MessageSourceIndexBuildResult(
+                IReadOnlyDictionary<string, FlowGraphSourceLocation> locations,
+                bool isComplete
+            )
+            {
+                Locations = locations;
+                IsComplete = isComplete;
+            }
+
+            internal IReadOnlyDictionary<string, FlowGraphSourceLocation> Locations { get; }
+
+            internal bool IsComplete { get; }
+        }
+
         private sealed class FlowGraphEdgeLayer : VisualElement
         {
             private const int SegmentCount = 28;
@@ -630,6 +712,12 @@ namespace DxMessaging.Editor.Windows
             string,
             FlowGraphSourceLocation
         > MessageSourceLocationCache = new(StringComparer.Ordinal);
+        private static readonly Dictionary<
+            string,
+            MessageSourceAssemblyIndex
+        > MessageSourceAssemblyIndexes = new(StringComparer.Ordinal);
+        private static Func<string, string[]> _messageSourceFileReader = File.ReadAllLines;
+        internal static event Action MessageSourceIndexChanged;
         private static readonly Regex SourceNamespaceDeclarationPattern = new(
             @"^\s*namespace\s+([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\s*([;{]?)",
             RegexOptions.CultureInvariant
@@ -648,6 +736,17 @@ namespace DxMessaging.Editor.Windows
             window.Refresh();
         }
 
+        private void OnEnable()
+        {
+            MessageSourceIndexChanged -= HandleMessageSourceIndexChanged;
+            MessageSourceIndexChanged += HandleMessageSourceIndexChanged;
+        }
+
+        private void OnDisable()
+        {
+            MessageSourceIndexChanged -= HandleMessageSourceIndexChanged;
+        }
+
         private void CreateGUI()
         {
             titleContent = new GUIContent(Title, DxMessagingEditorTheme.LoadIcon());
@@ -656,6 +755,7 @@ namespace DxMessaging.Editor.Windows
 
         private void Refresh()
         {
+            AllowIncompleteMessageSourceIndexRetries();
             _currentSnapshot = CaptureSnapshot();
             BuildGraphUi(
                 rootVisualElement,
@@ -710,6 +810,37 @@ namespace DxMessaging.Editor.Windows
             }
 
             _selectedItemKey = normalizedSelectionKey;
+            if (
+                RefreshGraphContent(
+                    rootVisualElement,
+                    _currentSnapshot,
+                    new FlowGraphViewState(_filterText, _selectedItemKey),
+                    exportText => EditorGUIUtility.systemCopyBuffer = exportText,
+                    HandleSelectionChanged
+                )
+            )
+            {
+                return;
+            }
+
+            BuildGraphUi(
+                rootVisualElement,
+                _currentSnapshot,
+                new FlowGraphViewState(_filterText, _selectedItemKey),
+                HandleFilterChanged,
+                Refresh,
+                exportText => EditorGUIUtility.systemCopyBuffer = exportText,
+                HandleSelectionChanged
+            );
+        }
+
+        private void HandleMessageSourceIndexChanged()
+        {
+            if (string.IsNullOrWhiteSpace(_selectedItemKey))
+            {
+                return;
+            }
+
             if (
                 RefreshGraphContent(
                     rootVisualElement,
@@ -6687,42 +6818,57 @@ namespace DxMessaging.Editor.Windows
             return true;
         }
 
-        private static bool TryResolveMessageSource(
+        internal static bool TryResolveMessageSource(
             string messageTypeName,
             out FlowGraphSourceLocation location
         )
         {
             location = default;
-            string normalizedTypeName = NormalizeCapturedTypeName(messageTypeName);
-            if (string.IsNullOrWhiteSpace(normalizedTypeName))
+            CapturedTypeIdentity identity = ParseCapturedTypeIdentity(messageTypeName);
+            if (string.IsNullOrWhiteSpace(identity.TypeName))
             {
                 return false;
             }
 
-            if (MessageSourceLocationCache.TryGetValue(normalizedTypeName, out location))
+            if (MessageSourceLocationCache.TryGetValue(identity.CacheKey, out location))
             {
                 return location.IsValid;
             }
 
-            Type messageType = TypeCache
+            System.Reflection.Assembly[] loadedAssemblies =
+                System.AppDomain.CurrentDomain.GetAssemblies();
+            IEnumerable<System.Reflection.Assembly> candidateAssemblies = loadedAssemblies;
+            if (!string.IsNullOrWhiteSpace(identity.AssemblyName))
+            {
+                candidateAssemblies = candidateAssemblies.Where(assembly =>
+                    string.Equals(
+                        assembly.GetName().Name,
+                        identity.AssemblyName,
+                        StringComparison.Ordinal
+                    )
+                );
+            }
+
+            Type messageType = candidateAssemblies
+                .Select(assembly => assembly.GetType(identity.TypeName, throwOnError: false))
+                .FirstOrDefault(candidate => candidate != null);
+            messageType ??= TypeCache
                 .GetTypesDerivedFrom<IMessage>()
                 .FirstOrDefault(candidate =>
-                    string.Equals(candidate.FullName, normalizedTypeName, StringComparison.Ordinal)
+                    string.Equals(candidate.FullName, identity.TypeName, StringComparison.Ordinal)
+                    && IsTypeFromCapturedAssembly(candidate, identity.AssemblyName)
                 );
-            messageType ??= System
-                .AppDomain.CurrentDomain.GetAssemblies()
-                .Select(assembly => assembly.GetType(normalizedTypeName, throwOnError: false))
-                .FirstOrDefault(candidate => candidate != null);
             if (
                 messageType == null
-                && normalizedTypeName.IndexOf('.') < 0
-                && normalizedTypeName.IndexOf('+') < 0
+                && identity.TypeName.IndexOf('.') < 0
+                && identity.TypeName.IndexOf('+') < 0
             )
             {
                 Type[] simpleNameMatches = TypeCache
                     .GetTypesDerivedFrom<IMessage>()
                     .Where(candidate =>
-                        string.Equals(candidate.Name, normalizedTypeName, StringComparison.Ordinal)
+                        string.Equals(candidate.Name, identity.TypeName, StringComparison.Ordinal)
+                        && IsTypeFromCapturedAssembly(candidate, identity.AssemblyName)
                     )
                     .Take(2)
                     .ToArray();
@@ -6730,62 +6876,282 @@ namespace DxMessaging.Editor.Windows
             }
             if (messageType == null)
             {
-                MessageSourceLocationCache[normalizedTypeName] = default;
+                MessageSourceLocationCache[identity.CacheKey] = default;
                 return false;
             }
 
+            string compilationAssemblyName = string.IsNullOrWhiteSpace(identity.AssemblyName)
+                ? messageType.Assembly.GetName().Name
+                : identity.AssemblyName;
             UnityEditor.Compilation.Assembly compilationAssembly = CompilationPipeline
                 .GetAssemblies()
                 .FirstOrDefault(candidate =>
-                    string.Equals(
-                        candidate.name,
-                        messageType.Assembly.GetName().Name,
-                        StringComparison.Ordinal
-                    )
+                    string.Equals(candidate.name, compilationAssemblyName, StringComparison.Ordinal)
                 );
             if (compilationAssembly == null)
             {
-                MessageSourceLocationCache[normalizedTypeName] = default;
+                MessageSourceLocationCache[identity.CacheKey] = default;
                 return false;
             }
 
-            foreach (string sourceFile in compilationAssembly.sourceFiles)
+            string declarationKey = CreateSourceDeclarationKey(
+                messageType.Namespace,
+                CreateSourceTypeNameChain(messageType)
+            );
+            if (
+                MessageSourceAssemblyIndexes.TryGetValue(
+                    compilationAssembly.name,
+                    out MessageSourceAssemblyIndex existingIndex
+                )
+            )
             {
-                string fullPath = Path.IsPathRooted(sourceFile)
-                    ? sourceFile
-                    : Path.GetFullPath(sourceFile);
-                if (!File.Exists(fullPath))
+                if (existingIndex.Locations == null)
                 {
-                    continue;
+                    return false;
                 }
 
-                string[] lines = File.ReadAllLines(fullPath);
-                int line = FindTypeDeclarationLine(
-                    lines,
-                    messageType.Namespace,
-                    CreateSourceTypeNameChain(messageType)
-                );
-                if (line <= 0)
+                if (existingIndex.Locations.TryGetValue(declarationKey, out location))
                 {
-                    continue;
+                    MessageSourceLocationCache[identity.CacheKey] = location;
+                    return true;
                 }
 
-                string assetPath = Path.IsPathRooted(sourceFile)
-                    ? FileUtil.GetProjectRelativePath(fullPath)
-                    : sourceFile;
-                assetPath = (assetPath ?? string.Empty).Replace('\\', '/');
-                if (string.IsNullOrWhiteSpace(assetPath))
+                if (!existingIndex.IsComplete)
                 {
-                    continue;
+                    if (
+                        existingIndex.BuildTask == null
+                        && DateTime.UtcNow >= existingIndex.RetryAfterUtc
+                    )
+                    {
+                        existingIndex.BuildTask = CreateMessageSourceIndexBuildTask(
+                            compilationAssembly
+                        );
+                        RegisterMessageSourceIndexDrain();
+                    }
+                    return false;
                 }
 
-                location = new FlowGraphSourceLocation(assetPath, line);
-                MessageSourceLocationCache[normalizedTypeName] = location;
-                return true;
+                MessageSourceLocationCache[identity.CacheKey] = default;
+                return false;
             }
 
-            MessageSourceLocationCache[normalizedTypeName] = default;
+            MessageSourceAssemblyIndexes.Add(
+                compilationAssembly.name,
+                new MessageSourceAssemblyIndex(
+                    CreateMessageSourceIndexBuildTask(compilationAssembly)
+                )
+            );
+            RegisterMessageSourceIndexDrain();
             return false;
+        }
+
+        private static bool IsTypeFromCapturedAssembly(Type type, string assemblyName)
+        {
+            return string.IsNullOrWhiteSpace(assemblyName)
+                || string.Equals(
+                    type.Assembly.GetName().Name,
+                    assemblyName,
+                    StringComparison.Ordinal
+                );
+        }
+
+        private static Task<MessageSourceIndexBuildResult> CreateMessageSourceIndexBuildTask(
+            UnityEditor.Compilation.Assembly compilationAssembly
+        )
+        {
+            MessageSourceFile[] sourceFiles = compilationAssembly
+                .sourceFiles.Select(CreateMessageSourceFile)
+                .Where(sourceFile =>
+                    !string.IsNullOrWhiteSpace(sourceFile.FullPath)
+                    && !string.IsNullOrWhiteSpace(sourceFile.AssetPath)
+                )
+                .ToArray();
+            Func<string, string[]> fileReader = _messageSourceFileReader;
+            return Task.Run(() => BuildMessageSourceAssemblyIndex(sourceFiles, fileReader));
+        }
+
+        private static void RegisterMessageSourceIndexDrain()
+        {
+            EditorApplication.update -= DrainMessageSourceAssemblyIndexes;
+            EditorApplication.update += DrainMessageSourceAssemblyIndexes;
+        }
+
+        private static MessageSourceFile CreateMessageSourceFile(string sourceFile)
+        {
+            if (string.IsNullOrWhiteSpace(sourceFile))
+            {
+                return default;
+            }
+
+            string fullPath = Path.IsPathRooted(sourceFile)
+                ? sourceFile
+                : Path.GetFullPath(sourceFile);
+            string assetPath = Path.IsPathRooted(sourceFile)
+                ? FileUtil.GetProjectRelativePath(fullPath)
+                : sourceFile;
+            assetPath = (assetPath ?? string.Empty).Replace('\\', '/');
+            return string.IsNullOrWhiteSpace(assetPath)
+                ? default
+                : new MessageSourceFile(fullPath, assetPath);
+        }
+
+        private static MessageSourceIndexBuildResult BuildMessageSourceAssemblyIndex(
+            IReadOnlyList<MessageSourceFile> sourceFiles,
+            Func<string, string[]> readAllLines
+        )
+        {
+            Dictionary<string, FlowGraphSourceLocation> locations = new(StringComparer.Ordinal);
+            if (sourceFiles == null || readAllLines == null)
+            {
+                return new MessageSourceIndexBuildResult(locations, isComplete: false);
+            }
+
+            bool isComplete = true;
+            foreach (MessageSourceFile sourceFile in sourceFiles)
+            {
+                string[] lines;
+                try
+                {
+                    lines = readAllLines(sourceFile.FullPath);
+                }
+                catch (IOException)
+                {
+                    isComplete = false;
+                    continue;
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    isComplete = false;
+                    continue;
+                }
+
+                foreach (SourceTypeDeclaration declaration in FindSourceTypeDeclarations(lines))
+                {
+                    string key = CreateSourceDeclarationKey(
+                        declaration.Namespace,
+                        declaration.TypeNames
+                    );
+                    if (!locations.ContainsKey(key))
+                    {
+                        locations.Add(
+                            key,
+                            new FlowGraphSourceLocation(sourceFile.AssetPath, declaration.Line)
+                        );
+                    }
+                }
+            }
+            return new MessageSourceIndexBuildResult(locations, isComplete);
+        }
+
+        private static void DrainMessageSourceAssemblyIndexes()
+        {
+            bool changed = false;
+            foreach (MessageSourceAssemblyIndex index in MessageSourceAssemblyIndexes.Values)
+            {
+                if (index.BuildTask == null || !index.BuildTask.IsCompleted)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    MessageSourceIndexBuildResult result = index.BuildTask.GetAwaiter().GetResult();
+                    if (!result.IsComplete && index.Locations != null)
+                    {
+                        Dictionary<string, FlowGraphSourceLocation> mergedLocations = new(
+                            index.Locations,
+                            StringComparer.Ordinal
+                        );
+                        foreach (
+                            KeyValuePair<string, FlowGraphSourceLocation> pair in result.Locations
+                        )
+                        {
+                            mergedLocations[pair.Key] = pair.Value;
+                        }
+                        index.Locations = mergedLocations;
+                    }
+                    else
+                    {
+                        index.Locations = result.Locations;
+                    }
+                    index.IsComplete = result.IsComplete;
+                    index.RetryAfterUtc = result.IsComplete
+                        ? DateTime.MaxValue
+                        : DateTime.UtcNow.AddSeconds(5);
+                }
+                catch (Exception exception)
+                {
+                    index.Locations = new Dictionary<string, FlowGraphSourceLocation>(
+                        StringComparer.Ordinal
+                    );
+                    index.IsComplete = false;
+                    index.RetryAfterUtc = DateTime.UtcNow.AddSeconds(5);
+                    Debug.LogWarning(
+                        $"DxMessaging Flow Graph could not index message source files: {exception.Message}"
+                    );
+                }
+                index.BuildTask = null;
+                changed = true;
+            }
+
+            if (changed)
+            {
+                MessageSourceIndexChanged?.Invoke();
+            }
+
+            if (!MessageSourceAssemblyIndexes.Values.Any(index => index.BuildTask != null))
+            {
+                EditorApplication.update -= DrainMessageSourceAssemblyIndexes;
+            }
+        }
+
+        internal static void AllowIncompleteMessageSourceIndexRetries()
+        {
+            foreach (
+                MessageSourceAssemblyIndex index in MessageSourceAssemblyIndexes.Values.Where(
+                    index => index.BuildTask == null && !index.IsComplete
+                )
+            )
+            {
+                index.RetryAfterUtc = DateTime.MinValue;
+            }
+        }
+
+        internal static int PendingMessageSourceIndexCount =>
+            MessageSourceAssemblyIndexes.Values.Count(index => index.BuildTask != null);
+
+        internal static int CompletedMessageSourceIndexCount =>
+            MessageSourceAssemblyIndexes.Values.Count(index =>
+                index.BuildTask != null && index.BuildTask.IsCompleted
+            );
+
+        internal static Func<string, string[]> MessageSourceFileReader
+        {
+            get => _messageSourceFileReader;
+            set => _messageSourceFileReader = value ?? File.ReadAllLines;
+        }
+
+        internal static void ResetMessageSourceIndexesForTests()
+        {
+            EditorApplication.update -= DrainMessageSourceAssemblyIndexes;
+            MessageSourceAssemblyIndexes.Clear();
+            MessageSourceLocationCache.Clear();
+            _messageSourceFileReader = File.ReadAllLines;
+        }
+
+        internal static void CompleteMessageSourceIndexesForTests()
+        {
+            Task[] buildTasks = MessageSourceAssemblyIndexes
+                .Values.Where(index => index.BuildTask != null)
+                .Select(index => (Task)index.BuildTask)
+                .ToArray();
+            Task.WaitAll(buildTasks);
+            DrainMessageSourceAssemblyIndexes();
+        }
+
+        internal static void DrainMessageSourceIndexesForTests()
+        {
+            DrainMessageSourceAssemblyIndexes();
         }
 
         internal static int FindTypeDeclarationLine(
@@ -6799,21 +7165,50 @@ namespace DxMessaging.Editor.Windows
                 return 0;
             }
 
-            List<SourceScope> scopes = new();
-            string fileScopedNamespace = string.Empty;
+            SourceTypeDeclaration match = FindSourceTypeDeclarations(lines)
+                .FirstOrDefault(declaration =>
+                    string.Equals(
+                        declaration.Namespace,
+                        targetNamespace ?? string.Empty,
+                        StringComparison.Ordinal
+                    )
+                    && declaration.TypeNames.SequenceEqual(targetTypeNames, StringComparer.Ordinal)
+                );
+            return match.Line;
+        }
+
+        private static IReadOnlyList<SourceTypeDeclaration> FindSourceTypeDeclarations(
+            IReadOnlyList<string> lines
+        )
+        {
+            List<SourceTypeDeclaration> declarations = new();
+            if (lines == null)
+            {
+                return declarations;
+            }
+
             bool insideBlockComment = false;
             bool insideVerbatimString = false;
-            int braceDepth = 0;
-            bool hasPendingScope = false;
-            SourceScopeKind pendingScopeKind = SourceScopeKind.Type;
-            string pendingScopeName = string.Empty;
+            string[] codeLines = new string[lines.Count];
             for (int index = 0; index < lines.Count; index++)
             {
-                string code = StripSourceCommentsAndLiterals(
+                codeLines[index] = StripSourceCommentsAndLiterals(
                     lines[index] ?? string.Empty,
                     ref insideBlockComment,
                     ref insideVerbatimString
                 );
+            }
+
+            List<SourceScope> scopes = new();
+            string fileScopedNamespace = string.Empty;
+            int braceDepth = 0;
+            int attributeSquareDepth = 0;
+            bool hasPendingScope = false;
+            SourceScopeKind pendingScopeKind = SourceScopeKind.Type;
+            string pendingScopeName = string.Empty;
+            for (int index = 0; index < codeLines.Length; index++)
+            {
+                string code = codeLines[index];
                 Match namespaceMatch = SourceNamespaceDeclarationPattern.Match(code);
                 if (
                     namespaceMatch.Success
@@ -6834,31 +7229,30 @@ namespace DxMessaging.Editor.Windows
                 if (typeMatch.Success)
                 {
                     string declaredTypeName = typeMatch.Groups[1].Value.TrimStart('@');
+                    if (
+                        code.Substring(typeMatch.Index + typeMatch.Length)
+                            .TrimStart()
+                            .StartsWith("<", StringComparison.Ordinal)
+                    )
+                    {
+                        declaredTypeName += TryReadSourceGenericParameters(
+                            codeLines,
+                            index,
+                            typeMatch.Index + typeMatch.Length,
+                            out string genericParameters
+                        )
+                            ? "`" + CountSourceGenericParameters(genericParameters)
+                            : "`?";
+                    }
                     string currentNamespace = CreateSourceNamespace(fileScopedNamespace, scopes);
                     string[] currentTypeNames = scopes
                         .Where(scope => scope.Kind == SourceScopeKind.Type)
                         .Select(scope => scope.Name)
+                        .Concat(new[] { declaredTypeName })
                         .ToArray();
-                    if (
-                        string.Equals(
-                            currentNamespace,
-                            targetNamespace ?? string.Empty,
-                            StringComparison.Ordinal
-                        )
-                        && currentTypeNames.Length == targetTypeNames.Count - 1
-                        && currentTypeNames.SequenceEqual(
-                            targetTypeNames.Take(targetTypeNames.Count - 1),
-                            StringComparer.Ordinal
-                        )
-                        && string.Equals(
-                            declaredTypeName,
-                            targetTypeNames[targetTypeNames.Count - 1],
-                            StringComparison.Ordinal
-                        )
-                    )
-                    {
-                        return index + 1;
-                    }
+                    declarations.Add(
+                        new SourceTypeDeclaration(currentNamespace, currentTypeNames, index + 1)
+                    );
 
                     hasPendingScope = true;
                     pendingScopeKind = SourceScopeKind.Type;
@@ -6867,6 +7261,20 @@ namespace DxMessaging.Editor.Windows
 
                 foreach (char character in code)
                 {
+                    if (character == '[')
+                    {
+                        attributeSquareDepth++;
+                        continue;
+                    }
+                    if (character == ']')
+                    {
+                        attributeSquareDepth = Math.Max(0, attributeSquareDepth - 1);
+                        continue;
+                    }
+                    if (attributeSquareDepth > 0)
+                    {
+                        continue;
+                    }
                     if (character == '{')
                     {
                         braceDepth++;
@@ -6893,7 +7301,77 @@ namespace DxMessaging.Editor.Windows
                     hasPendingScope = false;
                 }
             }
-            return 0;
+            return declarations;
+        }
+
+        private static bool TryReadSourceGenericParameters(
+            IReadOnlyList<string> codeLines,
+            int declarationLine,
+            int declarationEnd,
+            out string genericParameters
+        )
+        {
+            genericParameters = string.Empty;
+            if (codeLines == null || declarationLine < 0 || declarationLine >= codeLines.Count)
+            {
+                return false;
+            }
+
+            StringBuilder parameters = new();
+            bool started = false;
+            int angleDepth = 0;
+            int attributeSquareDepth = 0;
+            for (int lineIndex = declarationLine; lineIndex < codeLines.Count; lineIndex++)
+            {
+                string line = codeLines[lineIndex] ?? string.Empty;
+                int characterIndex = lineIndex == declarationLine ? declarationEnd : 0;
+                for (; characterIndex < line.Length; characterIndex++)
+                {
+                    char character = line[characterIndex];
+                    if (!started)
+                    {
+                        if (char.IsWhiteSpace(character))
+                        {
+                            continue;
+                        }
+                        if (character != '<')
+                        {
+                            return false;
+                        }
+                        started = true;
+                        angleDepth = 1;
+                        continue;
+                    }
+
+                    if (character == '[')
+                    {
+                        attributeSquareDepth++;
+                    }
+                    else if (character == ']')
+                    {
+                        attributeSquareDepth = Math.Max(0, attributeSquareDepth - 1);
+                    }
+                    else if (character == '<' && attributeSquareDepth == 0)
+                    {
+                        angleDepth++;
+                    }
+                    else if (character == '>' && attributeSquareDepth == 0)
+                    {
+                        angleDepth--;
+                        if (angleDepth == 0)
+                        {
+                            genericParameters = parameters.ToString();
+                            return !string.IsNullOrWhiteSpace(genericParameters);
+                        }
+                    }
+                    parameters.Append(character);
+                }
+                if (started)
+                {
+                    parameters.Append(' ');
+                }
+            }
+            return false;
         }
 
         private static IReadOnlyList<string> CreateSourceTypeNameChain(Type type)
@@ -6901,12 +7379,53 @@ namespace DxMessaging.Editor.Windows
             List<string> names = new();
             for (Type current = type; current != null; current = current.DeclaringType)
             {
-                string name = current.Name;
-                int genericArity = name.IndexOf('`');
-                names.Add(genericArity < 0 ? name : name.Substring(0, genericArity));
+                names.Add(current.Name);
             }
             names.Reverse();
             return names;
+        }
+
+        private static int CountSourceGenericParameters(string genericParameters)
+        {
+            int count = 1;
+            int squareDepth = 0;
+            int parenthesisDepth = 0;
+            for (int index = 0; index < genericParameters.Length; index++)
+            {
+                switch (genericParameters[index])
+                {
+                    case '[':
+                        squareDepth++;
+                        break;
+                    case ']':
+                        squareDepth = Math.Max(0, squareDepth - 1);
+                        break;
+                    case '(':
+                        parenthesisDepth++;
+                        break;
+                    case ')':
+                        parenthesisDepth = Math.Max(0, parenthesisDepth - 1);
+                        break;
+                    case ',':
+                        if (squareDepth == 0 && parenthesisDepth == 0)
+                        {
+                            count++;
+                        }
+                        break;
+                }
+            }
+            return count;
+        }
+
+        private static string CreateSourceDeclarationKey(
+            string sourceNamespace,
+            IReadOnlyList<string> typeNames
+        )
+        {
+            string typeName = string.Join("+", typeNames ?? Array.Empty<string>());
+            return string.IsNullOrWhiteSpace(sourceNamespace)
+                ? typeName
+                : sourceNamespace + "." + typeName;
         }
 
         private static string CreateSourceNamespace(
@@ -7018,11 +7537,22 @@ namespace DxMessaging.Editor.Windows
             return code.ToString();
         }
 
-        private static string NormalizeCapturedTypeName(string typeName)
+        private static CapturedTypeIdentity ParseCapturedTypeIdentity(string typeName)
         {
-            string normalized = typeName ?? string.Empty;
-            int assemblyStart = normalized.LastIndexOf(" [", StringComparison.Ordinal);
-            return assemblyStart < 0 ? normalized : normalized.Substring(0, assemblyStart);
+            string captured = typeName ?? string.Empty;
+            int assemblyStart = captured.LastIndexOf(" [", StringComparison.Ordinal);
+            if (assemblyStart < 0 || !captured.EndsWith("]", StringComparison.Ordinal))
+            {
+                return new CapturedTypeIdentity(captured, string.Empty);
+            }
+
+            string assemblyName = captured.Substring(
+                assemblyStart + 2,
+                captured.Length - assemblyStart - 3
+            );
+            return string.IsNullOrWhiteSpace(assemblyName)
+                ? new CapturedTypeIdentity(captured, string.Empty)
+                : new CapturedTypeIdentity(captured.Substring(0, assemblyStart), assemblyName);
         }
 
         private static Button CreateSourceLinkButton(string label, FlowGraphSourceLocation location)

--- a/README.md
+++ b/README.md
@@ -634,15 +634,19 @@ dedicated Unity editor tools under **Tools > Wallstop Studios > DxMessaging**.
 #### Flow Graph
 
 - Crossing-aware layered message and receiver nodes with ordered connection
-  ports, arrowhead direction, and unobtrusive shape-and-color route selectors
+  ports, feathered arrow paths, arrowhead direction, and shape-and-color route
+  selectors; click anywhere along a route to inspect it
+- Fit, zoom-out, and zoom-in controls for dense graphs, with automatic framing
+  down to 20 percent so hundreds of routes remain available in one overview
 - Named node metrics for sources or targets, receivers, handlers, calls, and
   state instead of compact `+N` overflow summaries; multi-kind message types
   use neutral `MIXED` metrics until filtered to one route kind
-- Responsive route details split into route, activity, emission-evidence, and
-  trace-evidence cards; dense technical diagnostics start collapsed
+- No default selection or details wall on open; responsive route details split
+  route and activity from collapsed emission, trace, and technical evidence
 - Recent registration-exact delivery call sites for targeted and broadcast
   routes; call sites identify the script and method when token diagnostics are
-  enabled without leaking evidence across components or message buses
+  enabled without leaking evidence across components or message buses, and
+  source links open the exact message declaration or captured call-site line
 - Global accept-all registrations shown as `ANY MESSAGE` observer scope rather
   than as an `IMessage` message type
 - Route-map route-kind mix, call shares, widest-message target-component

--- a/Samples~/Diagnostics Tooling Exerciser/README.md
+++ b/Samples~/Diagnostics Tooling Exerciser/README.md
@@ -25,6 +25,8 @@ the package editor tools.
    command for each receiver, and one broadcast signal for each source.
 1. Open **Tools > Wallstop Studios > DxMessaging > Message Monitor**.
 1. Open **Tools > Wallstop Studios > DxMessaging > Flow Graph**.
+1. Click any route line, including near a message or receiver endpoint, then
+   expand its evidence or open a captured message or call-site source link.
 1. Select `Player Ship`, `Enemy Drone`, and `HUD Console` to inspect local
    diagnostics counters.
 
@@ -53,8 +55,11 @@ After the default play-start burst:
 - Flow Graph shows three receiver components, four message nodes (the three
   concrete messages plus `IMessage`), 15 routes, and 33 recent trace paths.
   Its primary canvas places the four messages on the left, the three receivers
-  on the right, and draws all 15 live connections. The textual route and trace
-  reports remain inside the collapsed **Analysis and Raw Data** section.
+  on the right, and draws all 15 live connections. It starts with no default
+  selection; clicking any part of a connection opens focused route and activity
+  details while evidence and technical reports remain collapsed. The textual
+  route and trace reports remain inside the collapsed **Analysis and Raw Data**
+  section.
 - The component diagnostics panel shows enabled listener diagnostics and local
   emissions for each receiver.
 

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -5,6 +5,7 @@ namespace DxMessaging.Tests.Editor
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Threading;
     using Core;
     using Core.Diagnostics;
     using Core.MessageBus;
@@ -915,13 +916,29 @@ namespace DxMessaging.Tests.Editor
             );
             VisualElement root = new();
 
-            DxMessagingFlowGraphWindow.BuildGraphUi(
-                root,
-                snapshot,
-                new FlowGraphViewState(
-                    selectedItemKey: DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(edge)
-                )
+            FlowGraphViewState viewState = new(
+                selectedItemKey: DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(edge)
             );
+            DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot, viewState);
+            Button messageSource = root.Query<Button>(
+                    name: DxMessagingFlowGraphWindow.SourceLinkButtonName
+                )
+                .ToList()
+                .SingleOrDefault(button =>
+                    button.text.StartsWith("Open message source", StringComparison.Ordinal)
+                );
+            if (messageSource == null)
+            {
+                DxMessagingFlowGraphWindow.CompleteMessageSourceIndexesForTests();
+                DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot, viewState);
+                messageSource = root.Query<Button>(
+                        name: DxMessagingFlowGraphWindow.SourceLinkButtonName
+                    )
+                    .ToList()
+                    .SingleOrDefault(button =>
+                        button.text.StartsWith("Open message source", StringComparison.Ordinal)
+                    );
+            }
 
             Foldout evidence = root.Q<Foldout>(
                 DxMessagingFlowGraphWindow.DetailsEvidenceFoldoutName
@@ -936,13 +953,11 @@ namespace DxMessaging.Tests.Editor
                 Is.False,
                 "Route evidence should start collapsed so selecting a route does not replace the graph with text."
             );
-            Button messageSource = root.Query<Button>(
-                    name: DxMessagingFlowGraphWindow.SourceLinkButtonName
-                )
-                .ToList()
-                .Single(button =>
-                    button.text.StartsWith("Open message source", StringComparison.Ordinal)
-                );
+            Assert.That(
+                messageSource,
+                Is.Not.Null,
+                "The background source index should refresh the selected message with an exact source link."
+            );
             DxMessagingFlowGraphWindow.FlowGraphSourceLocation location =
                 (DxMessagingFlowGraphWindow.FlowGraphSourceLocation)messageSource.userData;
             Assert.That(
@@ -981,12 +996,16 @@ namespace DxMessaging.Tests.Editor
         [Test]
         public void MessageSourceResolverDistinguishesNestingAndGenericArity()
         {
-            Type[] messageTypes =
+            (Type type, string declaration)[] cases =
             {
-                typeof(SourceLinkBeta.DuplicateSourceMessage),
-                typeof(SourceLinkBeta.GenericSourceMessage<int>).GetGenericTypeDefinition(),
+                (typeof(SourceLinkBeta.DuplicateSourceMessage), "DuplicateSourceMessage"),
+                (typeof(SourceLinkBeta.GenericSourceMessage), "GenericSourceMessage :"),
+                (
+                    typeof(SourceLinkBeta.GenericSourceMessage<int>).GetGenericTypeDefinition(),
+                    "GenericSourceMessage<T>"
+                ),
             };
-            foreach (Type messageType in messageTypes)
+            foreach ((Type messageType, string expectedDeclaration) in cases)
             {
                 string messageTypeName = messageType.FullName;
                 FlowGraphEdge edge = new(
@@ -1017,21 +1036,35 @@ namespace DxMessaging.Tests.Editor
                 );
                 VisualElement root = new();
 
-                DxMessagingFlowGraphWindow.BuildGraphUi(
-                    root,
-                    snapshot,
-                    new FlowGraphViewState(
-                        selectedItemKey: DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(edge)
-                    )
+                FlowGraphViewState viewState = new(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(edge)
                 );
-
+                DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot, viewState);
                 Button messageSource = root.Query<Button>(
                         name: DxMessagingFlowGraphWindow.SourceLinkButtonName
                     )
                     .ToList()
-                    .Single(button =>
+                    .SingleOrDefault(button =>
                         button.text.StartsWith("Open message source", StringComparison.Ordinal)
                     );
+                if (messageSource == null)
+                {
+                    DxMessagingFlowGraphWindow.CompleteMessageSourceIndexesForTests();
+                    DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot, viewState);
+                    messageSource = root.Query<Button>(
+                            name: DxMessagingFlowGraphWindow.SourceLinkButtonName
+                        )
+                        .ToList()
+                        .SingleOrDefault(button =>
+                            button.text.StartsWith("Open message source", StringComparison.Ordinal)
+                        );
+                }
+
+                Assert.That(
+                    messageSource,
+                    Is.Not.Null,
+                    $"The background source index should resolve {messageTypeName}."
+                );
                 DxMessagingFlowGraphWindow.FlowGraphSourceLocation location =
                     (DxMessagingFlowGraphWindow.FlowGraphSourceLocation)messageSource.userData;
                 string declaration = File.ReadAllLines(Path.GetFullPath(location.AssetPath))[
@@ -1039,14 +1072,10 @@ namespace DxMessaging.Tests.Editor
                 ];
                 Assert.That(
                     declaration,
-                    Does.Contain(
-                        messageType == messageTypes[0]
-                            ? "DuplicateSourceMessage"
-                            : "GenericSourceMessage<T>"
-                    ),
+                    Does.Contain(expectedDeclaration),
                     $"{messageTypeName} resolved to the wrong declaration at {location.AssetPath}:{location.Line}."
                 );
-                if (messageType == messageTypes[0])
+                if (messageType == cases[0].type)
                 {
                     Assert.That(
                         location.Line,
@@ -1059,6 +1088,260 @@ namespace DxMessaging.Tests.Editor
                         "The duplicate message must resolve inside SourceLinkBeta, not SourceLinkAlpha."
                     );
                 }
+            }
+        }
+
+        [Test]
+        public void MessageSourceResolverReadsAssemblyFilesOffTheEditorThread()
+        {
+            DxMessagingFlowGraphWindow.ResetMessageSourceIndexesForTests();
+            int editorThreadId = Thread.CurrentThread.ManagedThreadId;
+            int readerThreadId = editorThreadId;
+            using ManualResetEventSlim readerStarted = new(initialState: false);
+            using ManualResetEventSlim releaseReader = new(initialState: false);
+            int indexChangedCount = 0;
+            try
+            {
+                DxMessagingFlowGraphWindow.MessageSourceIndexChanged += HandleIndexChanged;
+                DxMessagingFlowGraphWindow.MessageSourceFileReader = _ =>
+                {
+                    readerThreadId = Thread.CurrentThread.ManagedThreadId;
+                    readerStarted.Set();
+                    releaseReader.Wait(TimeSpan.FromSeconds(5));
+                    return Array.Empty<string>();
+                };
+
+                bool resolved = DxMessagingFlowGraphWindow.TryResolveMessageSource(
+                    typeof(FlowGraphMessage).FullName,
+                    out _
+                );
+
+                Assert.That(
+                    resolved,
+                    Is.False,
+                    "A cold source lookup should queue an index build instead of blocking for a result."
+                );
+                Assert.That(
+                    DxMessagingFlowGraphWindow.PendingMessageSourceIndexCount,
+                    Is.EqualTo(1),
+                    "A cold lookup should share one background index build for its compilation assembly."
+                );
+                Assert.That(
+                    readerStarted.Wait(TimeSpan.FromSeconds(10)),
+                    Is.True,
+                    "The queued source index should begin reading without requiring another UI action."
+                );
+                Assert.That(
+                    readerThreadId,
+                    Is.Not.EqualTo(editorThreadId),
+                    "Source files must be read on a worker thread, not Unity's editor thread."
+                );
+
+                releaseReader.Set();
+                DxMessagingFlowGraphWindow.CompleteMessageSourceIndexesForTests();
+                Assert.That(
+                    DxMessagingFlowGraphWindow.PendingMessageSourceIndexCount,
+                    Is.Zero,
+                    "The background index should drain and leave no pending assembly work."
+                );
+                Assert.That(
+                    indexChangedCount,
+                    Is.EqualTo(1),
+                    "Each completed assembly index should notify open Flow Graph windows immediately."
+                );
+            }
+            finally
+            {
+                releaseReader.Set();
+                DxMessagingFlowGraphWindow.CompleteMessageSourceIndexesForTests();
+                DxMessagingFlowGraphWindow.MessageSourceIndexChanged -= HandleIndexChanged;
+                DxMessagingFlowGraphWindow.ResetMessageSourceIndexesForTests();
+            }
+
+            void HandleIndexChanged()
+            {
+                indexChangedCount++;
+            }
+        }
+
+        [Test]
+        public void CompletedMessageSourceIndexDrainsWhileAnotherAssemblyIsPending()
+        {
+            DxMessagingFlowGraphWindow.ResetMessageSourceIndexesForTests();
+            using ManualResetEventSlim gatedReaderStarted = new(initialState: false);
+            using ManualResetEventSlim releaseGatedReader = new(initialState: false);
+            int indexChangedCount = 0;
+            try
+            {
+                DxMessagingFlowGraphWindow.MessageSourceIndexChanged += HandleIndexChanged;
+                DxMessagingFlowGraphWindow.MessageSourceFileReader = sourceFile =>
+                {
+                    if (
+                        sourceFile.EndsWith(
+                            "DxMessagingFlowGraphWindowTests.cs",
+                            StringComparison.Ordinal
+                        )
+                    )
+                    {
+                        gatedReaderStarted.Set();
+                        releaseGatedReader.Wait(TimeSpan.FromMinutes(1));
+                    }
+                    return Array.Empty<string>();
+                };
+
+                Assert.That(
+                    DxMessagingFlowGraphWindow.TryResolveMessageSource(
+                        typeof(GlobalStringMessage).FullName,
+                        out _
+                    ),
+                    Is.False
+                );
+                Assert.That(
+                    DxMessagingFlowGraphWindow.TryResolveMessageSource(
+                        typeof(FlowGraphMessage).FullName,
+                        out _
+                    ),
+                    Is.False
+                );
+                Assert.That(
+                    gatedReaderStarted.Wait(TimeSpan.FromSeconds(10)),
+                    Is.True,
+                    "The Editor-test assembly index should reach its intentionally gated source file."
+                );
+                Assert.That(
+                    SpinWait.SpinUntil(
+                        () => DxMessagingFlowGraphWindow.CompletedMessageSourceIndexCount > 0,
+                        TimeSpan.FromSeconds(10)
+                    ),
+                    Is.True,
+                    "The runtime assembly index should complete while the Editor-test index remains gated."
+                );
+
+                DxMessagingFlowGraphWindow.DrainMessageSourceIndexesForTests();
+
+                Assert.That(
+                    indexChangedCount,
+                    Is.EqualTo(1),
+                    "A completed assembly must notify immediately instead of waiting behind another pending build."
+                );
+                Assert.That(
+                    DxMessagingFlowGraphWindow.PendingMessageSourceIndexCount,
+                    Is.EqualTo(1),
+                    "Only the intentionally gated assembly should remain pending after the completed batch drains."
+                );
+
+                releaseGatedReader.Set();
+                DxMessagingFlowGraphWindow.CompleteMessageSourceIndexesForTests();
+                Assert.That(indexChangedCount, Is.EqualTo(2));
+            }
+            finally
+            {
+                releaseGatedReader.Set();
+                DxMessagingFlowGraphWindow.CompleteMessageSourceIndexesForTests();
+                DxMessagingFlowGraphWindow.MessageSourceIndexChanged -= HandleIndexChanged;
+                DxMessagingFlowGraphWindow.ResetMessageSourceIndexesForTests();
+            }
+
+            void HandleIndexChanged()
+            {
+                indexChangedCount++;
+            }
+        }
+
+        [Test]
+        public void MessageSourceResolverHonorsCapturedAssemblyIdentity()
+        {
+            DxMessagingFlowGraphWindow.ResetMessageSourceIndexesForTests();
+            try
+            {
+                string typeName = typeof(FlowGraphMessage).FullName;
+                Assert.That(
+                    DxMessagingFlowGraphWindow.TryResolveMessageSource(
+                        $"{typeName} [Not.The.Message.Assembly]",
+                        out _
+                    ),
+                    Is.False,
+                    "An assembly-qualified capture must not resolve a same-named type from another assembly."
+                );
+                Assert.That(
+                    DxMessagingFlowGraphWindow.PendingMessageSourceIndexCount,
+                    Is.Zero,
+                    "A missing captured assembly should not queue an unrelated assembly index."
+                );
+
+                string assemblyName = typeof(FlowGraphMessage).Assembly.GetName().Name;
+                Assert.That(
+                    DxMessagingFlowGraphWindow.TryResolveMessageSource(
+                        $"{typeName} [{assemblyName}]",
+                        out _
+                    ),
+                    Is.False,
+                    "The first lookup should queue the captured assembly index."
+                );
+                DxMessagingFlowGraphWindow.CompleteMessageSourceIndexesForTests();
+                Assert.That(
+                    DxMessagingFlowGraphWindow.TryResolveMessageSource(
+                        $"{typeName} [{assemblyName}]",
+                        out DxMessagingFlowGraphWindow.FlowGraphSourceLocation location
+                    ),
+                    Is.True,
+                    "The exact captured assembly should resolve after its background index completes."
+                );
+                Assert.That(
+                    location.AssetPath,
+                    Does.EndWith("Tests/Editor/DxMessagingFlowGraphWindowTests.cs")
+                );
+            }
+            finally
+            {
+                DxMessagingFlowGraphWindow.CompleteMessageSourceIndexesForTests();
+                DxMessagingFlowGraphWindow.ResetMessageSourceIndexesForTests();
+            }
+        }
+
+        [Test]
+        public void MessageSourceResolverRetriesTransientFileReadFailures()
+        {
+            DxMessagingFlowGraphWindow.ResetMessageSourceIndexesForTests();
+            try
+            {
+                string typeName = typeof(FlowGraphMessage).FullName;
+                DxMessagingFlowGraphWindow.MessageSourceFileReader = _ =>
+                    throw new IOException("Simulated transient source-file lock.");
+
+                Assert.That(
+                    DxMessagingFlowGraphWindow.TryResolveMessageSource(typeName, out _),
+                    Is.False
+                );
+                DxMessagingFlowGraphWindow.CompleteMessageSourceIndexesForTests();
+
+                DxMessagingFlowGraphWindow.MessageSourceFileReader = File.ReadAllLines;
+                DxMessagingFlowGraphWindow.AllowIncompleteMessageSourceIndexRetries();
+                Assert.That(
+                    DxMessagingFlowGraphWindow.TryResolveMessageSource(typeName, out _),
+                    Is.False,
+                    "The retry should remain asynchronous."
+                );
+                Assert.That(
+                    DxMessagingFlowGraphWindow.PendingMessageSourceIndexCount,
+                    Is.EqualTo(1),
+                    "A refresh should retry an incomplete assembly index after a transient read failure."
+                );
+                DxMessagingFlowGraphWindow.CompleteMessageSourceIndexesForTests();
+                Assert.That(
+                    DxMessagingFlowGraphWindow.TryResolveMessageSource(
+                        typeName,
+                        out DxMessagingFlowGraphWindow.FlowGraphSourceLocation location
+                    ),
+                    Is.True,
+                    "A temporary read failure must not become a permanent negative source-link cache entry."
+                );
+                Assert.That(location.Line, Is.GreaterThan(0));
+            }
+            finally
+            {
+                DxMessagingFlowGraphWindow.CompleteMessageSourceIndexesForTests();
+                DxMessagingFlowGraphWindow.ResetMessageSourceIndexesForTests();
             }
         }
 
@@ -1078,6 +1361,18 @@ namespace DxMessaging.Tests.Editor
                 "    \"\"still inside the literal\"\"",
                 "    \";",
                 "    public record struct GenericMessage<T> : IMessage;",
+                "    public readonly struct SplitMessage<",
+                "        TFirst,",
+                "        TSecond",
+                "    > : IMessage { }",
+                "    public readonly struct AttributedMessage<[Marker(typeof(Dictionary<,>))] TFirst, TSecond> : IMessage { }",
+                "    public class AttributeExpressionMessage<",
+                "        [Marker(2 > 1, new[] { 1, 2 })] TFirst,",
+                "        TSecond",
+                "    >",
+                "    {",
+                "        public struct Nested : IMessage { }",
+                "    }",
                 "}",
             };
 
@@ -1085,10 +1380,37 @@ namespace DxMessaging.Tests.Editor
                 DxMessagingFlowGraphWindow.FindTypeDeclarationLine(
                     lines,
                     "Example.Messages",
-                    new[] { "GenericMessage" }
+                    new[] { "GenericMessage`1" }
                 ),
                 Is.EqualTo(11),
                 "The scanner must select the live generic record declaration, not matching text inside a block comment or multiline verbatim string."
+            );
+            Assert.That(
+                DxMessagingFlowGraphWindow.FindTypeDeclarationLine(
+                    lines,
+                    "Example.Messages",
+                    new[] { "SplitMessage`2" }
+                ),
+                Is.EqualTo(12),
+                "The scanner must retain exact generic arity when a valid type parameter list spans lines."
+            );
+            Assert.That(
+                DxMessagingFlowGraphWindow.FindTypeDeclarationLine(
+                    lines,
+                    "Example.Messages",
+                    new[] { "AttributedMessage`2" }
+                ),
+                Is.EqualTo(16),
+                "The scanner must ignore nested generic commas inside parameter attributes and count the balanced outer list."
+            );
+            Assert.That(
+                DxMessagingFlowGraphWindow.FindTypeDeclarationLine(
+                    lines,
+                    "Example.Messages",
+                    new[] { "AttributeExpressionMessage`2", "Nested" }
+                ),
+                Is.EqualTo(22),
+                "Generic-parameter attribute operators and array braces must not close the outer list or consume its type scope."
             );
         }
 
@@ -9633,6 +9955,8 @@ namespace DxMessaging.Tests.Editor
         private static class SourceLinkBeta
         {
             internal readonly struct DuplicateSourceMessage : IUntargetedMessage { }
+
+            internal readonly struct GenericSourceMessage : IUntargetedMessage { }
 
             internal readonly struct GenericSourceMessage<T> : IUntargetedMessage { }
         }

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -842,8 +842,15 @@ namespace DxMessaging.Tests.Editor
                 selectionKey: "edge|second"
             );
 
+            IReadOnlyList<DxMessagingFlowGraphWindow.GraphCurveDescriptor> unselectedRenderOrder =
+                DxMessagingFlowGraphWindow.OrderGraphCurvesForRendering(new[] { first, second });
+            Assert.That(
+                unselectedRenderOrder.Select(curve => curve.SelectionKey),
+                Is.EqualTo(new[] { "edge|first", "edge|second" }),
+                "Rendering order must stay stable when no route is selected."
+            );
             string selected = DxMessagingFlowGraphWindow.FindGraphRouteAtPoint(
-                new[] { first, second },
+                unselectedRenderOrder,
                 first.Evaluate(0.25f),
                 hitRadius: 10f
             );
@@ -855,12 +862,47 @@ namespace DxMessaging.Tests.Editor
             );
             Assert.That(
                 DxMessagingFlowGraphWindow.FindGraphRouteAtPoint(
-                    new[] { first, second },
+                    unselectedRenderOrder,
                     first.Evaluate(0.5f),
                     hitRadius: 10f
                 ),
                 Is.EqualTo("edge|second"),
                 "An exact crossing must select the later route drawn visibly on top."
+            );
+            DxMessagingFlowGraphWindow.GraphCurveDescriptor selectedFirst = new(
+                first.Start,
+                first.End,
+                first.CurveOffset,
+                first.Color,
+                selected: true,
+                selectionKey: first.SelectionKey
+            );
+            DxMessagingFlowGraphWindow.GraphCurveDescriptor dimmedSecond = new(
+                second.Start,
+                second.End,
+                second.CurveOffset,
+                second.Color,
+                selected: false,
+                selectionKey: second.SelectionKey,
+                dimmed: true
+            );
+            IReadOnlyList<DxMessagingFlowGraphWindow.GraphCurveDescriptor> selectedRenderOrder =
+                DxMessagingFlowGraphWindow.OrderGraphCurvesForRendering(
+                    new[] { selectedFirst, dimmedSecond }
+                );
+            Assert.That(
+                selectedRenderOrder[selectedRenderOrder.Count - 1].SelectionKey,
+                Is.EqualTo("edge|first"),
+                "The selected route must render after every dimmed path so it stays visibly on top."
+            );
+            Assert.That(
+                DxMessagingFlowGraphWindow.FindGraphRouteAtPoint(
+                    selectedRenderOrder,
+                    selectedFirst.Evaluate(0.5f),
+                    hitRadius: 10f
+                ),
+                Is.EqualTo("edge|first"),
+                "At an exact crossing, hit testing must prefer the selected route rendered on top."
             );
             Assert.That(
                 DxMessagingFlowGraphWindow.FindGraphRouteAtPoint(
@@ -1497,6 +1539,11 @@ namespace DxMessaging.Tests.Editor
                 .Single(connection =>
                     connection.ClassListContains(DxMessagingFlowGraphWindow.SelectedRowClassName)
                 );
+            List<VisualElement> orderedConnections = refreshedGraph
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.GraphConnectionClassName
+                )
+                .ToList();
 
             Assert.That(selectedItemKey, Is.Not.Empty);
             Assert.That(refreshedState, Is.SameAs(canvasState));
@@ -1506,6 +1553,11 @@ namespace DxMessaging.Tests.Editor
             Assert.That(
                 selectedConnection.Children().Single().style.width.value.value,
                 Is.EqualTo(18f)
+            );
+            Assert.That(
+                orderedConnections[orderedConnections.Count - 1],
+                Is.SameAs(selectedConnection),
+                "The selected route marker must be the last sibling so dimmed markers cannot cover it."
             );
         }
 

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -3,6 +3,7 @@ namespace DxMessaging.Tests.Editor
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
     using Core;
     using Core.Diagnostics;
@@ -373,9 +374,9 @@ namespace DxMessaging.Tests.Editor
                 "Raw topology should default collapsed so components, messages, and edges do not duplicate the route map."
             );
             Assert.That(
-                detailsTitle.text,
-                Does.StartWith("Route:"),
-                $"The default selection should explain a route, but was '{detailsTitle.text}'."
+                detailsTitle,
+                Is.Null,
+                "The graph should wait for an intentional selection before opening diagnostics."
             );
 
             FlowGraphSnapshot tracedSnapshot = new(
@@ -561,9 +562,7 @@ namespace DxMessaging.Tests.Editor
                 .Query<VisualElement>(className: DxMessagingFlowGraphWindow.RouteMapRouteClassName)
                 .ToList()
                 .Count;
-            string detailsTitle = root.Q<Label>(
-                DxMessagingFlowGraphWindow.DetailsTitleLabelName
-            ).text;
+            Label detailsTitle = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsTitleLabelName);
 
             Assert.That(
                 graph
@@ -610,8 +609,8 @@ namespace DxMessaging.Tests.Editor
             Assert.That(moreRoutes.value, Is.False, "Overflow routes should default collapsed.");
             Assert.That(
                 detailsTitle,
-                Does.Contain("ConcreteMessage0"),
-                $"A concrete route should be selected ahead of GlobalAcceptAll, but was '{detailsTitle}'."
+                Is.Null,
+                "A dense graph should not auto-select a route and open diagnostics before user input."
             );
 
             analysis.value = true;
@@ -655,7 +654,7 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
-        public void GraphFrameScaleKeepsLargeNodeSetsReadableForPanning()
+        public void GraphFrameScaleAllowsStressGraphOverviewBeforePanning()
         {
             float scale = DxMessagingFlowGraphWindow.CalculateGraphFrameScale(
                 new Vector2(520f, 520f),
@@ -664,8 +663,432 @@ namespace DxMessaging.Tests.Editor
 
             Assert.That(
                 scale,
-                Is.EqualTo(0.8f),
-                $"A 100-row graph should preserve readable nodes and pan instead of shrinking them, but used {scale}."
+                Is.EqualTo(0.2f),
+                $"A 100-row stress graph should support a useful overview before panning, but used {scale}."
+            );
+        }
+
+        [Test]
+        public void BuildGraphUiProvidesExplicitZoomControlsForStressGraphs()
+        {
+            const int nodeCount = 40;
+            const int routesPerMessage = 10;
+            FlowGraphComponentNode[] components = Enumerable
+                .Range(0, nodeCount)
+                .Select(index => new FlowGraphComponentNode(
+                    $"component:{index}",
+                    $"Stress/Receiver {index}",
+                    "MessagingComponent",
+                    activeInHierarchy: true,
+                    listenerCount: 1,
+                    registrationCount: 1,
+                    callCount: index + 1,
+                    localMessageCount: 0
+                ))
+                .ToArray();
+            FlowGraphMessageNode[] messages = Enumerable
+                .Range(0, nodeCount)
+                .Select(index => new FlowGraphMessageNode($"Stress.Message{index}", 1, index + 1))
+                .ToArray();
+            FlowGraphEdge[] edges = Enumerable
+                .Range(0, nodeCount)
+                .SelectMany(messageIndex =>
+                    Enumerable
+                        .Range(0, routesPerMessage)
+                        .Select(routeIndex =>
+                        {
+                            int componentIndex = (messageIndex * 7 + routeIndex * 3) % nodeCount;
+                            string registrationTypeName = (routeIndex % 3) switch
+                            {
+                                0 => "Untargeted",
+                                1 => "Targeted",
+                                _ => "Broadcast",
+                            };
+                            return new FlowGraphEdge(
+                                messages[messageIndex].MessageTypeName,
+                                components[componentIndex].Id,
+                                components[componentIndex].HierarchyPath,
+                                registrationTypeName,
+                                registrationCount: 1,
+                                callCount: messageIndex + routeIndex + 1,
+                                context: $"Stress/Context {routeIndex}",
+                                contextId: routeIndex + 1
+                            );
+                        })
+                )
+                .ToArray();
+            EditorWindow window = CreateTrackedEditorWindow();
+            window.position = new Rect(80f, 80f, 1000f, 700f);
+            EditorWindowTestUtility.ShowWindow(window);
+            VisualElement root = window.rootVisualElement;
+            string selectedRoute = string.Empty;
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                new FlowGraphSnapshot(components, messages, edges, Array.Empty<string>()),
+                FlowGraphViewState.Default,
+                onSelectionChanged: key => selectedRoute = key
+            );
+
+            Assert.That(
+                root.Q<Button>(DxMessagingFlowGraphWindow.GraphZoomOutButtonName),
+                Is.Not.Null,
+                "Stress graphs need an explicit zoom-out control instead of requiring an undocumented wheel gesture."
+            );
+            Assert.That(
+                root.Q<Button>(DxMessagingFlowGraphWindow.GraphFitButtonName),
+                Is.Not.Null,
+                "Stress graphs need a one-action fit control."
+            );
+            Assert.That(
+                root.Q<Button>(DxMessagingFlowGraphWindow.GraphZoomInButtonName),
+                Is.Not.Null,
+                "A user who framed a stress graph needs an explicit way back to readable nodes."
+            );
+            VisualElement legend = root.Q<VisualElement>(
+                DxMessagingFlowGraphWindow.GraphLegendName
+            );
+            Assert.That(
+                legend.style.flexWrap.value,
+                Is.EqualTo(Wrap.Wrap),
+                "The legend and zoom controls must wrap instead of overflowing a constrained window."
+            );
+            Assert.That(
+                root.Q<VisualElement>(
+                    DxMessagingFlowGraphWindow.GraphZoomControlsName
+                ).style.flexShrink.value,
+                Is.EqualTo(0f),
+                "Constrained layouts must keep the zoom controls usable rather than shrinking them to zero width."
+            );
+            Assert.That(
+                root.Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.GraphConnectionClassName
+                    )
+                    .ToList()
+                    .Count,
+                Is.EqualTo(nodeCount * routesPerMessage),
+                "A dense many-to-many stress graph must keep hundreds of crossing routes selectable instead of dropping overflow routes."
+            );
+            VisualElement edgeLayer = root.Q<VisualElement>(
+                DxMessagingFlowGraphWindow.GraphEdgeLayerName
+            );
+            Assert.That(edgeLayer.panel, Is.Not.Null, "The stress edge layer must be attached.");
+            Assert.That(
+                edgeLayer.pickingMode,
+                Is.EqualTo(PickingMode.Position),
+                "Providing a route callback must make the complete edge layer interactive."
+            );
+            IReadOnlyList<DxMessagingFlowGraphWindow.GraphCurveDescriptor> curves =
+                (IReadOnlyList<DxMessagingFlowGraphWindow.GraphCurveDescriptor>)edgeLayer.userData;
+            Vector2 routePoint = curves[curves.Count - 1].Evaluate(0.2f);
+            float hitRadius = DxMessagingFlowGraphWindow.CalculateLocalGraphRouteHitRadius(
+                edgeLayer.worldTransform.MultiplyVector(Vector3.right).magnitude
+            );
+            string expectedRoute = DxMessagingFlowGraphWindow.FindGraphRouteAtPoint(
+                curves,
+                routePoint,
+                hitRadius
+            );
+            Assert.That(expectedRoute, Is.Not.Empty);
+            Event systemEvent = new()
+            {
+                type = EventType.MouseDown,
+                button = 0,
+                mousePosition = edgeLayer.LocalToWorld(routePoint),
+            };
+            using (MouseDownEvent mouseDown = MouseDownEvent.GetPooled(systemEvent))
+            {
+                mouseDown.target = edgeLayer;
+                edgeLayer.SendEvent(mouseDown);
+            }
+            Assert.That(
+                selectedRoute,
+                Is.EqualTo(expectedRoute),
+                "Clicking a non-marker segment in the attached 400-route graph must select the visible route."
+            );
+        }
+
+        [Test]
+        public void GraphFeatherColorPreservesRouteHueAtLowOpacity()
+        {
+            Color routeColor = new(0.2f, 0.4f, 0.8f, 0.75f);
+
+            Color featherColor = DxMessagingFlowGraphWindow.CreateGraphFeatherColor(routeColor);
+
+            Assert.That(featherColor.r, Is.EqualTo(routeColor.r));
+            Assert.That(featherColor.g, Is.EqualTo(routeColor.g));
+            Assert.That(featherColor.b, Is.EqualTo(routeColor.b));
+            Assert.That(featherColor.a, Is.EqualTo(routeColor.a * 0.22f));
+        }
+
+        [Test]
+        public void GraphRouteHitTestingSelectsTheSourceToDestinationCurve()
+        {
+            DxMessagingFlowGraphWindow.GraphCurveDescriptor first = new(
+                new Vector2(10f, 20f),
+                new Vector2(410f, 220f),
+                curveOffset: 0f,
+                Color.green,
+                selected: false,
+                selectionKey: "edge|first"
+            );
+            DxMessagingFlowGraphWindow.GraphCurveDescriptor second = new(
+                new Vector2(10f, 220f),
+                new Vector2(410f, 20f),
+                curveOffset: 0f,
+                Color.red,
+                selected: false,
+                selectionKey: "edge|second"
+            );
+
+            string selected = DxMessagingFlowGraphWindow.FindGraphRouteAtPoint(
+                new[] { first, second },
+                first.Evaluate(0.25f),
+                hitRadius: 10f
+            );
+
+            Assert.That(
+                selected,
+                Is.EqualTo("edge|first"),
+                "Clicking the source-to-destination path must select that route, not require finding its midpoint glyph."
+            );
+            Assert.That(
+                DxMessagingFlowGraphWindow.FindGraphRouteAtPoint(
+                    new[] { first, second },
+                    first.Evaluate(0.5f),
+                    hitRadius: 10f
+                ),
+                Is.EqualTo("edge|second"),
+                "An exact crossing must select the later route drawn visibly on top."
+            );
+            Assert.That(
+                DxMessagingFlowGraphWindow.FindGraphRouteAtPoint(
+                    new[] { first, second },
+                    new Vector2(900f, 900f),
+                    hitRadius: 10f
+                ),
+                Is.Empty,
+                "Empty-canvas clicks must remain available for panning."
+            );
+            Assert.That(
+                DxMessagingFlowGraphWindow.CalculateLocalGraphRouteHitRadius(0.2f),
+                Is.EqualTo(50f),
+                "The 20 percent overview must retain a 10-pixel screen-space route hit corridor."
+            );
+            Assert.That(
+                DxMessagingFlowGraphWindow.CalculateLocalGraphRouteHitRadius(2f),
+                Is.EqualTo(5f),
+                "Zooming in must not make adjacent routes share an oversized hit corridor."
+            );
+        }
+
+        [Test]
+        public void BuildGraphUiCollapsesRouteEvidenceAndLinksMessageSource()
+        {
+            string messageTypeName = typeof(FlowGraphMessage).FullName;
+            FlowGraphEdge edge = new(
+                messageTypeName,
+                "component:receiver",
+                "Root/Receiver",
+                "Untargeted",
+                registrationCount: 1,
+                callCount: 3,
+                recentEmissionSites: new[] { "Game.Emit () (at Assets/Scripts/Game.cs:42)" }
+            );
+            FlowGraphSnapshot snapshot = new(
+                new[]
+                {
+                    new FlowGraphComponentNode(
+                        "component:receiver",
+                        "Root/Receiver",
+                        "MessagingComponent",
+                        activeInHierarchy: true,
+                        listenerCount: 1,
+                        registrationCount: 1,
+                        callCount: 3,
+                        localMessageCount: 0
+                    ),
+                },
+                new[] { new FlowGraphMessageNode(messageTypeName, 1, 3) },
+                new[] { edge },
+                Array.Empty<string>()
+            );
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(edge)
+                )
+            );
+
+            Foldout evidence = root.Q<Foldout>(
+                DxMessagingFlowGraphWindow.DetailsEvidenceFoldoutName
+            );
+            Assert.That(
+                evidence,
+                Is.Not.Null,
+                "Verbose emission and trace evidence should live behind one named disclosure."
+            );
+            Assert.That(
+                evidence.value,
+                Is.False,
+                "Route evidence should start collapsed so selecting a route does not replace the graph with text."
+            );
+            Button messageSource = root.Query<Button>(
+                    name: DxMessagingFlowGraphWindow.SourceLinkButtonName
+                )
+                .ToList()
+                .Single(button =>
+                    button.text.StartsWith("Open message source", StringComparison.Ordinal)
+                );
+            DxMessagingFlowGraphWindow.FlowGraphSourceLocation location =
+                (DxMessagingFlowGraphWindow.FlowGraphSourceLocation)messageSource.userData;
+            Assert.That(
+                location.AssetPath,
+                Does.EndWith("Tests/Editor/DxMessagingFlowGraphWindowTests.cs"),
+                $"The selected message should resolve to its declaring script, but resolved {location.AssetPath}."
+            );
+            Assert.That(
+                location.Line,
+                Is.GreaterThan(0),
+                "The message-source action should open the declaring line, not only the file."
+            );
+        }
+
+        [Test]
+        public void SourceLocationParserExtractsUnityCallSitePathAndLine()
+        {
+            bool parsed = DxMessagingFlowGraphWindow.TryParseSourceLocation(
+                "Game.Emit () (at Assets/Scripts/Game.cs:42)",
+                out DxMessagingFlowGraphWindow.FlowGraphSourceLocation location
+            );
+
+            Assert.That(parsed, Is.True, "A standard Unity call site should be linkable.");
+            Assert.That(location.AssetPath, Is.EqualTo("Assets/Scripts/Game.cs"));
+            Assert.That(location.Line, Is.EqualTo(42));
+            Assert.That(
+                DxMessagingFlowGraphWindow.TryParseSourceLocation(
+                    "Game.Emit without a location",
+                    out _
+                ),
+                Is.False,
+                "Diagnostic text without a Unity source suffix must remain plain text."
+            );
+        }
+
+        [Test]
+        public void MessageSourceResolverDistinguishesNestingAndGenericArity()
+        {
+            Type[] messageTypes =
+            {
+                typeof(SourceLinkBeta.DuplicateSourceMessage),
+                typeof(SourceLinkBeta.GenericSourceMessage<int>).GetGenericTypeDefinition(),
+            };
+            foreach (Type messageType in messageTypes)
+            {
+                string messageTypeName = messageType.FullName;
+                FlowGraphEdge edge = new(
+                    messageTypeName,
+                    "component:source-link",
+                    "Root/Source Link",
+                    "Untargeted",
+                    registrationCount: 1,
+                    callCount: 1
+                );
+                FlowGraphSnapshot snapshot = new(
+                    new[]
+                    {
+                        new FlowGraphComponentNode(
+                            "component:source-link",
+                            "Root/Source Link",
+                            "MessagingComponent",
+                            activeInHierarchy: true,
+                            listenerCount: 1,
+                            registrationCount: 1,
+                            callCount: 1,
+                            localMessageCount: 0
+                        ),
+                    },
+                    new[] { new FlowGraphMessageNode(messageTypeName, 1, 1) },
+                    new[] { edge },
+                    Array.Empty<string>()
+                );
+                VisualElement root = new();
+
+                DxMessagingFlowGraphWindow.BuildGraphUi(
+                    root,
+                    snapshot,
+                    new FlowGraphViewState(
+                        selectedItemKey: DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(edge)
+                    )
+                );
+
+                Button messageSource = root.Query<Button>(
+                        name: DxMessagingFlowGraphWindow.SourceLinkButtonName
+                    )
+                    .ToList()
+                    .Single(button =>
+                        button.text.StartsWith("Open message source", StringComparison.Ordinal)
+                    );
+                DxMessagingFlowGraphWindow.FlowGraphSourceLocation location =
+                    (DxMessagingFlowGraphWindow.FlowGraphSourceLocation)messageSource.userData;
+                string declaration = File.ReadAllLines(Path.GetFullPath(location.AssetPath))[
+                    location.Line - 1
+                ];
+                Assert.That(
+                    declaration,
+                    Does.Contain(
+                        messageType == messageTypes[0]
+                            ? "DuplicateSourceMessage"
+                            : "GenericSourceMessage<T>"
+                    ),
+                    $"{messageTypeName} resolved to the wrong declaration at {location.AssetPath}:{location.Line}."
+                );
+                if (messageType == messageTypes[0])
+                {
+                    Assert.That(
+                        location.Line,
+                        Is.GreaterThan(
+                            Array.FindIndex(
+                                File.ReadAllLines(Path.GetFullPath(location.AssetPath)),
+                                line => line.Contains("class SourceLinkBeta")
+                            ) + 1
+                        ),
+                        "The duplicate message must resolve inside SourceLinkBeta, not SourceLinkAlpha."
+                    );
+                }
+            }
+        }
+
+        [Test]
+        public void TypeDeclarationScannerSupportsRecordsAndIgnoresNonCodeText()
+        {
+            string[] lines =
+            {
+                "namespace Example.Messages",
+                "{",
+                "    /*",
+                "    public record struct GenericMessage<T> : IMessage;",
+                "    */",
+                "    string decoy = @\"",
+                "    }",
+                "    public record struct GenericMessage<T> : IMessage;",
+                "    \"\"still inside the literal\"\"",
+                "    \";",
+                "    public record struct GenericMessage<T> : IMessage;",
+                "}",
+            };
+
+            Assert.That(
+                DxMessagingFlowGraphWindow.FindTypeDeclarationLine(
+                    lines,
+                    "Example.Messages",
+                    new[] { "GenericMessage" }
+                ),
+                Is.EqualTo(11),
+                "The scanner must select the live generic record declaration, not matching text inside a block comment or multiline verbatim string."
             );
         }
 
@@ -731,9 +1154,7 @@ namespace DxMessaging.Tests.Editor
                     className: DxMessagingFlowGraphWindow.GraphConnectionClassName
                 )
                 .ToList()
-                .Single(connection =>
-                    !connection.ClassListContains(DxMessagingFlowGraphWindow.SelectedRowClassName)
-                );
+                .First();
 
             using (ClickEvent click = ClickEvent.GetPooled())
             {
@@ -1781,7 +2202,7 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
-        public void BuildGraphUiRendersSelectionDetailsAndHighlightsFirstRoute()
+        public void BuildGraphUiWaitsForSelectionBeforeRenderingDetails()
         {
             FlowGraphSnapshot snapshot = CreateTwoEdgeSnapshot();
             VisualElement root = new();
@@ -1791,6 +2212,23 @@ namespace DxMessaging.Tests.Editor
             VisualElement details = root.Q<VisualElement>(
                 DxMessagingFlowGraphWindow.DetailsPaneName
             );
+            Assert.That(
+                details,
+                Is.Null,
+                "Diagnostics should remain closed until a route or node is intentionally selected."
+            );
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(
+                        snapshot.Edges[0]
+                    )
+                )
+            );
+
+            details = root.Q<VisualElement>(DxMessagingFlowGraphWindow.DetailsPaneName);
             Assert.That(details, Is.Not.Null);
             Assert.That(
                 details.Q<Label>(DxMessagingFlowGraphWindow.DetailsTitleLabelName).text,
@@ -9186,6 +9624,18 @@ namespace DxMessaging.Tests.Editor
         private readonly struct FlowGraphMixedMessage : IBroadcastMessage, ITargetedMessage { }
 
         private readonly struct EvidenceOnlyFlowGraphMessage : IUntargetedMessage { }
+
+        private static class SourceLinkAlpha
+        {
+            internal readonly struct DuplicateSourceMessage : IUntargetedMessage { }
+        }
+
+        private static class SourceLinkBeta
+        {
+            internal readonly struct DuplicateSourceMessage : IUntargetedMessage { }
+
+            internal readonly struct GenericSourceMessage<T> : IUntargetedMessage { }
+        }
 
         [Serializable]
         private sealed class FlowGraphExportPayload

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -129,9 +129,11 @@ interactive graph: message nodes occupy the left column, receiver nodes occupy
 the right column, and arrowheads carry direction without placing text labels on
 the lines. The layout alternates crossing-reduction sweeps across both columns,
 then orders each node's connection ports by the opposite column. Small
-shape-and-color route selectors use a 30-pixel canvas target. The readable zoom
-floor keeps that target at least 24 screen pixels while avoiding nearby arrows.
-Nodes use named metric rows instead of compact `+N` summaries.
+shape-and-color route selectors identify registration kinds, while the full
+feathered curve accepts clicks through a generous hit corridor. Select a route
+near either endpoint or between crossings; the selected path stays bright while
+unrelated paths dim. Nodes use named metric rows instead of compact `+N`
+summaries.
 
 Broadcast nodes identify source scope, targeted nodes identify target scope,
 and untargeted nodes identify the global bus. A type with more than one visible
@@ -139,20 +141,25 @@ route kind uses a `MIXED` node with neutral route, receiver, and call metrics;
 filtering it to one route kind restores that kind's focused metrics. Targeted
 and broadcast route details list recent call sites from the exact component
 registration delivery record when token diagnostics captured them. A call site
-identifies the emitting script, method, file, and line; it does not invent a
-sender object because targeted emission APIs carry a target, not a sender.
+identifies the emitting script, method, file, and line. Use **Open call site**
+to open that exact line. Message and route selections also provide **Open
+message source** when Unity can resolve the captured type to its declaration.
+The graph does not invent a sender object because targeted emission APIs carry
+a target, not a sender.
 Global accept-all registrations appear as
 `GLOBAL OBSERVER / ANY MESSAGE`, and their details list the concrete message
 types observed in recent trace evidence. Drag to pan, scroll to zoom, and select
-a node or connection to inspect it. Automatic framing keeps a readable zoom
-floor; large filtered graphs remain available through panning instead of shrinking their text
-and interaction targets into an unreadable overview. The canvas renders every
-filtered message, receiver, and route instead of moving extra message types
-into a text overflow list.
+a node or connection to inspect it. Use **-**, **Fit**, and **+** when a mouse
+wheel is unavailable. Automatic framing can zoom out to 20 percent for a useful
+overview of large graphs; zoom back in or pan before selecting closely spaced
+items. The canvas renders every filtered message, receiver, and route instead
+of moving extra message types into a text overflow list.
 
-The selected item inspector sits directly below the canvas. Route selections
-use responsive cards for the route path, activity metrics, emission evidence,
-and trace evidence. Its newline-oriented technical report starts collapsed.
+The window opens without selecting a node or route, so the canvas leads without
+a details wall. The selected item inspector sits directly below the canvas only
+after an intentional selection. Route selections show the route path and
+activity metrics first; emission evidence, trace evidence, and the
+newline-oriented technical report each start collapsed.
 Expand **Analysis and Raw Data** only when you need the textual route map,
 message and target lanes, trace activity, or topology lists. Inside that
 section, concrete routes sort before `GlobalAcceptAll`; call volume, recent

--- a/progress/session-188-flow-graph-followup.md
+++ b/progress/session-188-flow-graph-followup.md
@@ -38,7 +38,9 @@ site** action for the exact recorded file and line.
 - Message source resolution scans Unity compilation inputs for the captured
   runtime type and finds the exact class, struct, interface, or record
   declaration line. It distinguishes namespaces and declaring-type nesting,
-  strips generic arity, and ignores comments and multiline string literals.
+  preserves generic arity and captured assembly identity, and ignores comments
+  and multiline string literals. Assembly indexes build off the Editor thread,
+  read each source file once per build, and retry transient I/O failures.
 - Captured Unity call-site strings open their exact asset line.
 - A stress fixture renders 40 messages, 40 receivers, and 400 many-to-many
   crossing routes, and asserts that every connection stays selectable.
@@ -72,11 +74,23 @@ site** action for the exact recorded file and line.
   hit order, an attached 400-route mouse integration, and scope-aware source
   scanning. Follow-up then found multiline verbatim strings could corrupt the
   scanner; persisted literal state and a fake-declaration regression resolved
-  it. The final reviewer pass reported no remaining actionable issue.
+  it.
+- Cursor's late exact-head review found that the source resolver still scanned
+  every compilation source synchronously on the UI thread. The resolver now
+  captures immutable paths through Unity APIs on the main thread, indexes their
+  declarations on a worker, and refreshes selected graph details as each
+  completed batch drains. Follow-up adversarial review also identified generic
+  arity collisions, discarded captured assembly identity, delayed completion
+  notification, and permanent misses after transient file-read failures. The
+  implementation and focused regressions cover each case. The final adversarial
+  pass reported zero actionable findings, including minor issues.
+- Post-review local verification: **163 passed / 0 failed** in the focused Flow
+  Graph fixture and **607 passed / 0 failed** across the full Editor assembly.
 
 ## Publication
 
 - Commit `6ba526da` carries the complete implementation and validation record.
-- Draft PR [#348](https://github.com/Ambiguous-Interactive/DxMessaging/pull/348)
-  targets `master` and closes #345 while keeping #346 open.
-- Automated review and PR CI remain pending.
+- PR [#348](https://github.com/Ambiguous-Interactive/DxMessaging/pull/348) is
+  ready for review, targets `master`, closes #345, and keeps #346 open.
+- Renewed automated review and exact-head PR CI remain pending for the
+  background source-index follow-up.

--- a/progress/session-188-flow-graph-followup.md
+++ b/progress/session-188-flow-graph-followup.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-03
 Branch: `dev/wallstop/session-188-flow-graph-followup`
-PR: pending
+PR: [#348](https://github.com/Ambiguous-Interactive/DxMessaging/pull/348)
 Issue: [#345](https://github.com/Ambiguous-Interactive/DxMessaging/issues/345)
 
 ## Outcome
@@ -76,4 +76,7 @@ site** action for the exact recorded file and line.
 
 ## Publication
 
-- Commit, push, draft PR, automated review, and PR CI remain pending.
+- Commit `6ba526da` carries the complete implementation and validation record.
+- Draft PR [#348](https://github.com/Ambiguous-Interactive/DxMessaging/pull/348)
+  targets `master` and closes #345 while keeping #346 open.
+- Automated review and PR CI remain pending.

--- a/progress/session-188-flow-graph-followup.md
+++ b/progress/session-188-flow-graph-followup.md
@@ -1,0 +1,79 @@
+# Session 188 -- Flow Graph interaction and density follow-up
+
+Date: 2026-08-03
+Branch: `dev/wallstop/session-188-flow-graph-followup`
+PR: pending
+Issue: [#345](https://github.com/Ambiguous-Interactive/DxMessaging/issues/345)
+
+## Outcome
+
+Issue #345 reopened immediately after session 187 merged with concrete follow-up
+requests around route selection, aliasing, large graphs, source navigation, and
+the initial amount of text. This session keeps the interactive graph direction
+and closes those gaps.
+
+The entire source-to-destination curve now accepts clicks through a sampled hit
+corridor instead of making the midpoint route glyph the only interaction
+target. Feathered route meshes reduce jagged edges. A selected route remains
+bright while unrelated paths dim, preserving context without hiding topology.
+Explicit minus, Fit, plus, and percentage controls complement wheel zoom, and
+automatic framing can reach 20 percent for a useful overview of dense graphs.
+
+The window no longer chooses a default node or route. Details appear only after
+an intentional selection, and route or message evidence starts collapsed below
+the primary identity and activity information. Resolvable message selections
+open the exact declaration line. Captured call sites expose an **Open call
+site** action for the exact recorded file and line.
+
+## Contract updates
+
+- Clicking anywhere along a visible route selects its exact
+  message-to-receiver edge; an empty-canvas click remains available for panning.
+- A low-opacity feather preserves the route hue around the core mesh.
+- Selection dims unrelated routes without removing them from the graph.
+- Fit and explicit zoom controls remain usable in a 640-pixel-wide toolbar.
+- Automatic framing supports a 20 percent overview before users pan or zoom in.
+- No details inspector renders until the user selects a node or route.
+- Emission, trace, and technical evidence start collapsed.
+- Message source resolution scans Unity compilation inputs for the captured
+  runtime type and finds the exact class, struct, interface, or record
+  declaration line. It distinguishes namespaces and declaring-type nesting,
+  strips generic arity, and ignores comments and multiline string literals.
+- Captured Unity call-site strings open their exact asset line.
+- A stress fixture renders 40 messages, 40 receivers, and 400 many-to-many
+  crossing routes, and asserts that every connection stays selectable.
+
+## Unity MCP science
+
+- Final focused Flow Graph fixture: **159 passed / 0 failed** in 11.98 seconds
+  on Unity 6000.4.6f1.
+- Final full `WallstopStudios.DxMessaging.Tests.Editor` assembly: **603 passed /
+  0 failed / 0 skipped** in 7.45 seconds.
+- A live attached-panel click at 20 percent along a route curve opened its route
+  details and selected its matching graph markers.
+- A live zoom-out button click changed the graph from 63 percent to 50 percent
+  and updated the visible percentage label.
+- At 640 x 900, the wrapped toolbar measured all hint and zoom-control bounds
+  inside the root width.
+- Dark-skin captures show a quiet no-selection initial view and a focused route
+  view with unrelated routes dimmed and evidence collapsed.
+
+## Repository validation and review
+
+- Documentation snippet compilation: **441 passed / 0 failed**.
+- Node.js script suite: **406 passed / 0 failed** after the final source changes.
+- CSharpier, Prettier, Markdownlint, spelling, `npm run validate:all`, ASCII
+  changed-line checks, and `git diff --check` passed.
+- The latest `master` Unity Tests, Performance Numbers, and static CI completed
+  green before publication; this branch fast-forwarded over its automated
+  performance-number update without overlap.
+- Adversarial review found three defects: crossing draw/hit order, a marker-only
+  stress assertion, and ambiguous source lookup. The corrections added reverse
+  hit order, an attached 400-route mouse integration, and scope-aware source
+  scanning. Follow-up then found multiline verbatim strings could corrupt the
+  scanner; persisted literal state and a fake-declaration regression resolved
+  it. The final reviewer pass reported no remaining actionable issue.
+
+## Publication
+
+- Commit, push, draft PR, automated review, and PR CI remain pending.

--- a/progress/session-188-flow-graph-followup.md
+++ b/progress/session-188-flow-graph-followup.md
@@ -86,6 +86,9 @@ site** action for the exact recorded file and line.
   pass reported zero actionable findings, including minor issues.
 - Post-review local verification: **163 passed / 0 failed** in the focused Flow
   Graph fixture and **607 passed / 0 failed** across the full Editor assembly.
+- Renewed Cursor review found selected routes could remain below later dimmed
+  paths at crossings. Selected curves and markers now render last, and hit
+  testing follows that same visible order.
 
 ## Publication
 

--- a/progress/session-188-flow-graph-followup.md.meta
+++ b/progress/session-188-flow-graph-followup.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4b7f616c1ad04972977f4f9624fa28c2
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

Complete the reopened #345 Flow Graph follow-up so dense topology stays navigable and route inspection starts from the graph instead of a wall of text.

- make the full source-to-destination curve clickable with a constant 10-pixel screen-space hit corridor
- feather route meshes, keep the selected route bright, and dim unrelated paths
- add explicit zoom-out, Fit, zoom-in, and percentage controls with a 20% overview floor
- remove automatic default selection and collapse emission, trace, and technical evidence
- open exact message declarations and captured Unity call-site lines
- keep the toolbar usable at 640 pixels and retain every route in a 40-message, 40-receiver, 400-route stress graph

## Why

PR #347 established the interactive graph, but #345 was reopened with specific gaps: route lines were not directly selectable, large graphs could not zoom far enough out, source navigation was missing, edge aliasing remained harsh, and opening the window still surfaced too much text. This follow-up closes those gaps without changing the diagnostics export schema or runtime dispatch behavior.

The exact-source resolver is namespace-, declaring-type-, generic-arity-, record-, comment-, and multiline-verbatim-string-aware. Ambiguous simple type names intentionally produce no link rather than opening the wrong declaration.

## Validation

- Unity 6000.4.6f1 focused Flow Graph fixture: **159 passed / 0 failed / 0 skipped**
- Unity 6000.4.6f1 full Editor assembly: **603 passed / 0 failed / 0 skipped**
- documentation snippet compilation: **441 passed / 0 failed**
- Node.js script suite: **406 passed / 0 failed**
- CSharpier, Prettier, Markdownlint, cspell, `npm run validate:all`, changed-line ASCII, pre-commit hooks, pre-push hooks, and `git diff --check`
- live Unity MCP science verified full-curve selection, zoom controls, selected-route contrast, collapsed evidence, and a contained 640 x 900 toolbar
- iterative adversarial review covered draw/hit order, attached dense-graph input, exact source resolution, literal/comment parsing, Unity 2021.3 compatibility, panning conflicts, mesh behavior, and leaks; final review reported no actionable findings

## Issue impact

Closes #345.

This also improves the Flow Graph step in #346, but does not close the sample-guidance issue. #344 remains the next diagnostics-usability task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are editor-only UI and background file indexing in `DxMessagingFlowGraphWindow`, with no runtime messaging API impact; risk is moderate due to large new parsing/indexing logic and dense-graph hit-testing behavior.
> 
> **Overview**
> This PR finishes the reopened **#345** Flow Graph follow-up: dense graphs stay navigable and inspection starts from the graph instead of a default details wall.
> 
> **Route interaction:** The full source-to-destination curve is clickable via a sampled hit corridor (constant ~10px screen space), with feathered route meshes and dimmed non-selected paths. Selected routes and markers render last so crossings stay visible and win overlapping clicks. Explicit **-**, **Fit**, **+**, and a percentage label complement wheel zoom; framing can go down to **20%** for large graphs.
> 
> **Selection UX:** The window no longer auto-selects a route or node on open. Route path and activity lead; emission, trace, and technical evidence sit behind a collapsed **Evidence and source details** foldout.
> 
> **Source navigation:** Resolvable message types get **Open message source**; captured Unity call sites get **Open call site**. Declaration lookup indexes compilation assemblies **off the editor thread** (one read per source file per build), with namespace/nesting/generic arity awareness, captured assembly identity, and retries after transient I/O failures; the UI refreshes when indexes complete.
> 
> Docs, changelog, sample README, and editor tests (including a 400-route stress fixture) align with these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 338ac3ad6dbc3e9320b0d7ea74f059916b978864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->