### PR TITLE
Clarify Flow Graph evidence details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   use separate route-health and trace-coverage cards with bordered relationship
   records for their busiest paths. Captured object contexts render as breadcrumb
   hierarchies, call sites separate the method from the file and line, and compact
-  selection headers keep exact identities in tooltips. The complete text report
-  remains available through **Copy diagnostics** without rendering a text wall.
+  selection headers keep exact identities in tooltips. Breadcrumbs backed by an
+  exact captured Unity-object identity and relationship endpoints select their graph items, message
+  details expose a bounded on-demand route roster with receiver, registration,
+  context, and context-ID identities, and global observers use the accessible amber taxonomy
+  badge. The complete text report remains available through **Copy diagnostics**
+  without rendering a text wall.
   Broadcast and targeted routes
   expose recent component- and registration-exact delivery call sites without
   leaking evidence across message buses. Global accept-all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trace cards. Evidence lists message types and call sites as separate rows,
   links every resolvable type declaration and live call-site asset, and keeps
   dense type sets behind an eight-row disclosure. Technical diagnostics now
-  use separate route-health and trace-coverage cards; the complete text report
+  use separate route-health and trace-coverage cards with bordered relationship
+  records for their busiest paths. Captured object contexts render as breadcrumb
+  hierarchies, call sites separate the method from the file and line, and compact
+  selection headers keep exact identities in tooltips. The complete text report
   remains available through **Copy diagnostics** without rendering a text wall.
   Broadcast and targeted routes
   expose recent component- and registration-exact delivery call sites without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lines. Nodes use named metric rows instead of compact `+N` summaries, and
   multi-kind message types use neutral `MIXED` metrics until filtered to one
   route kind. Route selection opens responsive route, activity, emission, and
-  trace cards while
-  the dense technical report stays collapsed. Broadcast and targeted routes
+  trace cards. Evidence lists message types and call sites as separate rows,
+  links every resolvable type declaration and live call-site asset, and keeps
+  dense type sets behind an eight-row disclosure. Technical diagnostics now
+  use separate route-health and trace-coverage cards; the complete text report
+  remains available through **Copy diagnostics** without rendering a text wall.
+  Broadcast and targeted routes
   expose recent component- and registration-exact delivery call sites without
   leaking evidence across message buses. Global accept-all
   registrations appear as `ANY MESSAGE` observers instead of a misleading
@@ -55,7 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   overview floor, and removes the automatic default selection. Route activity
   now leads while emission, trace, and technical evidence start collapsed.
   Message and call-site source links open the exact declaration or captured
-  line when Unity can resolve it. Dense many-to-many coverage keeps hundreds of
+  line when Unity can resolve it, and evidence disclosures stay open when the
+  background source index refreshes. Dense many-to-many coverage keeps hundreds of
   crossing routes present and selectable in constrained layouts
   ([#345](https://github.com/Ambiguous-Interactive/DxMessaging/issues/345)).
 - Improve targeted and source-bound broadcast routing throughput and reduce the

--- a/Editor/DxMessagingEditorTheme.cs
+++ b/Editor/DxMessagingEditorTheme.cs
@@ -41,6 +41,7 @@ namespace DxMessaging.Editor
         internal const string TypeBadgeUntargetedClassName = "dx-typebadge--u";
         internal const string TypeBadgeTargetedClassName = "dx-typebadge--t";
         internal const string TypeBadgeBroadcastClassName = "dx-typebadge--b";
+        internal const string TypeBadgeGlobalObserverClassName = "dx-typebadge--g";
         internal const string DotClassName = "dx-dot";
         internal const string DotUntargetedClassName = "dx-dot--u";
         internal const string DotTargetedClassName = "dx-dot--t";
@@ -68,6 +69,8 @@ namespace DxMessaging.Editor
         internal const string DetailHeadClassName = "dx-detail__head";
         internal const string DetailTitleClassName = "dx-detail__title";
         internal const string DetailFrameClassName = "dx-detail__frame";
+        internal const string DetailLinkClassName = "dx-detail__link";
+        internal const string DetailActiveClassName = "dx-detail__active";
         internal const string KeyValueClassName = "dx-kv";
         internal const string KeyValueKeyClassName = "dx-kv__k";
         internal const string KeyValueValueClassName = "dx-kv__v";

--- a/Editor/Theme/DxMessagingTheme.uss
+++ b/Editor/Theme/DxMessagingTheme.uss
@@ -113,6 +113,7 @@
 .dx-typebadge--u { background-color: var(--dx-untargeted); }
 .dx-typebadge--t { background-color: var(--dx-targeted); }
 .dx-typebadge--b { background-color: var(--dx-broadcast); }
+.dx-typebadge--g { background-color: var(--dx-accent); color: var(--dx-accent-ink); }
 
 /* ---------- list ---------- */
 .dx-list-header {
@@ -160,6 +161,24 @@
 .dx-detail__head { flex-direction: row; align-items: center; margin-bottom: 10px; }
 .dx-detail__title { -unity-font-style: bold; font-size: 16px; color: var(--dx-text); margin-left: 9px; }
 .dx-detail__frame { color: var(--dx-text-muted); font-size: 10px; }
+.dx-detail__link {
+    background-color: var(--dx-tool-field);
+    border-left-width: 2px;
+    border-left-color: var(--dx-accent);
+    border-radius: var(--dx-r-chip);
+    padding-left: 4px;
+    padding-right: 4px;
+}
+.dx-detail__link:hover { background-color: var(--dx-tool-btn-hover); }
+.dx-detail__link:focus { background-color: var(--dx-tool-selected); }
+.dx-detail__active {
+    background-color: var(--dx-tool-selected);
+    border-left-width: 2px;
+    border-left-color: var(--dx-accent);
+    border-radius: var(--dx-r-chip);
+    padding-left: 4px;
+    padding-right: 4px;
+}
 
 .dx-card {
     background-color: var(--dx-tool-card);
@@ -172,6 +191,9 @@
     padding-bottom: 9px;
     margin-bottom: 8px;
 }
+.dx-card.dx-detail__link { background-color: var(--dx-tool-field); }
+.dx-card.dx-detail__link:hover { background-color: var(--dx-tool-btn-hover); }
+.dx-card.dx-detail__link:focus { background-color: var(--dx-tool-selected); }
 .dx-card__label {
     font-size: 9px;
     letter-spacing: 0.6px;

--- a/Editor/Theme/DxMessagingTheme.uss
+++ b/Editor/Theme/DxMessagingTheme.uss
@@ -163,8 +163,8 @@
 .dx-detail__frame { color: var(--dx-text-muted); font-size: 10px; }
 .dx-detail__link {
     background-color: var(--dx-tool-field);
-    border-left-width: 2px;
-    border-left-color: var(--dx-accent);
+    border-width: 1px;
+    border-color: var(--dx-accent);
     border-radius: var(--dx-r-chip);
     padding-left: 4px;
     padding-right: 4px;
@@ -173,8 +173,8 @@
 .dx-detail__link:focus { background-color: var(--dx-tool-selected); }
 .dx-detail__active {
     background-color: var(--dx-tool-selected);
-    border-left-width: 2px;
-    border-left-color: var(--dx-accent);
+    border-width: 1px;
+    border-color: var(--dx-accent);
     border-radius: var(--dx-r-chip);
     padding-left: 4px;
     padding-right: 4px;

--- a/Editor/Theme/DxTokens.uss
+++ b/Editor/Theme/DxTokens.uss
@@ -61,7 +61,7 @@
 /* ---- Light editor skin: "Press" paper ---- */
 .dx-theme.dx-light {
     --dx-accent: #b07d1f;
-    --dx-accent-ink: #ffffff;
+    --dx-accent-ink: #0d1117;
 
     --dx-untargeted-text: #35536f;
     --dx-targeted-text: #a3283b;

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -170,13 +170,18 @@ namespace DxMessaging.Editor.Windows
         internal const string EdgeRouteKindLabelName = "dxmessaging-flow-graph-edge-route-kind";
         internal const string DetailsPaneName = "dxmessaging-flow-graph-details";
         internal const string DetailsTitleLabelName = "dxmessaging-flow-graph-details-title";
-        internal const string DetailsBodyLabelName = "dxmessaging-flow-graph-details-body";
         internal const string DetailsSectionClassName = "dxmessaging-flow-graph-details-section";
         internal const string DetailsMetricClassName = "dxmessaging-flow-graph-details-metric";
+        internal const string DetailsMessageTypeRowClassName =
+            "dxmessaging-flow-graph-details-message-type-row";
         internal const string DetailsTechnicalFoldoutName =
             "dxmessaging-flow-graph-details-technical";
         internal const string DetailsEvidenceFoldoutName =
             "dxmessaging-flow-graph-details-evidence";
+        internal const string DetailsOverflowFoldoutName =
+            "dxmessaging-flow-graph-details-overflow";
+        internal const string DetailsCopyDiagnosticsButtonName =
+            "dxmessaging-flow-graph-details-copy-diagnostics";
         internal const string SourceLinkButtonName = "dxmessaging-flow-graph-source-link";
         internal const string GraphNodeMetricClassName = "dxmessaging-flow-graph-node-metric";
         internal const string WarningLabelName = "dxmessaging-flow-graph-warning";
@@ -191,6 +196,7 @@ namespace DxMessaging.Editor.Windows
         private const float GraphMinimumZoom = 0.2f;
         private const float GraphMaximumZoom = 2f;
         private const float GraphRouteHitRadius = 10f;
+        private const int VisibleDetailsRowLimit = 8;
         private const int ExportSchemaVersion = 6;
         private const string ExportCaptureMode = "registration-topology-with-recent-diagnostics";
         private const string ExportTraceSemantics =
@@ -203,6 +209,9 @@ namespace DxMessaging.Editor.Windows
             internal bool MoreRoutesExpanded;
             internal bool TraceActivityExpanded;
             internal bool TopologyExpanded;
+            internal bool DetailsEvidenceExpanded;
+            internal bool DetailsTechnicalExpanded;
+            internal bool DetailsOverflowExpanded;
             internal FlowGraphCanvasState CanvasState { get; } = new();
         }
 
@@ -1196,6 +1205,9 @@ namespace DxMessaging.Editor.Windows
             Foldout existingMoreRoutes = content.Q<Foldout>(RouteMapMoreRoutesFoldoutName);
             Foldout existingTraceActivity = content.Q<Foldout>(TraceActivityFoldoutName);
             Foldout existingTopology = content.Q<Foldout>(TopologyFoldoutName);
+            Foldout existingDetailsEvidence = content.Q<Foldout>(DetailsEvidenceFoldoutName);
+            Foldout existingDetailsTechnical = content.Q<Foldout>(DetailsTechnicalFoldoutName);
+            Foldout existingDetailsOverflow = content.Q<Foldout>(DetailsOverflowFoldoutName);
             if (existingAnalysis != null)
             {
                 foldoutState.AnalysisExpanded = existingAnalysis.value;
@@ -1215,6 +1227,18 @@ namespace DxMessaging.Editor.Windows
             if (existingTopology != null)
             {
                 foldoutState.TopologyExpanded = existingTopology.value;
+            }
+            if (existingDetailsEvidence != null)
+            {
+                foldoutState.DetailsEvidenceExpanded = existingDetailsEvidence.value;
+            }
+            if (existingDetailsTechnical != null)
+            {
+                foldoutState.DetailsTechnicalExpanded = existingDetailsTechnical.value;
+            }
+            if (existingDetailsOverflow != null)
+            {
+                foldoutState.DetailsOverflowExpanded = existingDetailsOverflow.value;
             }
             content.userData = foldoutState;
             content.Clear();
@@ -1276,7 +1300,7 @@ namespace DxMessaging.Editor.Windows
 
                 if (selectedItem.HasValue)
                 {
-                    content.Add(CreateDetailsPane(selectedItem, visibleSnapshot));
+                    content.Add(CreateDetailsPane(selectedItem, visibleSnapshot, foldoutState));
                 }
 
                 Foldout analysis = CreateCollapsedFoldout(
@@ -6252,7 +6276,8 @@ namespace DxMessaging.Editor.Windows
 
         private static VisualElement CreateDetailsPane(
             FlowGraphSelectedItem selectedItem,
-            FlowGraphVisibleSnapshot visibleSnapshot
+            FlowGraphVisibleSnapshot visibleSnapshot,
+            FlowGraphFoldoutState foldoutState
         )
         {
             VisualElement details = new() { name = DetailsPaneName };
@@ -6317,20 +6342,41 @@ namespace DxMessaging.Editor.Windows
                     break;
             }
 
+            Foldout evidence = details.Q<Foldout>(DetailsEvidenceFoldoutName);
+            if (evidence != null)
+            {
+                evidence.value = foldoutState.DetailsEvidenceExpanded;
+            }
+            Foldout overflow = details.Q<Foldout>(DetailsOverflowFoldoutName);
+            if (overflow != null)
+            {
+                overflow.value = foldoutState.DetailsOverflowExpanded;
+            }
+
             Foldout technical = new()
             {
                 name = DetailsTechnicalFoldoutName,
-                text = "Technical diagnostics",
-                value = false,
+                text = "Diagnostics summary",
+                value = foldoutState.DetailsTechnicalExpanded,
             };
             technical.style.marginTop = 4;
-            Label body = new(CreateDetailsBody(selectedItem, visibleSnapshot))
+            AddDetailsDiagnosticsSummary(technical, selectedItem, visibleSnapshot);
+            string diagnosticsText = CreateDetailsBody(selectedItem, visibleSnapshot);
+            Button copyDiagnostics = new()
             {
-                name = DetailsBodyLabelName,
+                name = DetailsCopyDiagnosticsButtonName,
+                text = "Copy diagnostics",
+                userData = diagnosticsText,
             };
-            body.style.marginTop = 4;
-            body.style.whiteSpace = WhiteSpace.Normal;
-            technical.Add(body);
+            copyDiagnostics.AddToClassList(DxMessagingEditorTheme.ButtonGhostClassName);
+            copyDiagnostics.AddToClassList(DxMessagingEditorTheme.ToolButtonClassName);
+            copyDiagnostics.style.alignSelf = Align.FlexStart;
+            copyDiagnostics.RegisterCallback<ClickEvent>(evt =>
+            {
+                evt.StopPropagation();
+                EditorGUIUtility.systemCopyBuffer = diagnosticsText;
+            });
+            technical.Add(copyDiagnostics);
             details.Add(technical);
 
             return details;
@@ -6385,12 +6431,6 @@ namespace DxMessaging.Editor.Windows
             );
             traffic.Add(
                 CreateDetailsKeyValue(
-                    "Message types",
-                    JoinDistinctOrNone(inboundEdges.Select(edge => edge.MessageTypeName))
-                )
-            );
-            traffic.Add(
-                CreateDetailsKeyValue(
                     "Call share",
                     CreateCallShareText(inboundEdges.Sum(edge => edge.CallCount), totalCalls)
                 )
@@ -6406,6 +6446,12 @@ namespace DxMessaging.Editor.Windows
             );
             Foldout evidence = CreateDetailsEvidenceFoldout();
             evidence.Add(traffic);
+            evidence.Add(
+                CreateMessageTypesSection(
+                    "MESSAGE TYPES",
+                    inboundEdges.Select(edge => edge.MessageTypeName)
+                )
+            );
             details.Add(evidence);
         }
 
@@ -6415,19 +6461,18 @@ namespace DxMessaging.Editor.Windows
             FlowGraphVisibleSnapshot visibleSnapshot
         )
         {
-            FlowGraphEdge[] messageEdges = visibleSnapshot
-                .Edges.Where(edge =>
-                    string.Equals(
-                        edge.MessageTypeName,
-                        message.MessageTypeName,
-                        StringComparison.Ordinal
-                    )
-                )
-                .ToArray();
+            FlowGraphEdge[] messageEdges = SelectMessageEdges(message, visibleSnapshot);
+            FlowGraphTracePath[] messageTracePaths = SelectMessageTracePaths(
+                message,
+                visibleSnapshot
+            );
             string visibleMessageKind = CreateVisibleMessageKind(
                 message.MessageKindName,
                 messageEdges.Select(edge => edge.RegistrationTypeName)
             );
+            int tracedDeliveryCount = IsGlobalObserverMessage(message)
+                ? messageTracePaths.Sum(path => path.RecentTracedDeliveryCount)
+                : message.RecentTracedDeliveryCount;
             details.Add(
                 CreateDetailsMetricSection(
                     "MESSAGE",
@@ -6455,7 +6500,7 @@ namespace DxMessaging.Editor.Windows
                     ),
                     new GraphNodeMetric(
                         "Traced",
-                        message.RecentTracedDeliveryCount.ToString(CultureInfo.InvariantCulture)
+                        tracedDeliveryCount.ToString(CultureInfo.InvariantCulture)
                     )
                 )
             );
@@ -6468,25 +6513,213 @@ namespace DxMessaging.Editor.Windows
             if (visibleMessageKind == "GLOBAL OBSERVER")
             {
                 evidence.Add(
-                    CreateDetailsKeyValue(
-                        "Observed types",
-                        JoinDistinctOrNone(
-                            visibleSnapshot
-                                .TracePaths.Where(path =>
-                                    string.Equals(
-                                        path.RegistrationTypeName,
-                                        MessageRegistrationType.GlobalAcceptAll.ToString(),
-                                        StringComparison.Ordinal
-                                    )
+                    CreateMessageTypesSection(
+                        "OBSERVED TYPES",
+                        visibleSnapshot
+                            .TracePaths.Where(path =>
+                                string.Equals(
+                                    path.RegistrationTypeName,
+                                    MessageRegistrationType.GlobalAcceptAll.ToString(),
+                                    StringComparison.Ordinal
                                 )
-                                .Select(path => path.MessageTypeName)
-                        )
+                            )
+                            .Select(path => path.MessageTypeName)
                     )
                 );
             }
             Foldout evidenceFoldout = CreateDetailsEvidenceFoldout();
             evidenceFoldout.Add(evidence);
             details.Add(evidenceFoldout);
+        }
+
+        private static void AddDetailsDiagnosticsSummary(
+            VisualElement diagnostics,
+            FlowGraphSelectedItem selectedItem,
+            FlowGraphVisibleSnapshot visibleSnapshot
+        )
+        {
+            FlowGraphEdge[] edges;
+            FlowGraphTracePath[] tracePaths;
+            switch (selectedItem.Kind)
+            {
+                case FlowGraphSelectionKind.Component:
+                    edges = visibleSnapshot
+                        .Edges.Where(edge =>
+                            string.Equals(
+                                edge.TargetComponentId,
+                                selectedItem.Component.Id,
+                                StringComparison.Ordinal
+                            )
+                        )
+                        .ToArray();
+                    tracePaths = visibleSnapshot
+                        .TracePaths.Where(path =>
+                            string.Equals(
+                                path.TargetComponentId,
+                                selectedItem.Component.Id,
+                                StringComparison.Ordinal
+                            )
+                        )
+                        .ToArray();
+                    break;
+                case FlowGraphSelectionKind.Message:
+                    edges = SelectMessageEdges(selectedItem.Message, visibleSnapshot);
+                    tracePaths = SelectMessageTracePaths(selectedItem.Message, visibleSnapshot);
+                    break;
+                case FlowGraphSelectionKind.Edge:
+                    edges = new[] { selectedItem.Edge };
+                    tracePaths = visibleSnapshot
+                        .TracePaths.Where(path => EdgeMatchesTracePath(selectedItem.Edge, path))
+                        .ToArray();
+                    break;
+                default:
+                    edges = Array.Empty<FlowGraphEdge>();
+                    tracePaths = Array.Empty<FlowGraphTracePath>();
+                    break;
+            }
+
+            VisualElement routeHealth = CreateDetailsMetricSection(
+                "ROUTE HEALTH",
+                new GraphNodeMetric("Routes", edges.Length.ToString(CultureInfo.InvariantCulture)),
+                new GraphNodeMetric(
+                    "Called",
+                    edges.Count(edge => edge.CallCount > 0).ToString(CultureInfo.InvariantCulture)
+                ),
+                new GraphNodeMetric(
+                    "Traced",
+                    edges
+                        .Count(edge => edge.RecentTracedDeliveryCount > 0)
+                        .ToString(CultureInfo.InvariantCulture)
+                ),
+                new GraphNodeMetric(
+                    "No calls",
+                    edges.Count(edge => edge.CallCount <= 0).ToString(CultureInfo.InvariantCulture)
+                )
+            );
+            routeHealth.Add(
+                CreateDetailsKeyValue(
+                    "Busiest traced",
+                    RemoveDiagnosticPrefix(
+                        CreateBusiestTracedRouteSummary(edges),
+                        "Busiest traced route: "
+                    )
+                )
+            );
+            diagnostics.Add(routeHealth);
+
+            VisualElement traceCoverage = CreateDetailsMetricSection(
+                "TRACE COVERAGE",
+                new GraphNodeMetric(
+                    "Paths",
+                    tracePaths.Length.ToString(CultureInfo.InvariantCulture)
+                ),
+                new GraphNodeMetric(
+                    "Deliveries",
+                    tracePaths
+                        .Sum(path => path.RecentTracedDeliveryCount)
+                        .ToString(CultureInfo.InvariantCulture)
+                ),
+                new GraphNodeMetric(
+                    "Trace ids",
+                    CountDistinctTraceIds(tracePaths).ToString(CultureInfo.InvariantCulture)
+                ),
+                new GraphNodeMetric(
+                    "Contexts",
+                    tracePaths
+                        .Select(path => NormalizeTraceContext(path.Context))
+                        .Distinct(StringComparer.Ordinal)
+                        .Count()
+                        .ToString(CultureInfo.InvariantCulture)
+                )
+            );
+            traceCoverage.Add(
+                CreateDetailsKeyValue(
+                    "Widest trace",
+                    RemoveDiagnosticPrefix(CreateWidestTraceSummary(tracePaths), "Widest trace: ")
+                )
+            );
+            traceCoverage.Add(
+                CreateDetailsKeyValue(
+                    "Busiest path",
+                    RemoveDiagnosticPrefix(
+                        CreateBusiestTracePathSummary(tracePaths),
+                        "Busiest path: "
+                    )
+                )
+            );
+            traceCoverage.Add(
+                CreateDetailsKeyValue(
+                    "Path share",
+                    RemoveDiagnosticPrefix(
+                        CreateBusiestTracePathShareSummary(tracePaths),
+                        "Busiest path share: "
+                    )
+                )
+            );
+            diagnostics.Add(traceCoverage);
+        }
+
+        private static FlowGraphEdge[] SelectMessageEdges(
+            FlowGraphMessageNode message,
+            FlowGraphVisibleSnapshot visibleSnapshot
+        )
+        {
+            bool globalObserver = IsGlobalObserverMessage(message);
+            return visibleSnapshot
+                .Edges.Where(edge =>
+                    globalObserver
+                        ? IsGlobalObserverRegistration(edge.RegistrationTypeName)
+                        : string.Equals(
+                            edge.MessageTypeName,
+                            message.MessageTypeName,
+                            StringComparison.Ordinal
+                        )
+                )
+                .ToArray();
+        }
+
+        private static FlowGraphTracePath[] SelectMessageTracePaths(
+            FlowGraphMessageNode message,
+            FlowGraphVisibleSnapshot visibleSnapshot
+        )
+        {
+            bool globalObserver = IsGlobalObserverMessage(message);
+            return visibleSnapshot
+                .TracePaths.Where(path =>
+                    globalObserver
+                        ? IsGlobalObserverRegistration(path.RegistrationTypeName)
+                        : string.Equals(
+                            path.MessageTypeName,
+                            message.MessageTypeName,
+                            StringComparison.Ordinal
+                        )
+                )
+                .ToArray();
+        }
+
+        private static bool IsGlobalObserverMessage(FlowGraphMessageNode message)
+        {
+            return string.Equals(
+                message.MessageTypeName,
+                GlobalObserverMessageName,
+                StringComparison.Ordinal
+            );
+        }
+
+        private static bool IsGlobalObserverRegistration(string registrationTypeName)
+        {
+            return string.Equals(
+                registrationTypeName,
+                MessageRegistrationType.GlobalAcceptAll.ToString(),
+                StringComparison.Ordinal
+            );
+        }
+
+        private static string RemoveDiagnosticPrefix(string text, string prefix)
+        {
+            return text.StartsWith(prefix, StringComparison.Ordinal)
+                ? text.Substring(prefix.Length)
+                : text;
         }
 
         private static void AddEdgeDetailsCards(
@@ -6744,6 +6977,82 @@ namespace DxMessaging.Editor.Windows
             return pair;
         }
 
+        private static VisualElement CreateMessageTypesSection(
+            string title,
+            IEnumerable<string> messageTypeNames
+        )
+        {
+            VisualElement section = CreateDetailsSection(title);
+            string[] distinctTypes = messageTypeNames
+                .Where(typeName => !string.IsNullOrWhiteSpace(typeName))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(typeName => typeName, StringComparer.Ordinal)
+                .ToArray();
+            if (distinctTypes.Length == 0)
+            {
+                section.Add(CreateDetailsKeyValue("Message types", "none"));
+                return section;
+            }
+
+            int visibleCount = Math.Min(VisibleDetailsRowLimit, distinctTypes.Length);
+            for (int index = 0; index < visibleCount; index++)
+            {
+                section.Add(CreateMessageTypeRow(distinctTypes[index]));
+            }
+            if (distinctTypes.Length > visibleCount)
+            {
+                Foldout overflow = new()
+                {
+                    name = DetailsOverflowFoldoutName,
+                    text = $"{distinctTypes.Length - visibleCount} more message types",
+                    value = false,
+                };
+                bool populated = false;
+                void PopulateOverflow()
+                {
+                    if (populated)
+                    {
+                        return;
+                    }
+
+                    for (int index = visibleCount; index < distinctTypes.Length; index++)
+                    {
+                        overflow.Add(CreateMessageTypeRow(distinctTypes[index]));
+                    }
+                    populated = true;
+                }
+                overflow.RegisterValueChangedCallback(evt =>
+                {
+                    if (evt.newValue)
+                    {
+                        PopulateOverflow();
+                    }
+                });
+                section.Add(overflow);
+            }
+            return section;
+        }
+
+        private static VisualElement CreateMessageTypeRow(string messageTypeName)
+        {
+            VisualElement row = new();
+            row.AddToClassList(DxMessagingEditorTheme.KeyValueClassName);
+            row.AddToClassList(DetailsMessageTypeRowClassName);
+            row.tooltip = messageTypeName;
+            Label typeLabel = new(CreateCompactGraphLabel(messageTypeName));
+            typeLabel.AddToClassList(DxMessagingEditorTheme.KeyValueValueClassName);
+            typeLabel.style.flexGrow = 1;
+            typeLabel.style.whiteSpace = WhiteSpace.Normal;
+            row.Add(typeLabel);
+            if (
+                TryResolveMessageSource(messageTypeName, out FlowGraphSourceLocation sourceLocation)
+            )
+            {
+                row.Add(CreateSourceLinkButton("Open source", sourceLocation));
+            }
+            return row;
+        }
+
         private static void AddDetailValues(
             VisualElement section,
             string firstLabel,
@@ -6770,13 +7079,27 @@ namespace DxMessaging.Editor.Windows
             IReadOnlyList<string> values
         )
         {
-            AddDetailValues(section, firstLabel, values);
-            foreach (string value in values)
+            if (values.Count == 0)
             {
-                if (TryParseSourceLocation(value, out FlowGraphSourceLocation location))
+                section.Add(CreateDetailsKeyValue(firstLabel, "none captured"));
+                return;
+            }
+
+            for (int index = 0; index < values.Count; index++)
+            {
+                string value = values[index];
+                VisualElement row = CreateDetailsKeyValue(
+                    index == 0 ? firstLabel : string.Empty,
+                    value
+                );
+                if (
+                    TryParseSourceLocation(value, out FlowGraphSourceLocation location)
+                    && AssetDatabase.LoadMainAssetAtPath(location.AssetPath) != null
+                )
                 {
-                    section.Add(CreateSourceLinkButton("Open call site", location));
+                    row.Add(CreateSourceLinkButton("Open call site", location));
                 }
+                section.Add(row);
             }
         }
 
@@ -7715,28 +8038,15 @@ namespace DxMessaging.Editor.Windows
             FlowGraphVisibleSnapshot visibleSnapshot
         )
         {
-            FlowGraphEdge[] messageEdges = visibleSnapshot
-                .Edges.Where(edge =>
-                    string.Equals(
-                        edge.MessageTypeName,
-                        message.MessageTypeName,
-                        StringComparison.Ordinal
-                    )
-                )
-                .ToArray();
-            FlowGraphTracePath[] tracePaths = visibleSnapshot
-                .TracePaths.Where(path =>
-                    string.Equals(
-                        path.MessageTypeName,
-                        message.MessageTypeName,
-                        StringComparison.Ordinal
-                    )
-                )
-                .ToArray();
+            FlowGraphEdge[] messageEdges = SelectMessageEdges(message, visibleSnapshot);
+            FlowGraphTracePath[] tracePaths = SelectMessageTracePaths(message, visibleSnapshot);
+            bool globalObserver = IsGlobalObserverMessage(message);
             int visibleRegistrationCount = messageEdges.Sum(edge => edge.RegistrationCount);
             int selectedCalls = messageEdges.Sum(edge => edge.CallCount);
             int totalCalls = SumVisibleCalls(visibleSnapshot);
-            int selectedTracedDeliveries = messageEdges.Sum(edge => edge.RecentTracedDeliveryCount);
+            int selectedTracedDeliveries = globalObserver
+                ? tracePaths.Sum(path => path.RecentTracedDeliveryCount)
+                : messageEdges.Sum(edge => edge.RecentTracedDeliveryCount);
             int totalTracedDeliveries = SumVisibleTracedDeliveries(visibleSnapshot);
             string visibleMessageKind = CreateVisibleMessageKind(
                 message.MessageKindName,
@@ -7781,7 +8091,11 @@ namespace DxMessaging.Editor.Windows
                 .Append(" global emissions | ")
                 .Append(message.RecentLocalMessageCount)
                 .Append(" listener messages | Traced deliveries: ")
-                .Append(message.RecentTracedDeliveryCount)
+                .Append(
+                    globalObserver
+                        ? tracePaths.Sum(path => path.RecentTracedDeliveryCount)
+                        : message.RecentTracedDeliveryCount
+                )
                 .AppendLine();
             builder
                 .Append("Registration kinds: ")

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -235,6 +235,19 @@ namespace DxMessaging.Editor.Windows
             internal FlowGraphCanvasState CanvasState { get; } = new();
         }
 
+        private sealed class DetailSelectionData
+        {
+            internal DetailSelectionData(string selectionKey, string focusRestorationId)
+            {
+                SelectionKey = selectionKey;
+                FocusRestorationId = focusRestorationId;
+            }
+
+            internal string SelectionKey { get; }
+
+            internal string FocusRestorationId { get; }
+        }
+
         private readonly struct GraphConnectionDescriptor
         {
             internal GraphConnectionDescriptor(
@@ -1213,15 +1226,27 @@ namespace DxMessaging.Editor.Windows
                 content.userData as FlowGraphFoldoutState ?? new FlowGraphFoldoutState();
             VisualElement focusedElement =
                 content.panel?.focusController.focusedElement as VisualElement;
-            string focusedSelectionKey = focusedElement?.userData as string;
-            bool restoreSelectionFocus =
+            string focusedSelectionKey = GetSelectionKey(focusedElement);
+            string focusedDetailRestorationId = GetDetailFocusRestorationId(focusedElement);
+            bool focusedGraphControl =
                 focusedElement != null
-                && !string.IsNullOrWhiteSpace(focusedSelectionKey)
                 && (
                     focusedElement.ClassListContains(GraphMessageNodeClassName)
                     || focusedElement.ClassListContains(GraphReceiverNodeClassName)
                     || focusedElement.ClassListContains(GraphConnectionClassName)
-                    || focusedElement.ClassListContains(DxMessagingEditorTheme.DetailLinkClassName)
+                );
+            bool focusedDetailLink =
+                focusedElement != null
+                && focusedElement.ClassListContains(DxMessagingEditorTheme.DetailLinkClassName);
+            bool restoreFocus =
+                !string.IsNullOrWhiteSpace(focusedSelectionKey)
+                && (focusedGraphControl || focusedDetailLink);
+            bool restoreDetailLinkFocus =
+                focusedDetailLink
+                && !string.Equals(
+                    viewState.SelectedItemKey,
+                    focusedSelectionKey,
+                    StringComparison.Ordinal
                 );
             Foldout existingAnalysis = content.Q<Foldout>(AnalysisFoldoutName);
             Foldout existingRouteInsights = content.Q<Foldout>(RouteMapInsightsFoldoutName);
@@ -1460,19 +1485,35 @@ namespace DxMessaging.Editor.Windows
                 content.Add(warningLabel);
             }
 
-            if (restoreSelectionFocus)
+            if (restoreFocus)
             {
-                VisualElement selectedControl = content
+                List<VisualElement> focusCandidates = content
                     .Query<VisualElement>()
                     .ToList()
-                    .FirstOrDefault(element =>
+                    .Where(element =>
                         element.focusable
                         && string.Equals(
-                            element.userData as string,
+                            GetSelectionKey(element),
                             focusedSelectionKey,
                             StringComparison.Ordinal
                         )
-                    );
+                        && (
+                            restoreDetailLinkFocus
+                                ? element.ClassListContains(
+                                    DxMessagingEditorTheme.DetailLinkClassName
+                                )
+                                    && string.Equals(
+                                        GetDetailFocusRestorationId(element),
+                                        focusedDetailRestorationId,
+                                        StringComparison.Ordinal
+                                    )
+                                : element.ClassListContains(GraphMessageNodeClassName)
+                                    || element.ClassListContains(GraphReceiverNodeClassName)
+                                    || element.ClassListContains(GraphConnectionClassName)
+                        )
+                    )
+                    .ToList();
+                VisualElement selectedControl = focusCandidates.FirstOrDefault();
                 selectedControl?.Focus();
             }
         }
@@ -6809,7 +6850,8 @@ namespace DxMessaging.Editor.Windows
                 row,
                 CreateEdgeSelectionKey(edge),
                 onSelectionChanged,
-                addDesignClass: true
+                addDesignClass: true,
+                focusRestorationId: "route:" + CreateEdgeSelectionKey(edge)
             );
             return row;
         }
@@ -7550,7 +7592,13 @@ namespace DxMessaging.Editor.Windows
                 descriptorLabel.style.marginLeft = 8;
                 trail.Add(descriptorLabel);
             }
-            ApplyDetailsSelection(trail, selectionKey, onSelectionChanged, addDesignClass: true);
+            ApplyDetailsSelection(
+                trail,
+                selectionKey,
+                onSelectionChanged,
+                addDesignClass: true,
+                focusRestorationId: "hierarchy:" + value
+            );
             return trail;
         }
 
@@ -7658,6 +7706,15 @@ namespace DxMessaging.Editor.Windows
             string currentSelectionKey = null
         )
         {
+            string relationshipFocusId = string.Join(
+                ":",
+                "relationship",
+                label,
+                messageTypeName,
+                targetComponentId,
+                registrationTypeName,
+                NormalizeTraceContext(context)
+            );
             VisualElement relationship = new()
             {
                 tooltip =
@@ -7710,7 +7767,8 @@ namespace DxMessaging.Editor.Windows
                         currentSelectionKey,
                         CreateMessageSelectionKey(messageTypeName),
                         StringComparison.Ordinal
-                    )
+                    ),
+                    focusRestorationId: relationshipFocusId + ":message"
                 )
             );
             flow.Add(CreateRouteArrow());
@@ -7724,7 +7782,8 @@ namespace DxMessaging.Editor.Windows
                     currentSelectionKey,
                     CreateComponentSelectionKey(targetComponentId),
                     StringComparison.Ordinal
-                )
+                ),
+                focusRestorationId: relationshipFocusId + ":receiver"
             );
             target.Add(CreateHierarchyTrail(targetPath));
             flow.Add(target);
@@ -7800,7 +7859,8 @@ namespace DxMessaging.Editor.Windows
             string name = null,
             string selectionKey = null,
             Action<string> onSelectionChanged = null,
-            bool active = false
+            bool active = false,
+            string focusRestorationId = null
         )
         {
             VisualElement identity = new() { name = name };
@@ -7842,7 +7902,8 @@ namespace DxMessaging.Editor.Windows
                     identity,
                     selectionKey,
                     onSelectionChanged,
-                    addDesignClass: true
+                    addDesignClass: true,
+                    focusRestorationId: focusRestorationId
                 );
             }
             return identity;
@@ -7852,7 +7913,8 @@ namespace DxMessaging.Editor.Windows
             VisualElement element,
             string selectionKey,
             Action<string> onSelectionChanged,
-            bool addDesignClass
+            bool addDesignClass,
+            string focusRestorationId
         )
         {
             if (
@@ -7869,7 +7931,7 @@ namespace DxMessaging.Editor.Windows
                 element.AddToClassList(DxMessagingEditorTheme.DetailLinkClassName);
             }
             element.focusable = true;
-            element.userData = selectionKey;
+            element.userData = new DetailSelectionData(selectionKey, focusRestorationId);
             element.pickingMode = PickingMode.Position;
             if (string.IsNullOrWhiteSpace(element.tooltip))
             {
@@ -7890,6 +7952,20 @@ namespace DxMessaging.Editor.Windows
                 evt.StopPropagation();
                 onSelectionChanged.Invoke(selectionKey);
             });
+        }
+
+        private static string GetSelectionKey(VisualElement element)
+        {
+            return element?.userData is DetailSelectionData detailSelection
+                ? detailSelection.SelectionKey
+                : element?.userData as string;
+        }
+
+        private static string GetDetailFocusRestorationId(VisualElement element)
+        {
+            return element?.userData is DetailSelectionData detailSelection
+                ? detailSelection.FocusRestorationId
+                : string.Empty;
         }
 
         private static VisualElement CreateMessageTypesSection(

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -6459,7 +6459,12 @@ namespace DxMessaging.Editor.Windows
             switch (selectedItem.Kind)
             {
                 case FlowGraphSelectionKind.Component:
-                    AddComponentDetailsCards(details, selectedItem.Component, visibleSnapshot);
+                    AddComponentDetailsCards(
+                        details,
+                        selectedItem.Component,
+                        visibleSnapshot,
+                        foldoutState.DetailsOverflowExpanded
+                    );
                     break;
                 case FlowGraphSelectionKind.Message:
                     AddMessageDetailsCards(
@@ -6472,7 +6477,12 @@ namespace DxMessaging.Editor.Windows
                     );
                     break;
                 case FlowGraphSelectionKind.Edge:
-                    AddEdgeDetailsCards(details, selectedItem.Edge, visibleSnapshot);
+                    AddEdgeDetailsCards(
+                        details,
+                        selectedItem.Edge,
+                        visibleSnapshot,
+                        foldoutState.DetailsOverflowExpanded
+                    );
                     break;
             }
 
@@ -6480,11 +6490,6 @@ namespace DxMessaging.Editor.Windows
             if (evidence != null)
             {
                 evidence.value = foldoutState.DetailsEvidenceExpanded;
-            }
-            Foldout overflow = details.Q<Foldout>(DetailsOverflowFoldoutName);
-            if (overflow != null)
-            {
-                overflow.value = foldoutState.DetailsOverflowExpanded;
             }
             Foldout technical = new()
             {
@@ -6523,7 +6528,8 @@ namespace DxMessaging.Editor.Windows
         private static void AddComponentDetailsCards(
             VisualElement details,
             FlowGraphComponentNode component,
-            FlowGraphVisibleSnapshot visibleSnapshot
+            FlowGraphVisibleSnapshot visibleSnapshot,
+            bool overflowExpanded
         )
         {
             FlowGraphEdge[] inboundEdges = visibleSnapshot
@@ -6587,7 +6593,8 @@ namespace DxMessaging.Editor.Windows
             evidence.Add(
                 CreateMessageTypesSection(
                     "MESSAGE TYPES",
-                    inboundEdges.Select(edge => edge.MessageTypeName)
+                    inboundEdges.Select(edge => edge.MessageTypeName),
+                    overflowExpanded
                 )
             );
             details.Add(evidence);
@@ -6679,7 +6686,8 @@ namespace DxMessaging.Editor.Windows
                                     StringComparison.Ordinal
                                 )
                             )
-                            .Select(path => path.MessageTypeName)
+                            .Select(path => path.MessageTypeName),
+                        foldoutState.DetailsOverflowExpanded
                     )
                 );
             }
@@ -7184,7 +7192,8 @@ namespace DxMessaging.Editor.Windows
         private static void AddEdgeDetailsCards(
             VisualElement details,
             FlowGraphEdge edge,
-            FlowGraphVisibleSnapshot visibleSnapshot
+            FlowGraphVisibleSnapshot visibleSnapshot,
+            bool overflowExpanded
         )
         {
             FlowGraphTracePath[] tracePaths = visibleSnapshot
@@ -7277,7 +7286,8 @@ namespace DxMessaging.Editor.Windows
                 evidenceFoldout.Add(
                     CreateMessageTypesSection(
                         "OBSERVED TYPES",
-                        tracePaths.Select(path => path.MessageTypeName)
+                        tracePaths.Select(path => path.MessageTypeName),
+                        overflowExpanded
                     )
                 );
             }
@@ -7976,7 +7986,8 @@ namespace DxMessaging.Editor.Windows
 
         private static VisualElement CreateMessageTypesSection(
             string title,
-            IEnumerable<string> messageTypeNames
+            IEnumerable<string> messageTypeNames,
+            bool overflowExpanded
         )
         {
             VisualElement section = CreateDetailsSection(title);
@@ -8025,6 +8036,11 @@ namespace DxMessaging.Editor.Windows
                         PopulateOverflow();
                     }
                 });
+                overflow.SetValueWithoutNotify(overflowExpanded);
+                if (overflowExpanded)
+                {
+                    PopulateOverflow();
+                }
                 section.Add(overflow);
             }
             return section;

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -184,6 +184,14 @@ namespace DxMessaging.Editor.Windows
             "dxmessaging-flow-graph-details-source-row";
         internal const string DetailsRelationshipClassName =
             "dxmessaging-flow-graph-details-relationship";
+        internal const string DetailsRouteRowClassName = "dxmessaging-flow-graph-details-route-row";
+        internal const string DetailsRoutesFoldoutName = "dxmessaging-flow-graph-details-routes";
+        internal const string DetailsRoutesOverflowFoldoutName =
+            "dxmessaging-flow-graph-details-routes-overflow";
+        internal const string DetailsRelationshipMessageLinkName =
+            "dxmessaging-flow-graph-details-relationship-message";
+        internal const string DetailsRelationshipReceiverLinkName =
+            "dxmessaging-flow-graph-details-relationship-receiver";
         internal const string DetailsTechnicalFoldoutName =
             "dxmessaging-flow-graph-details-technical";
         internal const string DetailsEvidenceFoldoutName =
@@ -222,6 +230,8 @@ namespace DxMessaging.Editor.Windows
             internal bool DetailsEvidenceExpanded;
             internal bool DetailsTechnicalExpanded;
             internal bool DetailsOverflowExpanded;
+            internal bool DetailsRoutesExpanded;
+            internal bool DetailsRoutesOverflowExpanded;
             internal FlowGraphCanvasState CanvasState { get; } = new();
         }
 
@@ -1203,12 +1213,15 @@ namespace DxMessaging.Editor.Windows
                 content.userData as FlowGraphFoldoutState ?? new FlowGraphFoldoutState();
             VisualElement focusedElement =
                 content.panel?.focusController.focusedElement as VisualElement;
-            bool restoreGraphFocus =
+            string focusedSelectionKey = focusedElement?.userData as string;
+            bool restoreSelectionFocus =
                 focusedElement != null
+                && !string.IsNullOrWhiteSpace(focusedSelectionKey)
                 && (
                     focusedElement.ClassListContains(GraphMessageNodeClassName)
                     || focusedElement.ClassListContains(GraphReceiverNodeClassName)
                     || focusedElement.ClassListContains(GraphConnectionClassName)
+                    || focusedElement.ClassListContains(DxMessagingEditorTheme.DetailLinkClassName)
                 );
             Foldout existingAnalysis = content.Q<Foldout>(AnalysisFoldoutName);
             Foldout existingRouteInsights = content.Q<Foldout>(RouteMapInsightsFoldoutName);
@@ -1218,6 +1231,10 @@ namespace DxMessaging.Editor.Windows
             Foldout existingDetailsEvidence = content.Q<Foldout>(DetailsEvidenceFoldoutName);
             Foldout existingDetailsTechnical = content.Q<Foldout>(DetailsTechnicalFoldoutName);
             Foldout existingDetailsOverflow = content.Q<Foldout>(DetailsOverflowFoldoutName);
+            Foldout existingDetailsRoutes = content.Q<Foldout>(DetailsRoutesFoldoutName);
+            Foldout existingDetailsRoutesOverflow = content.Q<Foldout>(
+                DetailsRoutesOverflowFoldoutName
+            );
             if (existingAnalysis != null)
             {
                 foldoutState.AnalysisExpanded = existingAnalysis.value;
@@ -1249,6 +1266,14 @@ namespace DxMessaging.Editor.Windows
             if (existingDetailsOverflow != null)
             {
                 foldoutState.DetailsOverflowExpanded = existingDetailsOverflow.value;
+            }
+            if (existingDetailsRoutes != null)
+            {
+                foldoutState.DetailsRoutesExpanded = existingDetailsRoutes.value;
+            }
+            if (existingDetailsRoutesOverflow != null)
+            {
+                foldoutState.DetailsRoutesOverflowExpanded = existingDetailsRoutesOverflow.value;
             }
             content.userData = foldoutState;
             content.Clear();
@@ -1310,7 +1335,15 @@ namespace DxMessaging.Editor.Windows
 
                 if (selectedItem.HasValue)
                 {
-                    content.Add(CreateDetailsPane(selectedItem, visibleSnapshot, foldoutState));
+                    content.Add(
+                        CreateDetailsPane(
+                            selectedItem,
+                            snapshot,
+                            visibleSnapshot,
+                            foldoutState,
+                            onSelectionChanged
+                        )
+                    );
                 }
 
                 Foldout analysis = CreateCollapsedFoldout(
@@ -1427,7 +1460,7 @@ namespace DxMessaging.Editor.Windows
                 content.Add(warningLabel);
             }
 
-            if (restoreGraphFocus && !string.IsNullOrWhiteSpace(viewState.SelectedItemKey))
+            if (restoreSelectionFocus)
             {
                 VisualElement selectedControl = content
                     .Query<VisualElement>()
@@ -1436,11 +1469,11 @@ namespace DxMessaging.Editor.Windows
                         element.focusable
                         && string.Equals(
                             element.userData as string,
-                            viewState.SelectedItemKey,
+                            focusedSelectionKey,
                             StringComparison.Ordinal
                         )
                     );
-                selectedControl?.schedule.Execute(selectedControl.Focus);
+                selectedControl?.Focus();
             }
         }
 
@@ -5883,12 +5916,26 @@ namespace DxMessaging.Editor.Windows
 
         internal static string CreateComponentSelectionKey(FlowGraphComponentNode component)
         {
-            return "component|" + component.Id;
+            return CreateComponentSelectionKey(component.Id);
         }
 
         internal static string CreateMessageSelectionKey(FlowGraphMessageNode message)
         {
-            return "message|" + message.MessageTypeName;
+            return CreateMessageSelectionKey(message.MessageTypeName);
+        }
+
+        private static string CreateComponentSelectionKey(string componentId)
+        {
+            return string.IsNullOrWhiteSpace(componentId)
+                ? string.Empty
+                : "component|" + componentId;
+        }
+
+        private static string CreateMessageSelectionKey(string messageTypeName)
+        {
+            return string.IsNullOrWhiteSpace(messageTypeName)
+                ? string.Empty
+                : "message|" + messageTypeName;
         }
 
         internal static string CreateEdgeSelectionKey(FlowGraphEdge edge)
@@ -6251,6 +6298,10 @@ namespace DxMessaging.Editor.Windows
             string labelText = CreateRouteKindBadgeText(routeKindText);
             Label routeKind = new(labelText) { name = name };
             DxMessagingEditorTheme.AddRouteKindTypeBadgeClasses(routeKind, routeKindText);
+            if (IsGlobalObserverRegistration(routeKindText))
+            {
+                routeKind.AddToClassList(DxMessagingEditorTheme.TypeBadgeGlobalObserverClassName);
+            }
             routeKind.style.unityFontStyleAndWeight = FontStyle.Bold;
             routeKind.style.whiteSpace = WhiteSpace.Normal;
             return routeKind;
@@ -6283,8 +6334,10 @@ namespace DxMessaging.Editor.Windows
 
         private static VisualElement CreateDetailsPane(
             FlowGraphSelectedItem selectedItem,
+            FlowGraphSnapshot snapshot,
             FlowGraphVisibleSnapshot visibleSnapshot,
-            FlowGraphFoldoutState foldoutState
+            FlowGraphFoldoutState foldoutState,
+            Action<string> onSelectionChanged
         )
         {
             VisualElement details = new() { name = DetailsPaneName };
@@ -6327,12 +6380,22 @@ namespace DxMessaging.Editor.Windows
             }
             else if (selectedItem.Kind == FlowGraphSelectionKind.Message)
             {
-                header.Add(
-                    CreateGraphLegendBadge(
-                        CreateVisibleMessageKind(selectedItem.Message, visibleSnapshot),
-                        DxMessagingEditorPalette.AmberSoft
-                    )
+                string visibleMessageKind = CreateVisibleMessageKind(
+                    selectedItem.Message,
+                    visibleSnapshot
                 );
+                Label messageKindBadge = CreateGraphLegendBadge(
+                    visibleMessageKind,
+                    DxMessagingEditorPalette.AmberSoft
+                );
+                if (string.Equals(visibleMessageKind, "GLOBAL OBSERVER", StringComparison.Ordinal))
+                {
+                    messageKindBadge.AddToClassList(DxMessagingEditorTheme.TypeBadgeClassName);
+                    messageKindBadge.AddToClassList(
+                        DxMessagingEditorTheme.TypeBadgeGlobalObserverClassName
+                    );
+                }
+                header.Add(messageKindBadge);
             }
             string messageTypeName =
                 selectedItem.Kind == FlowGraphSelectionKind.Message
@@ -6358,7 +6421,14 @@ namespace DxMessaging.Editor.Windows
                     AddComponentDetailsCards(details, selectedItem.Component, visibleSnapshot);
                     break;
                 case FlowGraphSelectionKind.Message:
-                    AddMessageDetailsCards(details, selectedItem.Message, visibleSnapshot);
+                    AddMessageDetailsCards(
+                        details,
+                        selectedItem.Message,
+                        snapshot,
+                        visibleSnapshot,
+                        foldoutState,
+                        onSelectionChanged
+                    );
                     break;
                 case FlowGraphSelectionKind.Edge:
                     AddEdgeDetailsCards(details, selectedItem.Edge, visibleSnapshot);
@@ -6375,7 +6445,6 @@ namespace DxMessaging.Editor.Windows
             {
                 overflow.value = foldoutState.DetailsOverflowExpanded;
             }
-
             Foldout technical = new()
             {
                 name = DetailsTechnicalFoldoutName,
@@ -6383,7 +6452,12 @@ namespace DxMessaging.Editor.Windows
                 value = foldoutState.DetailsTechnicalExpanded,
             };
             technical.style.marginTop = 4;
-            AddDetailsDiagnosticsSummary(technical, selectedItem, visibleSnapshot);
+            AddDetailsDiagnosticsSummary(
+                technical,
+                selectedItem,
+                visibleSnapshot,
+                onSelectionChanged
+            );
             string diagnosticsText = CreateDetailsBody(selectedItem, visibleSnapshot);
             Button copyDiagnostics = new()
             {
@@ -6481,7 +6555,10 @@ namespace DxMessaging.Editor.Windows
         private static void AddMessageDetailsCards(
             VisualElement details,
             FlowGraphMessageNode message,
-            FlowGraphVisibleSnapshot visibleSnapshot
+            FlowGraphSnapshot snapshot,
+            FlowGraphVisibleSnapshot visibleSnapshot,
+            FlowGraphFoldoutState foldoutState,
+            Action<string> onSelectionChanged
         )
         {
             FlowGraphEdge[] messageEdges = SelectMessageEdges(message, visibleSnapshot);
@@ -6527,12 +6604,23 @@ namespace DxMessaging.Editor.Windows
                     )
                 )
             );
+            details.Add(
+                CreateDetailsRouteRoster(
+                    messageEdges,
+                    onSelectionChanged,
+                    foldoutState.DetailsRoutesExpanded,
+                    foldoutState.DetailsRoutesOverflowExpanded
+                )
+            );
             VisualElement evidence = CreateDetailsSection("RECENT EVIDENCE");
             AddHierarchyDetailValues(
                 evidence,
                 "Contexts",
                 message.RecentContexts,
-                extractDescriptor: true
+                extractDescriptor: true,
+                selectionKeyFactory: value =>
+                    FindContextComponentSelectionKey(value, message, snapshot, visibleSnapshot),
+                onSelectionChanged: onSelectionChanged
             );
             AddSourceDetailValues(evidence, "Emitted by", message.RecentEmissionSites);
             Foldout evidenceFoldout = CreateDetailsEvidenceFoldout();
@@ -6557,10 +6645,180 @@ namespace DxMessaging.Editor.Windows
             details.Add(evidenceFoldout);
         }
 
+        private static VisualElement CreateDetailsRouteRoster(
+            IReadOnlyList<FlowGraphEdge> edges,
+            Action<string> onSelectionChanged,
+            bool expanded,
+            bool overflowExpanded
+        )
+        {
+            FlowGraphEdge[] orderedEdges = edges
+                .OrderByDescending(edge => edge.CallCount)
+                .ThenBy(edge => edge.TargetComponentPath, StringComparer.Ordinal)
+                .ThenBy(edge => edge.RegistrationTypeName, StringComparer.Ordinal)
+                .ThenBy(edge => edge.ContextId)
+                .ToArray();
+            if (orderedEdges.Length == 0)
+            {
+                VisualElement empty = CreateDetailsSection("ROUTE ROSTER");
+                empty.Add(CreateDetailsKeyValue("Routes", "none"));
+                return empty;
+            }
+
+            Foldout roster = new()
+            {
+                name = DetailsRoutesFoldoutName,
+                text = $"Route roster ({orderedEdges.Length})",
+                value = false,
+            };
+            roster.style.marginBottom = 8;
+            bool populated = false;
+            void Populate()
+            {
+                if (populated)
+                {
+                    return;
+                }
+
+                foreach (FlowGraphEdge edge in orderedEdges.Take(VisibleDetailsRowLimit))
+                {
+                    roster.Add(CreateDetailsRouteRow(edge, onSelectionChanged));
+                }
+                if (orderedEdges.Length > VisibleDetailsRowLimit)
+                {
+                    FlowGraphEdge[] overflowEdges = orderedEdges
+                        .Skip(VisibleDetailsRowLimit)
+                        .ToArray();
+                    Foldout overflow = new()
+                    {
+                        name = DetailsRoutesOverflowFoldoutName,
+                        text = $"{overflowEdges.Length} more routes",
+                        value = false,
+                    };
+                    bool overflowPopulated = false;
+                    void PopulateOverflow()
+                    {
+                        if (overflowPopulated)
+                        {
+                            return;
+                        }
+
+                        foreach (FlowGraphEdge edge in overflowEdges)
+                        {
+                            overflow.Add(CreateDetailsRouteRow(edge, onSelectionChanged));
+                        }
+                        overflowPopulated = true;
+                    }
+                    overflow.RegisterValueChangedCallback(evt =>
+                    {
+                        if (evt.newValue)
+                        {
+                            PopulateOverflow();
+                        }
+                    });
+                    overflow.SetValueWithoutNotify(overflowExpanded);
+                    if (overflowExpanded)
+                    {
+                        PopulateOverflow();
+                    }
+                    roster.Add(overflow);
+                }
+                populated = true;
+            }
+
+            roster.RegisterValueChangedCallback(evt =>
+            {
+                if (evt.newValue)
+                {
+                    Populate();
+                }
+            });
+            roster.SetValueWithoutNotify(expanded);
+            if (expanded)
+            {
+                Populate();
+            }
+            return roster;
+        }
+
+        private static VisualElement CreateDetailsRouteRow(
+            FlowGraphEdge edge,
+            Action<string> onSelectionChanged
+        )
+        {
+            string normalizedContext = NormalizeTraceContext(edge.Context);
+            string exactContext =
+                edge.ContextId == 0
+                    ? normalizedContext
+                    : $"{normalizedContext}, context #{edge.ContextId}";
+            VisualElement row = new()
+            {
+                tooltip =
+                    $"{edge.MessageTypeName} -> {edge.TargetComponentPath} [{edge.TargetComponentId}] ({edge.RegistrationTypeName}, {exactContext})",
+            };
+            row.AddToClassList(DetailsRouteRowClassName);
+            row.AddToClassList(DxMessagingEditorTheme.CardClassName);
+            row.style.marginTop = 5;
+            row.style.paddingTop = 7;
+            row.style.paddingRight = 8;
+            row.style.paddingBottom = 7;
+            row.style.paddingLeft = 8;
+            DxMessagingEditorTheme.ApplyCompleteBorder(
+                row,
+                DxMessagingEditorPalette.RouteKindColor(edge.RegistrationTypeName)
+            );
+
+            VisualElement summary = new();
+            summary.style.flexDirection = FlexDirection.Row;
+            summary.style.flexWrap = Wrap.Wrap;
+            summary.style.alignItems = Align.Center;
+            VisualElement receiver = CreateRelationshipIdentity("RECEIVER", string.Empty);
+            receiver.style.flexGrow = 1;
+            receiver.Add(CreateHierarchyTrail(edge.TargetComponentPath));
+            summary.Add(receiver);
+            Label routeKind = CreateRouteKindBadge(edge.RegistrationTypeName, name: null);
+            routeKind.style.marginLeft = 8;
+            summary.Add(routeKind);
+            Label activity = new($"{edge.CallCount} calls");
+            activity.AddToClassList(DxMessagingEditorTheme.DetailFrameClassName);
+            activity.style.marginLeft = 8;
+            summary.Add(activity);
+            row.Add(summary);
+            row.Add(CreateDetailsKeyValue("Receiver ID", edge.TargetComponentId));
+            row.Add(CreateDetailsKeyValue("Registration", edge.RegistrationTypeName));
+            if (!IsMissingHierarchyValue(normalizedContext))
+            {
+                row.Add(
+                    CreateHierarchyDetailRow(
+                        CreateRouteContextLabel(edge.RegistrationTypeName, plural: false),
+                        normalizedContext,
+                        extractDescriptor: true
+                    )
+                );
+            }
+            if (edge.ContextId != 0)
+            {
+                row.Add(
+                    CreateDetailsKeyValue(
+                        "Context ID",
+                        edge.ContextId.ToString(CultureInfo.InvariantCulture)
+                    )
+                );
+            }
+            ApplyDetailsSelection(
+                row,
+                CreateEdgeSelectionKey(edge),
+                onSelectionChanged,
+                addDesignClass: true
+            );
+            return row;
+        }
+
         private static void AddDetailsDiagnosticsSummary(
             VisualElement diagnostics,
             FlowGraphSelectedItem selectedItem,
-            FlowGraphVisibleSnapshot visibleSnapshot
+            FlowGraphVisibleSnapshot visibleSnapshot,
+            Action<string> onSelectionChanged
         )
         {
             FlowGraphEdge[] edges;
@@ -6640,6 +6898,7 @@ namespace DxMessaging.Editor.Windows
                             : "BUSIEST TRACED ROUTE",
                         busiestEdge.MessageTypeName,
                         busiestEdge.TargetComponentPath,
+                        busiestEdge.TargetComponentId,
                         busiestEdge.RegistrationTypeName,
                         busiestEdge.Context,
                         busiestEdge.RecentTracedDeliveryCount,
@@ -6649,7 +6908,9 @@ namespace DxMessaging.Editor.Windows
                         mergeBusiestRelationships
                             ? tracePaths.Sum(path => path.RecentTracedDeliveryCount)
                             : 0,
-                        mergeBusiestRelationships ? "path deliveries" : null
+                        mergeBusiestRelationships ? "path deliveries" : null,
+                        onSelectionChanged,
+                        selectedItem.Key
                     )
                 );
             }
@@ -6692,11 +6953,14 @@ namespace DxMessaging.Editor.Windows
                         "BUSIEST TRACE PATH",
                         busiestTracePath.MessageTypeName,
                         busiestTracePath.TargetComponentPath,
+                        busiestTracePath.TargetComponentId,
                         busiestTracePath.RegistrationTypeName,
                         busiestTracePath.Context,
                         busiestTracePath.RecentTracedDeliveryCount,
                         tracePaths.Sum(path => path.RecentTracedDeliveryCount),
-                        "deliveries"
+                        "deliveries",
+                        onSelectionChanged: onSelectionChanged,
+                        currentSelectionKey: selectedItem.Key
                     )
                 );
             }
@@ -7154,7 +7418,9 @@ namespace DxMessaging.Editor.Windows
             VisualElement section,
             string firstLabel,
             IReadOnlyList<string> values,
-            bool extractDescriptor = false
+            bool extractDescriptor = false,
+            Func<string, string> selectionKeyFactory = null,
+            Action<string> onSelectionChanged = null
         )
         {
             string[] distinctValues = values
@@ -7173,7 +7439,9 @@ namespace DxMessaging.Editor.Windows
                     CreateHierarchyDetailRow(
                         index == 0 ? firstLabel : string.Empty,
                         distinctValues[index],
-                        extractDescriptor
+                        extractDescriptor,
+                        selectionKeyFactory?.Invoke(distinctValues[index]),
+                        onSelectionChanged
                     )
                 );
             }
@@ -7182,7 +7450,9 @@ namespace DxMessaging.Editor.Windows
         private static VisualElement CreateHierarchyDetailRow(
             string key,
             string value,
-            bool extractDescriptor = false
+            bool extractDescriptor = false,
+            string selectionKey = null,
+            Action<string> onSelectionChanged = null
         )
         {
             string exactValue = string.IsNullOrWhiteSpace(value) ? "none" : value.Trim();
@@ -7195,13 +7465,22 @@ namespace DxMessaging.Editor.Windows
             keyLabel.style.width = 110;
             keyLabel.style.whiteSpace = WhiteSpace.Normal;
             row.Add(keyLabel);
-            row.Add(CreateHierarchyTrail(exactValue, extractDescriptor));
+            row.Add(
+                CreateHierarchyTrail(
+                    exactValue,
+                    extractDescriptor,
+                    selectionKey,
+                    onSelectionChanged
+                )
+            );
             return row;
         }
 
         private static VisualElement CreateHierarchyTrail(
             string value,
-            bool extractDescriptor = false
+            bool extractDescriptor = false,
+            string selectionKey = null,
+            Action<string> onSelectionChanged = null
         )
         {
             SplitHierarchyDescriptor(
@@ -7278,6 +7557,7 @@ namespace DxMessaging.Editor.Windows
                 descriptorLabel.style.marginLeft = 8;
                 trail.Add(descriptorLabel);
             }
+            ApplyDetailsSelection(trail, selectionKey, onSelectionChanged, addDesignClass: true);
             return trail;
         }
 
@@ -7303,6 +7583,41 @@ namespace DxMessaging.Editor.Windows
 
             descriptor = path.Substring(descriptorStart + 2, path.Length - descriptorStart - 3);
             path = path.Substring(0, descriptorStart);
+        }
+
+        private static string FindContextComponentSelectionKey(
+            string hierarchyValue,
+            FlowGraphMessageNode message,
+            FlowGraphSnapshot snapshot,
+            FlowGraphVisibleSnapshot visibleSnapshot
+        )
+        {
+            if (
+                !message.RecentContextComponentIds.TryGetValue(
+                    hierarchyValue,
+                    out string componentId
+                ) || string.IsNullOrWhiteSpace(componentId)
+            )
+            {
+                return string.Empty;
+            }
+
+            FlowGraphComponentNode[] matches = snapshot
+                .ComponentNodes.Where(component =>
+                    string.Equals(component.Id, componentId, StringComparison.Ordinal)
+                )
+                .Take(2)
+                .ToArray();
+            if (matches.Length != 1)
+            {
+                return string.Empty;
+            }
+
+            return visibleSnapshot.ComponentNodes.Any(component =>
+                string.Equals(component.Id, matches[0].Id, StringComparison.Ordinal)
+            )
+                ? CreateComponentSelectionKey(matches[0])
+                : string.Empty;
         }
 
         private static string CreateRouteContextLabel(string registrationTypeName, bool plural)
@@ -7337,6 +7652,7 @@ namespace DxMessaging.Editor.Windows
             string label,
             string messageTypeName,
             string targetPath,
+            string targetComponentId,
             string registrationTypeName,
             string context,
             int deliveryCount,
@@ -7344,7 +7660,9 @@ namespace DxMessaging.Editor.Windows
             string activityLabel,
             int secondaryDeliveryCount = -1,
             int secondaryTotalDeliveryCount = 0,
-            string secondaryActivityLabel = null
+            string secondaryActivityLabel = null,
+            Action<string> onSelectionChanged = null,
+            string currentSelectionKey = null
         )
         {
             VisualElement relationship = new()
@@ -7391,11 +7709,30 @@ namespace DxMessaging.Editor.Windows
                 CreateRelationshipIdentity(
                     "MESSAGE",
                     CreateCompactGraphLabel(messageTypeName),
-                    CreateMessageTitleMetadata(messageTypeName)
+                    CreateMessageTitleMetadata(messageTypeName),
+                    DetailsRelationshipMessageLinkName,
+                    CreateMessageSelectionKey(messageTypeName),
+                    onSelectionChanged,
+                    string.Equals(
+                        currentSelectionKey,
+                        CreateMessageSelectionKey(messageTypeName),
+                        StringComparison.Ordinal
+                    )
                 )
             );
             flow.Add(CreateRouteArrow());
-            VisualElement target = CreateRelationshipIdentity("RECEIVER", string.Empty);
+            VisualElement target = CreateRelationshipIdentity(
+                "RECEIVER",
+                string.Empty,
+                name: DetailsRelationshipReceiverLinkName,
+                selectionKey: CreateComponentSelectionKey(targetComponentId),
+                onSelectionChanged: onSelectionChanged,
+                active: string.Equals(
+                    currentSelectionKey,
+                    CreateComponentSelectionKey(targetComponentId),
+                    StringComparison.Ordinal
+                )
+            );
             target.Add(CreateHierarchyTrail(targetPath));
             flow.Add(target);
             relationship.Add(flow);
@@ -7466,10 +7803,14 @@ namespace DxMessaging.Editor.Windows
         private static VisualElement CreateRelationshipIdentity(
             string label,
             string value,
-            IReadOnlyList<string> metadata = null
+            IReadOnlyList<string> metadata = null,
+            string name = null,
+            string selectionKey = null,
+            Action<string> onSelectionChanged = null,
+            bool active = false
         )
         {
-            VisualElement identity = new();
+            VisualElement identity = new() { name = name };
             identity.style.flexGrow = 1;
             identity.style.flexBasis = 150;
             identity.style.minWidth = 130;
@@ -7498,7 +7839,64 @@ namespace DxMessaging.Editor.Windows
                     identity.Add(identityMetadata);
                 }
             }
+            if (active)
+            {
+                identity.AddToClassList(DxMessagingEditorTheme.DetailActiveClassName);
+            }
+            else
+            {
+                ApplyDetailsSelection(
+                    identity,
+                    selectionKey,
+                    onSelectionChanged,
+                    addDesignClass: true
+                );
+            }
             return identity;
+        }
+
+        private static void ApplyDetailsSelection(
+            VisualElement element,
+            string selectionKey,
+            Action<string> onSelectionChanged,
+            bool addDesignClass
+        )
+        {
+            if (
+                element == null
+                || string.IsNullOrWhiteSpace(selectionKey)
+                || onSelectionChanged == null
+            )
+            {
+                return;
+            }
+
+            if (addDesignClass)
+            {
+                element.AddToClassList(DxMessagingEditorTheme.DetailLinkClassName);
+            }
+            element.focusable = true;
+            element.userData = selectionKey;
+            element.pickingMode = PickingMode.Position;
+            if (string.IsNullOrWhiteSpace(element.tooltip))
+            {
+                element.tooltip = "Select in the Flow Graph";
+            }
+            element.RegisterCallback<ClickEvent>(evt =>
+            {
+                evt.StopPropagation();
+                onSelectionChanged.Invoke(selectionKey);
+            });
+            element.RegisterCallback<KeyDownEvent>(evt =>
+            {
+                if (evt.keyCode != KeyCode.Return && evt.keyCode != KeyCode.Space)
+                {
+                    return;
+                }
+
+                evt.StopPropagation();
+                onSelectionChanged.Invoke(selectionKey);
+            });
         }
 
         private static VisualElement CreateMessageTypesSection(
@@ -9323,6 +9721,11 @@ namespace DxMessaging.Editor.Windows
 
             private HashSet<string> Contexts { get; } = new(StringComparer.Ordinal);
 
+            private Dictionary<string, HashSet<int>> ContextIdsByDisplay { get; } =
+                new(StringComparer.Ordinal);
+
+            private Dictionary<int, string> ContextComponentIds { get; } = new();
+
             internal int RegistrationCount { get; set; }
 
             internal int CallCount { get; set; }
@@ -9359,7 +9762,20 @@ namespace DxMessaging.Editor.Windows
                 EmissionSites.Add(CreateEmissionSite(emission.stackTrace));
                 if (emission.context.HasValue)
                 {
-                    Contexts.Add(CreateContextDisplayText(emission.context));
+                    string contextDisplay = CreateContextDisplayText(emission.context);
+                    Contexts.Add(contextDisplay);
+                    if (!ContextIdsByDisplay.TryGetValue(contextDisplay, out HashSet<int> ids))
+                    {
+                        ids = new HashSet<int>();
+                        ContextIdsByDisplay[contextDisplay] = ids;
+                    }
+                    int contextId = emission.context.Value.Id;
+                    ids.Add(contextId);
+                    string componentId = TryCreateContextComponentId(emission.context.Value);
+                    if (!string.IsNullOrWhiteSpace(componentId))
+                    {
+                        ContextComponentIds[contextId] = componentId;
+                    }
                 }
             }
 
@@ -9374,9 +9790,59 @@ namespace DxMessaging.Editor.Windows
                     RecentTracedDeliveryCount,
                     MessageKindName,
                     EmissionSites.OrderBy(site => site, StringComparer.Ordinal).ToArray(),
-                    Contexts.OrderBy(context => context, StringComparer.Ordinal).ToArray()
+                    Contexts.OrderBy(context => context, StringComparer.Ordinal).ToArray(),
+                    BuildContextComponentIds()
                 );
             }
+
+            private IReadOnlyDictionary<string, string> BuildContextComponentIds()
+            {
+                Dictionary<string, string> contextComponentIds = new(StringComparer.Ordinal);
+                foreach (KeyValuePair<string, HashSet<int>> pair in ContextIdsByDisplay)
+                {
+                    if (pair.Value.Count != 1)
+                    {
+                        continue;
+                    }
+
+                    int contextId = pair.Value.First();
+                    if (ContextComponentIds.TryGetValue(contextId, out string componentId))
+                    {
+                        contextComponentIds[pair.Key] = componentId;
+                    }
+                }
+                return contextComponentIds;
+            }
+        }
+
+        private static string TryCreateContextComponentId(InstanceId context)
+        {
+            UnityEngine.Object contextObject = context.Object;
+            if (contextObject == null)
+            {
+                return string.Empty;
+            }
+            if (contextObject is MessagingComponent exactComponent)
+            {
+                return IsSceneComponent(exactComponent)
+                    ? CreateComponentId(exactComponent)
+                    : string.Empty;
+            }
+
+            GameObject contextGameObject = contextObject is GameObject gameObject
+                ? gameObject
+                : (contextObject as Component)?.gameObject;
+            if (contextGameObject == null)
+            {
+                return string.Empty;
+            }
+
+            MessagingComponent[] candidates = contextGameObject
+                .GetComponents<MessagingComponent>()
+                .Where(IsSceneComponent)
+                .Take(2)
+                .ToArray();
+            return candidates.Length == 1 ? CreateComponentId(candidates[0]) : string.Empty;
         }
 
         private sealed class EdgeBuilder
@@ -10312,7 +10778,8 @@ namespace DxMessaging.Editor.Windows
             int recentTracedDeliveryCount = 0,
             string messageKindName = "MESSAGE",
             IReadOnlyList<string> recentEmissionSites = null,
-            IReadOnlyList<string> recentContexts = null
+            IReadOnlyList<string> recentContexts = null,
+            IReadOnlyDictionary<string, string> recentContextComponentIds = null
         )
         {
             MessageTypeName = messageTypeName ?? string.Empty;
@@ -10326,6 +10793,8 @@ namespace DxMessaging.Editor.Windows
                 : messageKindName;
             RecentEmissionSites = recentEmissionSites ?? Array.Empty<string>();
             RecentContexts = recentContexts ?? Array.Empty<string>();
+            RecentContextComponentIds =
+                recentContextComponentIds ?? new Dictionary<string, string>();
         }
 
         internal string MessageTypeName { get; }
@@ -10345,6 +10814,8 @@ namespace DxMessaging.Editor.Windows
         internal IReadOnlyList<string> RecentEmissionSites { get; }
 
         internal IReadOnlyList<string> RecentContexts { get; }
+
+        internal IReadOnlyDictionary<string, string> RecentContextComponentIds { get; }
 
         internal bool Matches(string filterText)
         {

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -7139,13 +7139,6 @@ namespace DxMessaging.Editor.Windows
             return row;
         }
 
-        private static string RemoveDiagnosticPrefix(string text, string prefix)
-        {
-            return text.StartsWith(prefix, StringComparison.Ordinal)
-                ? text.Substring(prefix.Length)
-                : text;
-        }
-
         private static void AddEdgeDetailsCards(
             VisualElement details,
             FlowGraphEdge edge,
@@ -7990,26 +7983,6 @@ namespace DxMessaging.Editor.Windows
                 );
             }
             return row;
-        }
-
-        private static void AddDetailValues(
-            VisualElement section,
-            string firstLabel,
-            IReadOnlyList<string> values
-        )
-        {
-            if (values.Count == 0)
-            {
-                section.Add(CreateDetailsKeyValue(firstLabel, "none captured"));
-                return;
-            }
-
-            for (int index = 0; index < values.Count; index++)
-            {
-                section.Add(
-                    CreateDetailsKeyValue(index == 0 ? firstLabel : string.Empty, values[index])
-                );
-            }
         }
 
         private static void AddSourceDetailValues(

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -7544,7 +7544,10 @@ namespace DxMessaging.Editor.Windows
                 };
             }
 
-            VisualElement trail = new();
+            VisualElement trail = new()
+            {
+                tooltip = string.IsNullOrWhiteSpace(value) ? "none" : value.Trim(),
+            };
             trail.AddToClassList(DetailsHierarchyTrailClassName);
             trail.style.flexDirection = FlexDirection.Row;
             trail.style.flexWrap = Wrap.Wrap;
@@ -7768,7 +7771,8 @@ namespace DxMessaging.Editor.Windows
                         CreateMessageSelectionKey(messageTypeName),
                         StringComparison.Ordinal
                     ),
-                    focusRestorationId: relationshipFocusId + ":message"
+                    focusRestorationId: relationshipFocusId + ":message",
+                    exactTooltip: messageTypeName
                 )
             );
             flow.Add(CreateRouteArrow());
@@ -7783,7 +7787,8 @@ namespace DxMessaging.Editor.Windows
                     CreateComponentSelectionKey(targetComponentId),
                     StringComparison.Ordinal
                 ),
-                focusRestorationId: relationshipFocusId + ":receiver"
+                focusRestorationId: relationshipFocusId + ":receiver",
+                exactTooltip: $"{targetPath} [{targetComponentId}]"
             );
             target.Add(CreateHierarchyTrail(targetPath));
             flow.Add(target);
@@ -7860,10 +7865,11 @@ namespace DxMessaging.Editor.Windows
             string selectionKey = null,
             Action<string> onSelectionChanged = null,
             bool active = false,
-            string focusRestorationId = null
+            string focusRestorationId = null,
+            string exactTooltip = null
         )
         {
-            VisualElement identity = new() { name = name };
+            VisualElement identity = new() { name = name, tooltip = exactTooltip };
             identity.style.flexGrow = 1;
             identity.style.flexBasis = 150;
             identity.style.minWidth = 130;

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -174,6 +174,16 @@ namespace DxMessaging.Editor.Windows
         internal const string DetailsMetricClassName = "dxmessaging-flow-graph-details-metric";
         internal const string DetailsMessageTypeRowClassName =
             "dxmessaging-flow-graph-details-message-type-row";
+        internal const string DetailsHierarchyRowClassName =
+            "dxmessaging-flow-graph-details-hierarchy-row";
+        internal const string DetailsHierarchyTrailClassName =
+            "dxmessaging-flow-graph-details-hierarchy-trail";
+        internal const string DetailsHierarchySegmentClassName =
+            "dxmessaging-flow-graph-details-hierarchy-segment";
+        internal const string DetailsSourceRowClassName =
+            "dxmessaging-flow-graph-details-source-row";
+        internal const string DetailsRelationshipClassName =
+            "dxmessaging-flow-graph-details-relationship";
         internal const string DetailsTechnicalFoldoutName =
             "dxmessaging-flow-graph-details-technical";
         internal const string DetailsEvidenceFoldoutName =
@@ -5772,6 +5782,19 @@ namespace DxMessaging.Editor.Windows
 
         private static string CreateWidestTraceSummary(IEnumerable<FlowGraphTracePath> tracePaths)
         {
+            TraceIdPathSummary widestTrace = FindWidestTrace(tracePaths);
+            if (widestTrace.PathCount <= 0)
+            {
+                return "Widest trace: none";
+            }
+
+            return $"Widest trace: {widestTrace.TraceId} ({FormatCount(widestTrace.PathCount, "path")})";
+        }
+
+        private static TraceIdPathSummary FindWidestTrace(
+            IEnumerable<FlowGraphTracePath> tracePaths
+        )
+        {
             Dictionary<long, int> pathCountsByTraceId = new();
             foreach (FlowGraphTracePath path in tracePaths)
             {
@@ -5790,12 +5813,7 @@ namespace DxMessaging.Editor.Windows
                 .OrderByDescending(summary => summary.PathCount)
                 .ThenBy(summary => summary.TraceId)
                 .FirstOrDefault();
-            if (widestTrace.PathCount <= 0)
-            {
-                return "Widest trace: none";
-            }
-
-            return $"Widest trace: {widestTrace.TraceId} ({FormatCount(widestTrace.PathCount, "path")})";
+            return widestTrace;
         }
 
         private static VisualElement CreateRouteMapRow(
@@ -6230,18 +6248,7 @@ namespace DxMessaging.Editor.Windows
 
         private static Label CreateRouteKindBadge(string routeKindText, string name)
         {
-            string normalizedKind = DxMessagingEditorPalette.NormalizeRouteKind(routeKindText);
-            string labelText =
-                string.Equals(
-                    routeKindText,
-                    MessageRegistrationType.GlobalAcceptAll.ToString(),
-                    StringComparison.Ordinal
-                )
-                    ? "GLOBAL OBSERVER"
-                : string.IsNullOrWhiteSpace(normalizedKind)
-                    ? string.IsNullOrWhiteSpace(routeKindText) ? "<unknown route kind>"
-                        : routeKindText.Trim()
-                : normalizedKind;
+            string labelText = CreateRouteKindBadgeText(routeKindText);
             Label routeKind = new(labelText) { name = name };
             DxMessagingEditorTheme.AddRouteKindTypeBadgeClasses(routeKind, routeKindText);
             routeKind.style.unityFontStyleAndWeight = FontStyle.Bold;
@@ -6293,17 +6300,27 @@ namespace DxMessaging.Editor.Windows
             details.style.paddingLeft = 12;
 
             VisualElement header = new();
-            header.style.flexDirection = FlexDirection.Row;
-            header.style.alignItems = Align.Center;
-            header.style.marginBottom = 10;
+            header.AddToClassList(DxMessagingEditorTheme.DetailHeadClassName);
+            header.style.flexWrap = Wrap.Wrap;
+            VisualElement heading = new();
+            heading.style.flexGrow = 1;
+            heading.style.flexShrink = 1;
             Label title = new(CreateDetailsTitle(selectedItem)) { name = DetailsTitleLabelName };
-            title.AddToClassList(DxMessagingEditorTheme.CardLabelClassName);
-            title.style.unityFontStyleAndWeight = FontStyle.Bold;
+            title.AddToClassList(DxMessagingEditorTheme.DetailTitleClassName);
+            title.tooltip = CreateDetailsTitleTooltip(selectedItem);
             title.style.whiteSpace = WhiteSpace.Normal;
-            title.style.fontSize = 14;
-            title.style.flexGrow = 1;
-            title.style.marginBottom = 0;
-            header.Add(title);
+            title.style.marginLeft = 0;
+            heading.Add(title);
+            foreach (string titleMetadata in CreateDetailsTitleMetadata(selectedItem))
+            {
+                Label metadata = new(titleMetadata);
+                metadata.AddToClassList(DxMessagingEditorTheme.DetailFrameClassName);
+                metadata.tooltip = CreateDetailsTitleTooltip(selectedItem);
+                metadata.style.marginTop = 2;
+                metadata.style.whiteSpace = WhiteSpace.Normal;
+                heading.Add(metadata);
+            }
+            header.Add(heading);
             if (selectedItem.Kind == FlowGraphSelectionKind.Edge)
             {
                 header.Add(CreateRouteKindBadge(selectedItem.Edge.RegistrationTypeName, null));
@@ -6325,7 +6342,13 @@ namespace DxMessaging.Editor.Windows
                 : string.Empty;
             if (TryResolveMessageSource(messageTypeName, out FlowGraphSourceLocation messageSource))
             {
-                header.Add(CreateSourceLinkButton("Open message source", messageSource));
+                header.Add(
+                    CreateSourceLinkButton(
+                        "Open message source",
+                        messageSource,
+                        includeLocationInText: false
+                    )
+                );
             }
             details.Add(header);
 
@@ -6422,7 +6445,7 @@ namespace DxMessaging.Editor.Windows
             );
             VisualElement traffic = CreateDetailsSection("VISIBLE TRAFFIC");
             traffic.Add(CreateDetailsKeyValue("Type", component.ComponentTypeName));
-            traffic.Add(CreateDetailsKeyValue("Hierarchy", component.HierarchyPath));
+            traffic.Add(CreateHierarchyDetailRow("Hierarchy", component.HierarchyPath));
             traffic.Add(
                 CreateDetailsKeyValue(
                     "Inbound routes",
@@ -6505,14 +6528,18 @@ namespace DxMessaging.Editor.Windows
                 )
             );
             VisualElement evidence = CreateDetailsSection("RECENT EVIDENCE");
-            evidence.Add(CreateDetailsKeyValue("Message type", message.MessageTypeName));
-            evidence.Add(
-                CreateDetailsKeyValue("Contexts", JoinDistinctOrNone(message.RecentContexts))
+            AddHierarchyDetailValues(
+                evidence,
+                "Contexts",
+                message.RecentContexts,
+                extractDescriptor: true
             );
             AddSourceDetailValues(evidence, "Emitted by", message.RecentEmissionSites);
+            Foldout evidenceFoldout = CreateDetailsEvidenceFoldout();
+            evidenceFoldout.Add(evidence);
             if (visibleMessageKind == "GLOBAL OBSERVER")
             {
-                evidence.Add(
+                evidenceFoldout.Add(
                     CreateMessageTypesSection(
                         "OBSERVED TYPES",
                         visibleSnapshot
@@ -6527,8 +6554,6 @@ namespace DxMessaging.Editor.Windows
                     )
                 );
             }
-            Foldout evidenceFoldout = CreateDetailsEvidenceFoldout();
-            evidenceFoldout.Add(evidence);
             details.Add(evidenceFoldout);
         }
 
@@ -6577,6 +6602,16 @@ namespace DxMessaging.Editor.Windows
                     tracePaths = Array.Empty<FlowGraphTracePath>();
                     break;
             }
+            bool showAggregateRelationships = selectedItem.Kind != FlowGraphSelectionKind.Edge;
+            bool hasBusiestEdge = TryGetBusiestTracedEdge(edges, out FlowGraphEdge busiestEdge);
+            bool hasBusiestTracePath = TryGetBusiestTracePath(
+                tracePaths,
+                out FlowGraphTracePath busiestTracePath
+            );
+            bool mergeBusiestRelationships =
+                hasBusiestEdge
+                && hasBusiestTracePath
+                && RelationshipsMatch(busiestEdge, busiestTracePath);
 
             VisualElement routeHealth = CreateDetailsMetricSection(
                 "ROUTE HEALTH",
@@ -6596,15 +6631,32 @@ namespace DxMessaging.Editor.Windows
                     edges.Count(edge => edge.CallCount <= 0).ToString(CultureInfo.InvariantCulture)
                 )
             );
-            routeHealth.Add(
-                CreateDetailsKeyValue(
-                    "Busiest traced",
-                    RemoveDiagnosticPrefix(
-                        CreateBusiestTracedRouteSummary(edges),
-                        "Busiest traced route: "
+            if (showAggregateRelationships && hasBusiestEdge)
+            {
+                routeHealth.Add(
+                    CreateDetailsRelationship(
+                        mergeBusiestRelationships
+                            ? "BUSIEST ROUTE + TRACE PATH"
+                            : "BUSIEST TRACED ROUTE",
+                        busiestEdge.MessageTypeName,
+                        busiestEdge.TargetComponentPath,
+                        busiestEdge.RegistrationTypeName,
+                        busiestEdge.Context,
+                        busiestEdge.RecentTracedDeliveryCount,
+                        edges.Sum(edge => edge.RecentTracedDeliveryCount),
+                        mergeBusiestRelationships ? "route traces" : "traced",
+                        mergeBusiestRelationships ? busiestTracePath.RecentTracedDeliveryCount : -1,
+                        mergeBusiestRelationships
+                            ? tracePaths.Sum(path => path.RecentTracedDeliveryCount)
+                            : 0,
+                        mergeBusiestRelationships ? "path deliveries" : null
                     )
-                )
-            );
+                );
+            }
+            else if (showAggregateRelationships)
+            {
+                routeHealth.Add(CreateDetailsKeyValue("Busiest traced route", "none"));
+            }
             diagnostics.Add(routeHealth);
 
             VisualElement traceCoverage = CreateDetailsMetricSection(
@@ -6632,30 +6684,26 @@ namespace DxMessaging.Editor.Windows
                         .ToString(CultureInfo.InvariantCulture)
                 )
             );
-            traceCoverage.Add(
-                CreateDetailsKeyValue(
-                    "Widest trace",
-                    RemoveDiagnosticPrefix(CreateWidestTraceSummary(tracePaths), "Widest trace: ")
-                )
-            );
-            traceCoverage.Add(
-                CreateDetailsKeyValue(
-                    "Busiest path",
-                    RemoveDiagnosticPrefix(
-                        CreateBusiestTracePathSummary(tracePaths),
-                        "Busiest path: "
+            traceCoverage.Add(CreateWidestTraceDetail(tracePaths));
+            if (showAggregateRelationships && hasBusiestTracePath && !mergeBusiestRelationships)
+            {
+                traceCoverage.Add(
+                    CreateDetailsRelationship(
+                        "BUSIEST TRACE PATH",
+                        busiestTracePath.MessageTypeName,
+                        busiestTracePath.TargetComponentPath,
+                        busiestTracePath.RegistrationTypeName,
+                        busiestTracePath.Context,
+                        busiestTracePath.RecentTracedDeliveryCount,
+                        tracePaths.Sum(path => path.RecentTracedDeliveryCount),
+                        "deliveries"
                     )
-                )
-            );
-            traceCoverage.Add(
-                CreateDetailsKeyValue(
-                    "Path share",
-                    RemoveDiagnosticPrefix(
-                        CreateBusiestTracePathShareSummary(tracePaths),
-                        "Busiest path share: "
-                    )
-                )
-            );
+                );
+            }
+            else if (showAggregateRelationships && !hasBusiestTracePath)
+            {
+                traceCoverage.Add(CreateDetailsKeyValue("Busiest trace path", "none"));
+            }
             diagnostics.Add(traceCoverage);
         }
 
@@ -6715,6 +6763,118 @@ namespace DxMessaging.Editor.Windows
             );
         }
 
+        private static bool TryGetBusiestTracedEdge(
+            IEnumerable<FlowGraphEdge> edges,
+            out FlowGraphEdge busiestEdge
+        )
+        {
+            busiestEdge = edges
+                .Where(edge => edge.RecentTracedDeliveryCount > 0)
+                .OrderByDescending(edge => edge.RecentTracedDeliveryCount)
+                .ThenBy(edge => edge.MessageTypeName, StringComparer.Ordinal)
+                .ThenBy(edge => edge.TargetComponentPath, StringComparer.Ordinal)
+                .ThenBy(edge => edge.RegistrationTypeName, StringComparer.Ordinal)
+                .FirstOrDefault();
+            return busiestEdge.RecentTracedDeliveryCount > 0;
+        }
+
+        private static bool TryGetBusiestTracePath(
+            IEnumerable<FlowGraphTracePath> tracePaths,
+            out FlowGraphTracePath busiestPath
+        )
+        {
+            busiestPath = tracePaths
+                .Where(path => path.RecentTracedDeliveryCount > 0)
+                .OrderByDescending(path => path.RecentTracedDeliveryCount)
+                .ThenBy(path => path.MessageTypeName, StringComparer.Ordinal)
+                .ThenBy(path => path.TargetComponentPath, StringComparer.Ordinal)
+                .ThenBy(path => path.RegistrationTypeName, StringComparer.Ordinal)
+                .ThenBy(path => NormalizeTraceContext(path.Context), StringComparer.Ordinal)
+                .FirstOrDefault();
+            return busiestPath.RecentTracedDeliveryCount > 0;
+        }
+
+        private static bool RelationshipsMatch(FlowGraphEdge edge, FlowGraphTracePath tracePath)
+        {
+            bool stableIdentityMatches =
+                string.Equals(
+                    edge.MessageTypeName,
+                    tracePath.MessageTypeName,
+                    StringComparison.Ordinal
+                )
+                && string.Equals(
+                    edge.TargetComponentId,
+                    tracePath.TargetComponentId,
+                    StringComparison.Ordinal
+                )
+                && string.Equals(
+                    edge.TargetComponentPath,
+                    tracePath.TargetComponentPath,
+                    StringComparison.Ordinal
+                )
+                && string.Equals(
+                    edge.RegistrationTypeName,
+                    tracePath.RegistrationTypeName,
+                    StringComparison.Ordinal
+                );
+            if (!stableIdentityMatches)
+            {
+                return false;
+            }
+            if (edge.ContextId != 0 || tracePath.ContextId != 0)
+            {
+                return edge.ContextId == tracePath.ContextId;
+            }
+            return string.Equals(
+                CreateHierarchyComparisonKey(edge.Context),
+                CreateHierarchyComparisonKey(tracePath.Context),
+                StringComparison.Ordinal
+            );
+        }
+
+        private static string CreateHierarchyComparisonKey(string value)
+        {
+            string normalized = NormalizeTraceContext(value);
+            SplitHierarchyDescriptor(
+                normalized,
+                extractDescriptor: true,
+                out string hierarchyPath,
+                out _
+            );
+            return hierarchyPath;
+        }
+
+        private static VisualElement CreateWidestTraceDetail(
+            IEnumerable<FlowGraphTracePath> tracePaths
+        )
+        {
+            TraceIdPathSummary widestTrace = FindWidestTrace(tracePaths);
+            VisualElement row = new();
+            row.AddToClassList(DxMessagingEditorTheme.KeyValueClassName);
+            Label keyLabel = new("Widest trace");
+            keyLabel.AddToClassList(DxMessagingEditorTheme.KeyValueKeyClassName);
+            keyLabel.style.width = 110;
+            row.Add(keyLabel);
+            VisualElement values = new();
+            values.style.flexDirection = FlexDirection.Row;
+            values.style.flexWrap = Wrap.Wrap;
+            values.style.flexGrow = 1;
+            Label traceIdentity = new(
+                widestTrace.PathCount <= 0 ? "none" : $"Trace #{widestTrace.TraceId}"
+            );
+            traceIdentity.AddToClassList(DxMessagingEditorTheme.KeyValueValueClassName);
+            values.Add(traceIdentity);
+            if (widestTrace.PathCount > 0)
+            {
+                Label pathCount = new(FormatCount(widestTrace.PathCount, "path"));
+                pathCount.AddToClassList(DxMessagingEditorTheme.DetailFrameClassName);
+                pathCount.style.marginLeft = 10;
+                values.Add(pathCount);
+            }
+            row.Add(values);
+            return row;
+        }
+
         private static string RemoveDiagnosticPrefix(string text, string prefix)
         {
             return text.StartsWith(prefix, StringComparison.Ordinal)
@@ -6768,7 +6928,13 @@ namespace DxMessaging.Editor.Windows
                 )
             );
             evidence.Add(CreateDetailsKeyValue("Registration", edge.RegistrationTypeName));
-            evidence.Add(CreateDetailsKeyValue("Context", CreateReadableRouteContext(edge)));
+            evidence.Add(
+                CreateHierarchyDetailRow(
+                    CreateRouteContextLabel(edge.RegistrationTypeName, plural: false),
+                    CreateReadableRouteContext(edge),
+                    extractDescriptor: true
+                )
+            );
             evidence.Add(
                 CreateDetailsKeyValue(
                     "Evidence scope",
@@ -6792,23 +6958,30 @@ namespace DxMessaging.Editor.Windows
                         .ToString(CultureInfo.InvariantCulture)
                 )
             );
-            traces.Add(CreateDetailsKeyValue("Contexts", JoinTraceContextsOrNone(tracePaths)));
+            AddHierarchyDetailValues(
+                traces,
+                CreateRouteContextLabel(edge.RegistrationTypeName, plural: true),
+                tracePaths.Select(path => NormalizeTraceContext(path.Context)).ToArray(),
+                extractDescriptor: true
+            );
             traces.Add(
                 CreateDetailsKeyValue(
                     "Trace ids",
                     CountDistinctTraceIds(tracePaths).ToString(CultureInfo.InvariantCulture)
                 )
             );
-            traces.Add(
-                CreateDetailsKeyValue(
-                    "Busiest path",
-                    CreateBusiestTracePathSummary(tracePaths)
-                        .Replace("Busiest path: ", string.Empty)
-                )
-            );
             Foldout evidenceFoldout = CreateDetailsEvidenceFoldout();
             evidenceFoldout.Add(evidence);
             evidenceFoldout.Add(traces);
+            if (IsGlobalObserverRegistration(edge.RegistrationTypeName))
+            {
+                evidenceFoldout.Add(
+                    CreateMessageTypesSection(
+                        "OBSERVED TYPES",
+                        tracePaths.Select(path => path.MessageTypeName)
+                    )
+                );
+            }
             details.Add(evidenceFoldout);
         }
 
@@ -6977,6 +7150,357 @@ namespace DxMessaging.Editor.Windows
             return pair;
         }
 
+        private static void AddHierarchyDetailValues(
+            VisualElement section,
+            string firstLabel,
+            IReadOnlyList<string> values,
+            bool extractDescriptor = false
+        )
+        {
+            string[] distinctValues = values
+                .Where(value => !IsMissingHierarchyValue(value))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+            if (distinctValues.Length == 0)
+            {
+                section.Add(CreateDetailsKeyValue(firstLabel, "none captured"));
+                return;
+            }
+
+            for (int index = 0; index < distinctValues.Length; index++)
+            {
+                section.Add(
+                    CreateHierarchyDetailRow(
+                        index == 0 ? firstLabel : string.Empty,
+                        distinctValues[index],
+                        extractDescriptor
+                    )
+                );
+            }
+        }
+
+        private static VisualElement CreateHierarchyDetailRow(
+            string key,
+            string value,
+            bool extractDescriptor = false
+        )
+        {
+            string exactValue = string.IsNullOrWhiteSpace(value) ? "none" : value.Trim();
+            VisualElement row = new() { tooltip = exactValue };
+            row.AddToClassList(DxMessagingEditorTheme.KeyValueClassName);
+            row.AddToClassList(DetailsHierarchyRowClassName);
+            row.style.alignItems = Align.FlexStart;
+            Label keyLabel = new(key);
+            keyLabel.AddToClassList(DxMessagingEditorTheme.KeyValueKeyClassName);
+            keyLabel.style.width = 110;
+            keyLabel.style.whiteSpace = WhiteSpace.Normal;
+            row.Add(keyLabel);
+            row.Add(CreateHierarchyTrail(exactValue, extractDescriptor));
+            return row;
+        }
+
+        private static VisualElement CreateHierarchyTrail(
+            string value,
+            bool extractDescriptor = false
+        )
+        {
+            SplitHierarchyDescriptor(
+                value,
+                extractDescriptor,
+                out string path,
+                out string descriptor
+            );
+
+            string[] segments = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(segment => segment.Trim())
+                .Where(segment => segment.Length > 0)
+                .ToArray();
+            if (segments.Length == 0)
+            {
+                segments = new[] { "none" };
+            }
+            if (segments.Length > 4)
+            {
+                segments = new[]
+                {
+                    segments[0],
+                    "...",
+                    segments[segments.Length - 2],
+                    segments[segments.Length - 1],
+                };
+            }
+
+            VisualElement trail = new();
+            trail.AddToClassList(DetailsHierarchyTrailClassName);
+            trail.style.flexDirection = FlexDirection.Row;
+            trail.style.flexWrap = Wrap.Wrap;
+            trail.style.alignItems = Align.Center;
+            trail.style.flexGrow = 1;
+            trail.style.flexShrink = 1;
+            for (int index = 0; index < segments.Length; index++)
+            {
+                VisualElement segmentGroup = new();
+                segmentGroup.AddToClassList(DetailsHierarchySegmentClassName);
+                segmentGroup.style.flexDirection = FlexDirection.Row;
+                segmentGroup.style.alignItems = Align.Center;
+                segmentGroup.style.flexShrink = 1;
+                if (index > 0)
+                {
+                    Label separator = new(">");
+                    separator.AddToClassList(DxMessagingEditorTheme.DetailFrameClassName);
+                    separator.style.marginLeft = 5;
+                    separator.style.marginRight = 5;
+                    separator.style.flexShrink = 0;
+                    segmentGroup.Add(separator);
+                }
+
+                Label segment = new(segments[index]);
+                segment.AddToClassList(DxMessagingEditorTheme.KeyValueValueClassName);
+                segment.style.flexShrink = 1;
+                segment.style.whiteSpace = WhiteSpace.Normal;
+                segment.style.overflow = Overflow.Hidden;
+                segment.style.textOverflow = TextOverflow.Ellipsis;
+                if (index == segments.Length - 1)
+                {
+                    segment.style.unityFontStyleAndWeight = FontStyle.Bold;
+                }
+                else
+                {
+                    segment.style.opacity = 0.72f;
+                }
+                segmentGroup.Add(segment);
+                trail.Add(segmentGroup);
+            }
+            if (!string.IsNullOrWhiteSpace(descriptor))
+            {
+                Label descriptorLabel = new(descriptor);
+                descriptorLabel.AddToClassList(DxMessagingEditorTheme.PriorityClassName);
+                descriptorLabel.style.marginLeft = 8;
+                trail.Add(descriptorLabel);
+            }
+            return trail;
+        }
+
+        private static void SplitHierarchyDescriptor(
+            string value,
+            bool extractDescriptor,
+            out string path,
+            out string descriptor
+        )
+        {
+            path = string.IsNullOrWhiteSpace(value) ? "none" : value.Trim();
+            descriptor = string.Empty;
+            if (!extractDescriptor)
+            {
+                return;
+            }
+
+            int descriptorStart = path.LastIndexOf(" (", StringComparison.Ordinal);
+            if (descriptorStart <= 0 || !path.EndsWith(")", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            descriptor = path.Substring(descriptorStart + 2, path.Length - descriptorStart - 3);
+            path = path.Substring(0, descriptorStart);
+        }
+
+        private static string CreateRouteContextLabel(string registrationTypeName, bool plural)
+        {
+            string normalizedKind = DxMessagingEditorPalette.NormalizeRouteKind(
+                registrationTypeName
+            );
+            if (
+                string.Equals(
+                    normalizedKind,
+                    DxMessagingEditorPalette.TargetedKind,
+                    StringComparison.Ordinal
+                )
+            )
+            {
+                return plural ? "Targets" : "Target";
+            }
+            if (
+                string.Equals(
+                    normalizedKind,
+                    DxMessagingEditorPalette.BroadcastKind,
+                    StringComparison.Ordinal
+                )
+            )
+            {
+                return plural ? "Sources" : "Source";
+            }
+            return "Scope";
+        }
+
+        private static VisualElement CreateDetailsRelationship(
+            string label,
+            string messageTypeName,
+            string targetPath,
+            string registrationTypeName,
+            string context,
+            int deliveryCount,
+            int totalDeliveryCount,
+            string activityLabel,
+            int secondaryDeliveryCount = -1,
+            int secondaryTotalDeliveryCount = 0,
+            string secondaryActivityLabel = null
+        )
+        {
+            VisualElement relationship = new()
+            {
+                tooltip =
+                    $"{messageTypeName} -> {targetPath} ({registrationTypeName}, {NormalizeTraceContext(context)})",
+            };
+            relationship.AddToClassList(DetailsRelationshipClassName);
+            relationship.style.marginTop = 6;
+            relationship.style.paddingTop = 8;
+            relationship.style.paddingRight = 9;
+            relationship.style.paddingBottom = 8;
+            relationship.style.paddingLeft = 9;
+            relationship.style.backgroundColor = DxMessagingEditorPalette.SelectedWash;
+            relationship.style.borderTopLeftRadius = 6;
+            relationship.style.borderTopRightRadius = 6;
+            relationship.style.borderBottomLeftRadius = 6;
+            relationship.style.borderBottomRightRadius = 6;
+            DxMessagingEditorTheme.ApplyCompleteBorder(
+                relationship,
+                DxMessagingEditorPalette.RouteKindColor(registrationTypeName)
+            );
+
+            VisualElement header = new();
+            header.style.flexDirection = FlexDirection.Row;
+            header.style.flexWrap = Wrap.Wrap;
+            header.style.alignItems = Align.Center;
+            Label relationshipLabel = new(label);
+            relationshipLabel.AddToClassList(DxMessagingEditorTheme.CardLabelClassName);
+            relationshipLabel.style.flexGrow = 1;
+            relationshipLabel.style.marginBottom = 0;
+            header.Add(relationshipLabel);
+            Label routeKind = CreateRouteKindBadge(registrationTypeName, name: null);
+            routeKind.style.marginLeft = 6;
+            header.Add(routeKind);
+            relationship.Add(header);
+
+            VisualElement flow = new();
+            flow.style.flexDirection = FlexDirection.Row;
+            flow.style.flexWrap = Wrap.Wrap;
+            flow.style.alignItems = Align.Center;
+            flow.style.marginTop = 6;
+            flow.Add(
+                CreateRelationshipIdentity(
+                    "MESSAGE",
+                    CreateCompactGraphLabel(messageTypeName),
+                    CreateMessageTitleMetadata(messageTypeName)
+                )
+            );
+            flow.Add(CreateRouteArrow());
+            VisualElement target = CreateRelationshipIdentity("RECEIVER", string.Empty);
+            target.Add(CreateHierarchyTrail(targetPath));
+            flow.Add(target);
+            relationship.Add(flow);
+
+            string normalizedContext = NormalizeTraceContext(context);
+            SplitHierarchyDescriptor(
+                normalizedContext,
+                extractDescriptor: true,
+                out string contextPath,
+                out _
+            );
+            if (
+                !IsMissingHierarchyValue(normalizedContext)
+                && !string.Equals(contextPath, targetPath, StringComparison.Ordinal)
+            )
+            {
+                relationship.Add(
+                    CreateHierarchyDetailRow(
+                        CreateRouteContextLabel(registrationTypeName, plural: false),
+                        normalizedContext,
+                        extractDescriptor: true
+                    )
+                );
+            }
+            relationship.Add(
+                CreateRelationshipActivity(deliveryCount, totalDeliveryCount, activityLabel)
+            );
+            if (secondaryDeliveryCount >= 0)
+            {
+                relationship.Add(
+                    CreateRelationshipActivity(
+                        secondaryDeliveryCount,
+                        secondaryTotalDeliveryCount,
+                        secondaryActivityLabel
+                    )
+                );
+            }
+            return relationship;
+        }
+
+        private static VisualElement CreateRelationshipActivity(
+            int deliveryCount,
+            int totalDeliveryCount,
+            string activityLabel
+        )
+        {
+            VisualElement activity = new();
+            activity.style.flexDirection = FlexDirection.Row;
+            activity.style.flexWrap = Wrap.Wrap;
+            activity.style.marginTop = 5;
+            Label activityCount = new($"{deliveryCount} {activityLabel}");
+            activityCount.AddToClassList(DxMessagingEditorTheme.DetailFrameClassName);
+            activity.Add(activityCount);
+            Label activityShare = new(CreateCallShareText(deliveryCount, totalDeliveryCount));
+            activityShare.AddToClassList(DxMessagingEditorTheme.DetailFrameClassName);
+            activityShare.style.marginLeft = 10;
+            activity.Add(activityShare);
+            return activity;
+        }
+
+        private static bool IsMissingHierarchyValue(string value)
+        {
+            return string.IsNullOrWhiteSpace(value)
+                || string.Equals(value.Trim(), "none", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value.Trim(), "<none>", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static VisualElement CreateRelationshipIdentity(
+            string label,
+            string value,
+            IReadOnlyList<string> metadata = null
+        )
+        {
+            VisualElement identity = new();
+            identity.style.flexGrow = 1;
+            identity.style.flexBasis = 150;
+            identity.style.minWidth = 130;
+            Label identityLabel = new(label);
+            identityLabel.AddToClassList(DxMessagingEditorTheme.CardLabelClassName);
+            identityLabel.style.marginBottom = 2;
+            identity.Add(identityLabel);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                Label identityValue = new(value);
+                identityValue.AddToClassList(DxMessagingEditorTheme.KeyValueValueClassName);
+                identityValue.style.unityFontStyleAndWeight = FontStyle.Bold;
+                identity.Add(identityValue);
+            }
+            if (metadata != null)
+            {
+                for (int index = 0; index < metadata.Count; index++)
+                {
+                    if (string.IsNullOrWhiteSpace(metadata[index]))
+                    {
+                        continue;
+                    }
+                    Label identityMetadata = new(metadata[index]);
+                    identityMetadata.AddToClassList(DxMessagingEditorTheme.DetailFrameClassName);
+                    identityMetadata.style.whiteSpace = WhiteSpace.Normal;
+                    identity.Add(identityMetadata);
+                }
+            }
+            return identity;
+        }
+
         private static VisualElement CreateMessageTypesSection(
             string title,
             IEnumerable<string> messageTypeNames
@@ -7039,16 +7563,33 @@ namespace DxMessaging.Editor.Windows
             row.AddToClassList(DxMessagingEditorTheme.KeyValueClassName);
             row.AddToClassList(DetailsMessageTypeRowClassName);
             row.tooltip = messageTypeName;
+            VisualElement identity = new();
+            identity.style.flexGrow = 1;
+            identity.style.flexShrink = 1;
             Label typeLabel = new(CreateCompactGraphLabel(messageTypeName));
             typeLabel.AddToClassList(DxMessagingEditorTheme.KeyValueValueClassName);
-            typeLabel.style.flexGrow = 1;
             typeLabel.style.whiteSpace = WhiteSpace.Normal;
-            row.Add(typeLabel);
+            identity.Add(typeLabel);
+            IReadOnlyList<string> metadata = CreateMessageTitleMetadata(messageTypeName);
+            for (int index = 0; index < metadata.Count; index++)
+            {
+                Label metadataLabel = new(metadata[index]);
+                metadataLabel.AddToClassList(DxMessagingEditorTheme.DetailFrameClassName);
+                metadataLabel.style.whiteSpace = WhiteSpace.Normal;
+                identity.Add(metadataLabel);
+            }
+            row.Add(identity);
             if (
                 TryResolveMessageSource(messageTypeName, out FlowGraphSourceLocation sourceLocation)
             )
             {
-                row.Add(CreateSourceLinkButton("Open source", sourceLocation));
+                row.Add(
+                    CreateSourceLinkButton(
+                        "Open source",
+                        sourceLocation,
+                        includeLocationInText: false
+                    )
+                );
             }
             return row;
         }
@@ -7088,19 +7629,75 @@ namespace DxMessaging.Editor.Windows
             for (int index = 0; index < values.Count; index++)
             {
                 string value = values[index];
-                VisualElement row = CreateDetailsKeyValue(
-                    index == 0 ? firstLabel : string.Empty,
-                    value
+                VisualElement row = new() { tooltip = value };
+                row.AddToClassList(DxMessagingEditorTheme.KeyValueClassName);
+                row.AddToClassList(DetailsSourceRowClassName);
+                row.style.alignItems = Align.Center;
+                Label keyLabel = new(index == 0 ? firstLabel : string.Empty);
+                keyLabel.AddToClassList(DxMessagingEditorTheme.KeyValueKeyClassName);
+                keyLabel.style.width = 110;
+                keyLabel.style.whiteSpace = WhiteSpace.Normal;
+                row.Add(keyLabel);
+                VisualElement identity = new();
+                identity.style.flexGrow = 1;
+                identity.style.flexShrink = 1;
+                Label symbol = new(CreateCompactCallSiteLabel(value));
+                symbol.AddToClassList(DxMessagingEditorTheme.KeyValueValueClassName);
+                symbol.style.unityFontStyleAndWeight = FontStyle.Bold;
+                symbol.style.whiteSpace = WhiteSpace.Normal;
+                identity.Add(symbol);
+                bool hasLocation = TryParseSourceLocation(
+                    value,
+                    out FlowGraphSourceLocation location
                 );
-                if (
-                    TryParseSourceLocation(value, out FlowGraphSourceLocation location)
-                    && AssetDatabase.LoadMainAssetAtPath(location.AssetPath) != null
-                )
+                Label file = new(
+                    hasLocation
+                        ? $"{Path.GetFileName(location.AssetPath)}:{location.Line}"
+                        : "Captured call site"
+                );
+                file.AddToClassList(DxMessagingEditorTheme.DetailFrameClassName);
+                file.style.marginTop = 1;
+                file.style.whiteSpace = WhiteSpace.Normal;
+                file.style.flexShrink = 1;
+                identity.Add(file);
+                row.Add(identity);
+                if (hasLocation && AssetDatabase.LoadMainAssetAtPath(location.AssetPath) != null)
                 {
-                    row.Add(CreateSourceLinkButton("Open call site", location));
+                    row.Add(
+                        CreateSourceLinkButton(
+                            "Open call site",
+                            location,
+                            includeLocationInText: false
+                        )
+                    );
                 }
                 section.Add(row);
             }
+        }
+
+        private static string CreateCompactCallSiteLabel(string value)
+        {
+            string callSite = value ?? string.Empty;
+            int sourceStart = callSite.LastIndexOf(" (at ", StringComparison.Ordinal);
+            if (sourceStart >= 0)
+            {
+                callSite = callSite.Substring(0, sourceStart);
+            }
+            callSite = callSite.Trim().Replace(" ()", "()");
+            int methodSeparator = Math.Max(callSite.LastIndexOf(':'), callSite.LastIndexOf('.'));
+            if (methodSeparator <= 0 || methodSeparator >= callSite.Length - 1)
+            {
+                return string.IsNullOrWhiteSpace(callSite) ? "unknown call site" : callSite;
+            }
+
+            string owner = callSite.Substring(0, methodSeparator);
+            string method = callSite.Substring(methodSeparator + 1);
+            int ownerSeparator = Math.Max(owner.LastIndexOf('.'), owner.LastIndexOf('+'));
+            if (ownerSeparator >= 0 && ownerSeparator < owner.Length - 1)
+            {
+                owner = owner.Substring(ownerSeparator + 1);
+            }
+            return owner + "." + method;
         }
 
         internal static bool TryParseSourceLocation(
@@ -7891,12 +8488,18 @@ namespace DxMessaging.Editor.Windows
                 : new CapturedTypeIdentity(captured.Substring(0, assemblyStart), assemblyName);
         }
 
-        private static Button CreateSourceLinkButton(string label, FlowGraphSourceLocation location)
+        private static Button CreateSourceLinkButton(
+            string label,
+            FlowGraphSourceLocation location,
+            bool includeLocationInText = true
+        )
         {
             Button button = new()
             {
                 name = SourceLinkButtonName,
-                text = $"{label} - {Path.GetFileName(location.AssetPath)}:{location.Line}",
+                text = includeLocationInText
+                    ? $"{label} - {Path.GetFileName(location.AssetPath)}:{location.Line}"
+                    : label,
                 tooltip = $"Open {location.AssetPath}:{location.Line}",
                 userData = location,
             };
@@ -7927,14 +8530,93 @@ namespace DxMessaging.Editor.Windows
             switch (selectedItem.Kind)
             {
                 case FlowGraphSelectionKind.Component:
-                    return "Component: " + selectedItem.Component.HierarchyPath;
+                    return CreateCompactReceiverLabel(selectedItem.Component.HierarchyPath);
                 case FlowGraphSelectionKind.Message:
-                    return "Message: " + selectedItem.Message.MessageTypeName;
+                    return CreateCompactGraphLabel(selectedItem.Message.MessageTypeName);
                 case FlowGraphSelectionKind.Edge:
-                    return $"Route: {CreateCompactGraphLabel(selectedItem.Edge.MessageTypeName)} -> {selectedItem.Edge.TargetComponentPath}";
+                    return $"{CreateCompactGraphLabel(selectedItem.Edge.MessageTypeName)} -> {CreateCompactReceiverLabel(selectedItem.Edge.TargetComponentPath)}";
                 default:
                     return "Selection Details";
             }
+        }
+
+        private static IReadOnlyList<string> CreateDetailsTitleMetadata(
+            FlowGraphSelectedItem selectedItem
+        )
+        {
+            switch (selectedItem.Kind)
+            {
+                case FlowGraphSelectionKind.Component:
+                    return new[] { selectedItem.Component.ComponentTypeName };
+                case FlowGraphSelectionKind.Message:
+                    return CreateMessageTitleMetadata(selectedItem.Message.MessageTypeName);
+                case FlowGraphSelectionKind.Edge:
+                    return CreateMessageTitleMetadata(selectedItem.Edge.MessageTypeName);
+                default:
+                    return Array.Empty<string>();
+            }
+        }
+
+        private static IReadOnlyList<string> CreateMessageTitleMetadata(string messageTypeName)
+        {
+            CapturedTypeIdentity identity = ParseCapturedTypeIdentity(messageTypeName);
+            string owner = CreateCapturedTypeOwner(messageTypeName);
+            List<string> metadata = new();
+            if (!string.IsNullOrWhiteSpace(owner))
+            {
+                metadata.Add(owner);
+            }
+            if (!string.IsNullOrWhiteSpace(identity.AssemblyName))
+            {
+                metadata.Add(identity.AssemblyName + " assembly");
+            }
+            return metadata;
+        }
+
+        private static string CreateCapturedTypeOwner(string messageTypeName)
+        {
+            CapturedTypeIdentity identity = ParseCapturedTypeIdentity(messageTypeName);
+            int typeSeparator = Math.Max(
+                identity.TypeName.LastIndexOf('.'),
+                identity.TypeName.LastIndexOf('+')
+            );
+            return typeSeparator > 0 ? identity.TypeName.Substring(0, typeSeparator) : string.Empty;
+        }
+
+        private static string CreateDetailsTitleTooltip(FlowGraphSelectedItem selectedItem)
+        {
+            switch (selectedItem.Kind)
+            {
+                case FlowGraphSelectionKind.Component:
+                    return $"{selectedItem.Component.HierarchyPath} ({selectedItem.Component.ComponentTypeName})";
+                case FlowGraphSelectionKind.Message:
+                    return selectedItem.Message.MessageTypeName;
+                case FlowGraphSelectionKind.Edge:
+                    return $"{selectedItem.Edge.MessageTypeName} -> {selectedItem.Edge.TargetComponentPath} ({selectedItem.Edge.RegistrationTypeName})";
+                default:
+                    return "Selection details";
+            }
+        }
+
+        private static string CreateRouteKindBadgeText(string routeKindText)
+        {
+            if (
+                string.Equals(
+                    routeKindText,
+                    MessageRegistrationType.GlobalAcceptAll.ToString(),
+                    StringComparison.Ordinal
+                )
+            )
+            {
+                return "GLOBAL OBSERVER";
+            }
+
+            string normalizedKind = DxMessagingEditorPalette.NormalizeRouteKind(routeKindText);
+            return string.IsNullOrWhiteSpace(normalizedKind)
+                ? string.IsNullOrWhiteSpace(routeKindText)
+                    ? "<unknown route kind>"
+                    : routeKindText.Trim()
+                : normalizedKind;
         }
 
         private static string CreateDetailsBody(

--- a/Samples~/Diagnostics Tooling Exerciser/README.md
+++ b/Samples~/Diagnostics Tooling Exerciser/README.md
@@ -59,10 +59,13 @@ After the default play-start burst:
   selection; clicking any part of a connection opens focused route and activity
   details while evidence and diagnostics remain collapsed. Expanded evidence
   uses breadcrumb context trails plus compact source-linked message and call-site
-  rows. Diagnostics split route health from trace coverage; component and
-  message selections show distinct busiest paths as directed relationship
-  records, while route selections omit those redundant aggregates. The full
-  text report remains available through **Copy diagnostics**. The textual
+  rows. Breadcrumbs backed by exact captured Unity-object identities and
+  relationship endpoints select the matching graph item; **Route roster** reveals
+  each exact receiver ID, registration subtype, context, and context ID on demand.
+  Diagnostics split route health from trace coverage; component and message
+  selections show distinct busiest paths as directed relationship records,
+  while route selections omit those redundant aggregates. The full text report
+  remains available through **Copy diagnostics**. The textual
   route and trace reports remain inside the collapsed **Analysis and Raw Data**
   section.
 - The component diagnostics panel shows enabled listener diagnostics and local

--- a/Samples~/Diagnostics Tooling Exerciser/README.md
+++ b/Samples~/Diagnostics Tooling Exerciser/README.md
@@ -58,9 +58,11 @@ After the default play-start burst:
   on the right, and draws all 15 live connections. It starts with no default
   selection; clicking any part of a connection opens focused route and activity
   details while evidence and diagnostics remain collapsed. Expanded evidence
-  uses compact source-linked message and call-site rows, and diagnostics split
-  route health from trace coverage with the full text report available through
-  **Copy diagnostics**. The textual
+  uses breadcrumb context trails plus compact source-linked message and call-site
+  rows. Diagnostics split route health from trace coverage; component and
+  message selections show distinct busiest paths as directed relationship
+  records, while route selections omit those redundant aggregates. The full
+  text report remains available through **Copy diagnostics**. The textual
   route and trace reports remain inside the collapsed **Analysis and Raw Data**
   section.
 - The component diagnostics panel shows enabled listener diagnostics and local

--- a/Samples~/Diagnostics Tooling Exerciser/README.md
+++ b/Samples~/Diagnostics Tooling Exerciser/README.md
@@ -53,11 +53,14 @@ After the default play-start burst:
 - Message Monitor global history includes `ToolingPulse`, `ToolingCommand`, and
   `ToolingSignal` entries with trace IDs like `sample-pulse-001`.
 - Flow Graph shows three receiver components, four message nodes (the three
-  concrete messages plus `IMessage`), 15 routes, and 33 recent trace paths.
+  concrete messages plus `ANY MESSAGE`), 15 routes, and 33 recent trace paths.
   Its primary canvas places the four messages on the left, the three receivers
   on the right, and draws all 15 live connections. It starts with no default
   selection; clicking any part of a connection opens focused route and activity
-  details while evidence and technical reports remain collapsed. The textual
+  details while evidence and diagnostics remain collapsed. Expanded evidence
+  uses compact source-linked message and call-site rows, and diagnostics split
+  route health from trace coverage with the full text report available through
+  **Copy diagnostics**. The textual
   route and trace reports remain inside the collapsed **Analysis and Raw Data**
   section.
 - The component diagnostics panel shows enabled listener diagnostics and local

--- a/Tests/Editor/DxMessagingEditorThemeTests.cs
+++ b/Tests/Editor/DxMessagingEditorThemeTests.cs
@@ -99,6 +99,20 @@ namespace DxMessaging.Tests.Editor
             );
         }
 
+        [TestCase(false)]
+        [TestCase(true)]
+        public void AccentInkMeetsNormalTextContrastInBothSkins(bool lightSkin)
+        {
+            Color background = ReadTokenColor("--dx-accent", lightSkin);
+            Color foreground = ReadTokenColor("--dx-accent-ink", lightSkin);
+
+            Assert.That(
+                ContrastRatio(foreground, background),
+                Is.GreaterThanOrEqualTo(4.5f),
+                "Accent-backed badges and buttons use 10 px text, so their ink must satisfy normal-text contrast."
+            );
+        }
+
         [TestCase(true)]
         [TestCase(false)]
         public void ForSkinPicksTheValueBelongingToTheSkinInUse(bool proSkin)
@@ -341,6 +355,29 @@ namespace DxMessaging.Tests.Editor
             Assert.That(actual.g, Is.EqualTo(expected.g).Within(0.0001f), message);
             Assert.That(actual.b, Is.EqualTo(expected.b).Within(0.0001f), message);
             Assert.That(actual.a, Is.EqualTo(expected.a).Within(0.0001f), message);
+        }
+
+        private static float ContrastRatio(Color first, Color second)
+        {
+            float firstLuminance = RelativeLuminance(first);
+            float secondLuminance = RelativeLuminance(second);
+            float lighter = Mathf.Max(firstLuminance, secondLuminance);
+            float darker = Mathf.Min(firstLuminance, secondLuminance);
+            return (lighter + 0.05f) / (darker + 0.05f);
+        }
+
+        private static float RelativeLuminance(Color color)
+        {
+            return 0.2126f * Linearize(color.r)
+                + 0.7152f * Linearize(color.g)
+                + 0.0722f * Linearize(color.b);
+        }
+
+        private static float Linearize(float channel)
+        {
+            return channel <= 0.04045f
+                ? channel / 12.92f
+                : Mathf.Pow((channel + 0.055f) / 1.055f, 2.4f);
         }
 
         /// <summary>

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -723,10 +723,16 @@ namespace DxMessaging.Tests.Editor
             EditorWindowTestUtility.ShowWindow(window);
             VisualElement root = window.rootVisualElement;
             string selectedRoute = string.Empty;
+            FlowGraphSnapshot stressSnapshot = new(
+                components,
+                messages,
+                edges,
+                Array.Empty<string>()
+            );
 
             DxMessagingFlowGraphWindow.BuildGraphUi(
                 root,
-                new FlowGraphSnapshot(components, messages, edges, Array.Empty<string>()),
+                stressSnapshot,
                 FlowGraphViewState.Default,
                 onSelectionChanged: key => selectedRoute = key
             );
@@ -806,6 +812,63 @@ namespace DxMessaging.Tests.Editor
                 selectedRoute,
                 Is.EqualTo(expectedRoute),
                 "Clicking a non-marker segment in the attached 400-route graph must select the visible route."
+            );
+
+            DxMessagingFlowGraphWindow.RefreshGraphContent(
+                root,
+                stressSnapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateComponentSelectionKey(
+                        components[0]
+                    )
+                )
+            );
+            Foldout detailsOverflow = root.Q<Foldout>(
+                DxMessagingFlowGraphWindow.DetailsOverflowFoldoutName
+            );
+            int initialMessageTypeRows = detailsOverflow
+                .parent.Children()
+                .Count(child =>
+                    child.ClassListContains(
+                        DxMessagingFlowGraphWindow.DetailsMessageTypeRowClassName
+                    )
+                );
+            Assert.That(
+                initialMessageTypeRows,
+                Is.EqualTo(8),
+                "Dense component evidence should expose a bounded first page of message types."
+            );
+            Assert.That(
+                detailsOverflow.text,
+                Is.EqualTo("2 more message types"),
+                "The overflow disclosure should account for every remaining source-linked type."
+            );
+            Assert.That(
+                detailsOverflow.value,
+                Is.False,
+                "Dense evidence should not replace the graph with dozens of type rows on selection."
+            );
+            Assert.That(
+                detailsOverflow
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.DetailsMessageTypeRowClassName
+                    )
+                    .ToList(),
+                Is.Empty,
+                "Collapsed overflow should not create hidden source rows or resolve their source links."
+            );
+
+            detailsOverflow.value = true;
+
+            Assert.That(
+                detailsOverflow
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.DetailsMessageTypeRowClassName
+                    )
+                    .ToList()
+                    .Count,
+                Is.EqualTo(2),
+                "Expanding the disclosure should lazily create every remaining message type row."
             );
         }
 
@@ -956,7 +1019,9 @@ namespace DxMessaging.Tests.Editor
                 new[] { edge },
                 Array.Empty<string>()
             );
-            VisualElement root = new();
+            EditorWindow window = CreateTrackedEditorWindow();
+            EditorWindowTestUtility.ShowWindow(window);
+            VisualElement root = window.rootVisualElement;
 
             FlowGraphViewState viewState = new(
                 selectedItemKey: DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(edge)
@@ -1011,6 +1076,162 @@ namespace DxMessaging.Tests.Editor
                 location.Line,
                 Is.GreaterThan(0),
                 "The message-source action should open the declaring line, not only the file."
+            );
+            Assert.That(
+                evidence.Query<Label>().ToList().Any(label => label.text.Contains("Game.Emit")),
+                Is.True,
+                "A stale call site should remain readable as evidence."
+            );
+            Assert.That(
+                evidence
+                    .Query<Button>(name: DxMessagingFlowGraphWindow.SourceLinkButtonName)
+                    .ToList()
+                    .Any(button =>
+                        button.text.StartsWith("Open call site", StringComparison.Ordinal)
+                    ),
+                Is.False,
+                "A call-site action should not appear when its captured asset no longer resolves."
+            );
+            Foldout diagnostics = root.Q<Foldout>(
+                DxMessagingFlowGraphWindow.DetailsTechnicalFoldoutName
+            );
+            List<string> sectionTitles = diagnostics
+                .Query<VisualElement>(className: DxMessagingFlowGraphWindow.DetailsSectionClassName)
+                .ToList()
+                .Select(section => section.Q<Label>().text)
+                .ToList();
+            Assert.That(
+                sectionTitles,
+                Does.Contain("ROUTE HEALTH"),
+                "Diagnostics should lead with categorized route health."
+            );
+            Assert.That(
+                sectionTitles,
+                Does.Contain("TRACE COVERAGE"),
+                "Trace coverage should remain separate from route health."
+            );
+            Assert.That(
+                root.Query<Label>()
+                    .ToList()
+                    .Any(label =>
+                        label.text.StartsWith("Visible call share:", StringComparison.Ordinal)
+                    ),
+                Is.False,
+                "Raw diagnostics should not render as a multiline wall anywhere in the details pane."
+            );
+            Assert.That(
+                GetCopiedDiagnostics(diagnostics),
+                Does.Contain("Visible call share"),
+                "The copy action should retain the complete report without rendering it."
+            );
+            string originalClipboard = EditorGUIUtility.systemCopyBuffer;
+            try
+            {
+                string expectedDiagnostics = GetCopiedDiagnostics(diagnostics);
+                EditorGUIUtility.systemCopyBuffer = "diagnostics-copy-sentinel";
+                Button copyDiagnostics = diagnostics.Q<Button>(
+                    DxMessagingFlowGraphWindow.DetailsCopyDiagnosticsButtonName
+                );
+                using (ClickEvent click = ClickEvent.GetPooled())
+                {
+                    click.target = copyDiagnostics;
+                    copyDiagnostics.SendEvent(click);
+                }
+                Assert.That(
+                    EditorGUIUtility.systemCopyBuffer,
+                    Is.EqualTo(expectedDiagnostics),
+                    "Clicking the attached copy action should publish the complete diagnostic report."
+                );
+            }
+            finally
+            {
+                EditorGUIUtility.systemCopyBuffer = originalClipboard;
+            }
+        }
+
+        [Test]
+        public void BuildGraphUiStructuresComponentEvidenceAndLinksMessageTypes()
+        {
+            string firstMessageType = typeof(FlowGraphMessage).FullName;
+            string secondMessageType = typeof(EvidenceOnlyFlowGraphMessage).FullName;
+            FlowGraphComponentNode component = new(
+                "component:receiver",
+                "Root/Receiver",
+                "MessagingComponent",
+                activeInHierarchy: true,
+                listenerCount: 1,
+                registrationCount: 2,
+                callCount: 5,
+                localMessageCount: 5
+            );
+            FlowGraphSnapshot snapshot = new(
+                new[] { component },
+                new[]
+                {
+                    new FlowGraphMessageNode(firstMessageType, 1, 3),
+                    new FlowGraphMessageNode(secondMessageType, 1, 2),
+                },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        firstMessageType,
+                        component.Id,
+                        component.HierarchyPath,
+                        "Untargeted",
+                        registrationCount: 1,
+                        callCount: 3
+                    ),
+                    new FlowGraphEdge(
+                        secondMessageType,
+                        component.Id,
+                        component.HierarchyPath,
+                        "Targeted",
+                        registrationCount: 1,
+                        callCount: 2
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            VisualElement root = new();
+            FlowGraphViewState viewState = new(
+                selectedItemKey: DxMessagingFlowGraphWindow.CreateComponentSelectionKey(component)
+            );
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot, viewState);
+            DxMessagingFlowGraphWindow.CompleteMessageSourceIndexesForTests();
+            DxMessagingFlowGraphWindow.BuildGraphUi(root, snapshot, viewState);
+
+            List<VisualElement> messageTypeRows = root.Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.DetailsMessageTypeRowClassName
+                )
+                .ToList();
+            List<Button> sourceLinks = messageTypeRows
+                .SelectMany(row =>
+                    row.Query<Button>(name: DxMessagingFlowGraphWindow.SourceLinkButtonName)
+                        .ToList()
+                )
+                .ToList();
+            Assert.That(
+                messageTypeRows,
+                Has.Count.EqualTo(2),
+                "Each visible message type should receive a separate scannable evidence row."
+            );
+            Assert.That(
+                sourceLinks,
+                Has.Count.EqualTo(2),
+                "Every resolvable component message type should link to its declaration."
+            );
+            Assert.That(
+                messageTypeRows.Select(row => row.Q<Label>().text),
+                Is.EquivalentTo(
+                    new[] { nameof(FlowGraphMessage), nameof(EvidenceOnlyFlowGraphMessage) }
+                ),
+                "The source-linked rows should use compact type labels instead of namespace paragraphs."
+            );
+            Assert.That(
+                messageTypeRows.Select(row => row.tooltip),
+                Is.EquivalentTo(new[] { firstMessageType, secondMessageType }),
+                "Compact rows should retain exact type identity in their tooltips."
             );
         }
 
@@ -1594,6 +1815,8 @@ namespace DxMessaging.Tests.Editor
             DxMessagingFlowGraphWindow.BuildGraphUi(root, initialSnapshot, viewState);
 
             VisualElement graph = root.Q<VisualElement>(DxMessagingFlowGraphWindow.GraphCanvasName);
+            root.Q<Foldout>(DxMessagingFlowGraphWindow.DetailsEvidenceFoldoutName).value = true;
+            root.Q<Foldout>(DxMessagingFlowGraphWindow.DetailsTechnicalFoldoutName).value = true;
             DxMessagingFlowGraphWindow.FlowGraphCanvasState canvasState =
                 (DxMessagingFlowGraphWindow.FlowGraphCanvasState)graph.userData;
             canvasState.Initialized = true;
@@ -1648,7 +1871,17 @@ namespace DxMessaging.Tests.Editor
                 "The same stable route must remain selected after its display label changes."
             );
             Assert.That(
-                root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text,
+                root.Q<Foldout>(DxMessagingFlowGraphWindow.DetailsEvidenceFoldoutName).value,
+                Is.True,
+                "Refresh should preserve an expanded evidence disclosure while source links update."
+            );
+            Assert.That(
+                root.Q<Foldout>(DxMessagingFlowGraphWindow.DetailsTechnicalFoldoutName).value,
+                Is.True,
+                "Refresh should preserve an expanded diagnostics disclosure while source links update."
+            );
+            Assert.That(
+                GetCopiedDiagnostics(root),
                 Does.Contain("Route context: Instance 4242"),
                 "The preserved selection must resolve to the refreshed route details."
             );
@@ -1785,7 +2018,7 @@ namespace DxMessaging.Tests.Editor
             VisualElement marker = root.Q<VisualElement>(
                 className: DxMessagingFlowGraphWindow.GraphConnectionClassName
             );
-            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            string details = GetCopiedDiagnostics(root);
             Assert.That(marker.Query<Label>().ToList(), Is.Empty);
             Assert.That(
                 marker.tooltip,
@@ -1806,6 +2039,11 @@ namespace DxMessaging.Tests.Editor
             );
             Assert.That(
                 root.Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.DetailsSectionClassName
+                    )
+                    .ToList()
+                    .Single(section => section.Q<Label>().text == "ROUTE ACTIVITY")
+                    .Query<VisualElement>(
                         className: DxMessagingFlowGraphWindow.DetailsMetricClassName
                     )
                     .ToList()
@@ -2136,10 +2374,7 @@ namespace DxMessaging.Tests.Editor
             );
             Assert.That(selectedDetails, Does.Contain("TARGETED"));
             Assert.That(selectedDetails, Does.Not.Contain("Message kind: MIXED"));
-            Assert.That(
-                root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text,
-                Does.Contain("Message kind: TARGETED")
-            );
+            Assert.That(GetCopiedDiagnostics(root), Does.Contain("Message kind: TARGETED"));
         }
 
         [Test]
@@ -2209,11 +2444,62 @@ namespace DxMessaging.Tests.Editor
                 .ToList()
                 .Select(label => label.text)
                 .ToArray();
-            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            string details = GetCopiedDiagnostics(root);
             Assert.That(graphLabels, Does.Contain("GLOBAL OBSERVER"));
             Assert.That(graphLabels, Does.Contain("ANY MESSAGE"));
             Assert.That(string.Join("\n", graphLabels), Does.Not.Contain("IMessage"));
             Assert.That(details, Does.Contain("Combat.DamageApplied"));
+            Assert.That(
+                details,
+                Does.Contain("Traced deliveries: 2"),
+                "The complete observer report should derive its traced headline from concrete GlobalAcceptAll paths."
+            );
+            Assert.That(
+                details,
+                Does.Contain("Trace-path deliveries: 2"),
+                "The complete observer report should include concrete GlobalAcceptAll path volume."
+            );
+            VisualElement messageDetails = root.Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.DetailsSectionClassName
+                )
+                .ToList()
+                .Single(section => section.Q<Label>().text == "MESSAGE");
+            Dictionary<string, string> messageMetrics = messageDetails
+                .Query<VisualElement>(className: DxMessagingFlowGraphWindow.DetailsMetricClassName)
+                .ToList()
+                .ToDictionary(
+                    metric => metric.Query<Label>().ToList().First().text,
+                    metric => metric.Query<Label>().ToList().Last().text,
+                    StringComparer.Ordinal
+                );
+            Assert.That(
+                messageMetrics["Traced"],
+                Is.EqualTo("2"),
+                "The observer headline should agree with its concrete traced deliveries."
+            );
+            VisualElement traceCoverage = root.Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.DetailsSectionClassName
+                )
+                .ToList()
+                .Single(section => section.Q<Label>().text == "TRACE COVERAGE");
+            Dictionary<string, string> traceCoverageMetrics = traceCoverage
+                .Query<VisualElement>(className: DxMessagingFlowGraphWindow.DetailsMetricClassName)
+                .ToList()
+                .ToDictionary(
+                    metric => metric.Query<Label>().ToList().First().text,
+                    metric => metric.Query<Label>().ToList().Last().text,
+                    StringComparer.Ordinal
+                );
+            Assert.That(
+                traceCoverageMetrics["Paths"],
+                Is.EqualTo("1"),
+                "Trace coverage should include the concrete path delivered through GlobalAcceptAll."
+            );
+            Assert.That(
+                traceCoverageMetrics["Deliveries"],
+                Is.EqualTo("2"),
+                "Trace coverage should total deliveries from concrete GlobalAcceptAll paths."
+            );
 
             DxMessagingFlowGraphWindow.BuildGraphUi(
                 root,
@@ -2609,11 +2895,11 @@ namespace DxMessaging.Tests.Editor
                 Does.Contain("InventoryChanged -> Root/Alpha")
             );
             Assert.That(
-                details.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text,
+                GetCopiedDiagnostics(details),
                 Does.Contain("Registration type: Untargeted")
             );
             Assert.That(
-                details.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text,
+                GetCopiedDiagnostics(details),
                 Does.Contain("Visible call share: 4/6 (67%)")
             );
 
@@ -2654,12 +2940,9 @@ namespace DxMessaging.Tests.Editor
                 details.Q<Label>(DxMessagingFlowGraphWindow.DetailsTitleLabelName).text,
                 Does.Contain("ScoreChanged")
             );
+            Assert.That(GetCopiedDiagnostics(details), Does.Contain("Listener components: 1"));
             Assert.That(
-                details.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text,
-                Does.Contain("Listener components: 1")
-            );
-            Assert.That(
-                details.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text,
+                GetCopiedDiagnostics(details),
                 Does.Contain("Busiest listener: Root/Beta (2 calls)")
             );
         }
@@ -2723,7 +3006,7 @@ namespace DxMessaging.Tests.Editor
                 .ToList()[0]
                 .Q<Label>(DxMessagingFlowGraphWindow.NodeSummaryLabelName)
                 .text;
-            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            string details = GetCopiedDiagnostics(root);
             string exportText = DxMessagingFlowGraphWindow.CreateExportText(snapshot);
             FlowGraphExportPayload exportPayload = JsonUtility.FromJson<FlowGraphExportPayload>(
                 exportText
@@ -6370,7 +6653,7 @@ namespace DxMessaging.Tests.Editor
                 )
             );
 
-            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            string details = GetCopiedDiagnostics(root);
 
             Assert.That(details, Does.Contain("Visible registrations: 1 | Calls: 4"));
             Assert.That(details, Does.Contain("Listener components: 1"));
@@ -6400,7 +6683,7 @@ namespace DxMessaging.Tests.Editor
                 )
             );
 
-            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            string details = GetCopiedDiagnostics(root);
 
             Assert.That(details, Does.Contain("Recent traced routes: 1/2 | No-call routes: 1"));
             Assert.That(
@@ -6426,7 +6709,7 @@ namespace DxMessaging.Tests.Editor
                 )
             );
 
-            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            string details = GetCopiedDiagnostics(root);
 
             Assert.That(details, Does.Contain("Recent traced routes: 2/3 | No-call routes: 1"));
             Assert.That(
@@ -6453,7 +6736,7 @@ namespace DxMessaging.Tests.Editor
                 )
             );
 
-            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            string details = GetCopiedDiagnostics(root);
 
             Assert.That(details, Does.Contain("Recent traced routes: 1/2 | No-call routes: 1"));
             Assert.That(
@@ -6582,7 +6865,7 @@ namespace DxMessaging.Tests.Editor
                 )
             );
 
-            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            string details = GetCopiedDiagnostics(root);
 
             Assert.That(details, Does.Contain("Recent trace paths: 3"));
             Assert.That(details, Does.Contain("Traced deliveries: 7"));
@@ -6687,7 +6970,7 @@ namespace DxMessaging.Tests.Editor
                 )
             );
 
-            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            string details = GetCopiedDiagnostics(root);
 
             Assert.That(details, Does.Contain("Recent trace paths: 1"));
             Assert.That(
@@ -6793,7 +7076,7 @@ namespace DxMessaging.Tests.Editor
                 )
             );
 
-            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            string details = GetCopiedDiagnostics(root);
 
             Assert.That(
                 details,
@@ -6932,7 +7215,7 @@ namespace DxMessaging.Tests.Editor
                 )
             );
 
-            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            string details = GetCopiedDiagnostics(root);
 
             Assert.That(
                 details,
@@ -7062,7 +7345,7 @@ namespace DxMessaging.Tests.Editor
                 )
             );
 
-            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            string details = GetCopiedDiagnostics(root);
 
             Assert.That(
                 details,
@@ -7109,7 +7392,7 @@ namespace DxMessaging.Tests.Editor
                 )
             );
 
-            string details = root.Q<Label>(DxMessagingFlowGraphWindow.DetailsBodyLabelName).text;
+            string details = GetCopiedDiagnostics(root);
 
             Assert.That(details, Does.Contain("Visible traced share: 0/0 (n/a)"));
             Assert.That(details, Does.Contain("Contexts: 0 | Busiest context: none"));
@@ -9963,6 +10246,24 @@ namespace DxMessaging.Tests.Editor
                 },
                 Array.Empty<string>()
             );
+        }
+
+        private static string GetCopiedDiagnostics(VisualElement root)
+        {
+            Button copyDiagnostics = root.Q<Button>(
+                DxMessagingFlowGraphWindow.DetailsCopyDiagnosticsButtonName
+            );
+            Assert.That(
+                copyDiagnostics,
+                Is.Not.Null,
+                "Selected details should expose the complete report through a copy action."
+            );
+            Assert.That(
+                copyDiagnostics.userData,
+                Is.TypeOf<string>(),
+                "The copy action should retain the exact diagnostic text as its payload."
+            );
+            return (string)copyDiagnostics.userData;
         }
 
         private GameObject CreateTrackedObject(string name)

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -870,6 +870,29 @@ namespace DxMessaging.Tests.Editor
                 Is.EqualTo(2),
                 "Expanding the disclosure should lazily create every remaining message type row."
             );
+
+            DxMessagingFlowGraphWindow.RefreshGraphContent(
+                root,
+                stressSnapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateComponentSelectionKey(
+                        components[0]
+                    )
+                )
+            );
+            detailsOverflow = root.Q<Foldout>(
+                DxMessagingFlowGraphWindow.DetailsOverflowFoldoutName
+            );
+            Assert.That(detailsOverflow.value, Is.True);
+            Assert.That(
+                detailsOverflow
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.DetailsMessageTypeRowClassName
+                    )
+                    .ToList(),
+                Has.Count.EqualTo(2),
+                "Restoring an expanded overflow must explicitly repopulate its lazy rows even while the rebuilt details tree is detached."
+            );
         }
 
         [Test]

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -1317,6 +1317,11 @@ namespace DxMessaging.Tests.Editor
                 "Only hierarchy evidence that resolves to a captured graph component should look interactive."
             );
             Assert.That(
+                selectableContextTrails.Select(trail => trail.tooltip),
+                Is.EquivalentTo(new[] { firstContext, secondContext }),
+                "Selectable breadcrumb controls should retain the exact captured identity instead of replacing it with a generic action tooltip."
+            );
+            Assert.That(
                 hierarchyRows[2]
                     .Q<VisualElement>(className: DxMessagingEditorTheme.DetailLinkClassName),
                 Is.Null,
@@ -1378,6 +1383,13 @@ namespace DxMessaging.Tests.Editor
                 .Q<VisualElement>(DxMessagingFlowGraphWindow.DetailsRelationshipReceiverLinkName);
             Assert.That(messageIdentity, Is.Not.Null);
             Assert.That(receiverIdentity, Is.Not.Null);
+            Assert.That(messageIdentity.tooltip, Is.EqualTo(messageTypeName));
+            Assert.That(
+                receiverIdentity.tooltip,
+                Does.Contain(snapshot.ComponentNodes[0].HierarchyPath)
+                    .And.Contain(snapshot.ComponentNodes[0].Id),
+                "Relationship endpoints should retain their exact path and stable receiver identity in the interactive control's tooltip."
+            );
             Assert.That(
                 messageIdentity.ClassListContains(DxMessagingEditorTheme.DetailActiveClassName),
                 Is.True,

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -1156,6 +1156,7 @@ namespace DxMessaging.Tests.Editor
                 $"{typeof(FlowGraphMessage).FullName} [{typeof(FlowGraphMessage).Assembly.GetName().Name}]";
             string firstContext = "World/Combat/Enemy Drone (GameObject)";
             string secondContext = "World/UI/HUD Console (GameObject)";
+            string secondRouteContext = "World/Targeting/HUD Target (GameObject)";
             string fallbackContext = "Instance 4242";
             string callSite =
                 "DxMessaging.Tests.Editor.DiagnosticsToolingExerciser:EmitOneOfEach () "
@@ -1167,7 +1168,12 @@ namespace DxMessaging.Tests.Editor
                 recentTracedDeliveryCount: 4,
                 messageKindName: "TARGETED",
                 recentEmissionSites: new[] { callSite },
-                recentContexts: new[] { firstContext, secondContext, fallbackContext }
+                recentContexts: new[] { firstContext, secondContext, fallbackContext },
+                recentContextComponentIds: new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    [firstContext] = "component:enemy",
+                    [secondContext] = "component:hud",
+                }
             );
             FlowGraphSnapshot snapshot = new(
                 new[]
@@ -1214,7 +1220,7 @@ namespace DxMessaging.Tests.Editor
                         "Targeted",
                         registrationCount: 1,
                         callCount: 2,
-                        context: secondContext,
+                        context: secondRouteContext,
                         recentTracedDeliveryCount: 1
                     ),
                 },
@@ -1240,14 +1246,20 @@ namespace DxMessaging.Tests.Editor
                 },
                 Array.Empty<string>()
             );
-            VisualElement root = new();
+            EditorWindow window = CreateTrackedEditorWindow();
+            window.position = new Rect(80f, 80f, 520f, 1000f);
+            EditorWindowTestUtility.ShowWindow(window);
+            VisualElement root = window.rootVisualElement;
+            string selectedItemKey = DxMessagingFlowGraphWindow.CreateMessageSelectionKey(message);
+            FlowGraphViewState viewState = new(
+                selectedItemKey: DxMessagingFlowGraphWindow.CreateMessageSelectionKey(message)
+            );
 
             DxMessagingFlowGraphWindow.BuildGraphUi(
                 root,
                 snapshot,
-                new FlowGraphViewState(
-                    selectedItemKey: DxMessagingFlowGraphWindow.CreateMessageSelectionKey(message)
-                )
+                viewState,
+                onSelectionChanged: key => selectedItemKey = key
             );
 
             Foldout evidence = root.Q<Foldout>(
@@ -1293,6 +1305,37 @@ namespace DxMessaging.Tests.Editor
                 Does.Contain("Contexts"),
                 "Message-level evidence should keep a neutral role because captured contexts are not route-filtered."
             );
+            List<VisualElement> selectableContextTrails = hierarchyRows
+                .Select(row =>
+                    row.Q<VisualElement>(className: DxMessagingEditorTheme.DetailLinkClassName)
+                )
+                .Where(trail => trail != null)
+                .ToList();
+            Assert.That(
+                selectableContextTrails,
+                Has.Count.EqualTo(2),
+                "Only hierarchy evidence that resolves to a captured graph component should look interactive."
+            );
+            Assert.That(
+                hierarchyRows[2]
+                    .Q<VisualElement>(className: DxMessagingEditorTheme.DetailLinkClassName),
+                Is.Null,
+                "An unresolved instance fallback must not advertise a dead click target."
+            );
+            using (ClickEvent click = ClickEvent.GetPooled())
+            {
+                click.target = selectableContextTrails[0];
+                selectableContextTrails[0].SendEvent(click);
+            }
+            Assert.That(
+                selectedItemKey,
+                Is.EqualTo(
+                    DxMessagingFlowGraphWindow.CreateComponentSelectionKey(
+                        snapshot.ComponentNodes[0]
+                    )
+                ),
+                "A resolved evidence hierarchy should select its graph component."
+            );
             VisualElement sourceRow = evidence.Q<VisualElement>(
                 className: DxMessagingFlowGraphWindow.DetailsSourceRowClassName
             );
@@ -1328,6 +1371,41 @@ namespace DxMessaging.Tests.Editor
                 relationships.Count,
                 Is.EqualTo(1),
                 "Matching busiest route and trace-path evidence should share one directed relationship."
+            );
+            VisualElement messageIdentity = relationships[0]
+                .Q<VisualElement>(DxMessagingFlowGraphWindow.DetailsRelationshipMessageLinkName);
+            VisualElement receiverIdentity = relationships[0]
+                .Q<VisualElement>(DxMessagingFlowGraphWindow.DetailsRelationshipReceiverLinkName);
+            Assert.That(messageIdentity, Is.Not.Null);
+            Assert.That(receiverIdentity, Is.Not.Null);
+            Assert.That(
+                messageIdentity.ClassListContains(DxMessagingEditorTheme.DetailActiveClassName),
+                Is.True,
+                "The relationship endpoint that owns the open details should read as active."
+            );
+            Assert.That(
+                messageIdentity.ClassListContains(DxMessagingEditorTheme.DetailLinkClassName),
+                Is.False,
+                "The current relationship endpoint should not advertise a no-op link."
+            );
+            Assert.That(messageIdentity.focusable, Is.False);
+            Assert.That(
+                receiverIdentity.ClassListContains(DxMessagingEditorTheme.DetailLinkClassName),
+                Is.True,
+                "The other relationship endpoint should remain selectable."
+            );
+            using (ClickEvent click = ClickEvent.GetPooled())
+            {
+                click.target = receiverIdentity;
+                receiverIdentity.SendEvent(click);
+            }
+            Assert.That(
+                selectedItemKey,
+                Is.EqualTo(
+                    DxMessagingFlowGraphWindow.CreateComponentSelectionKey(
+                        snapshot.ComponentNodes[0]
+                    )
+                )
             );
             Assert.That(
                 relationships
@@ -1383,6 +1461,666 @@ namespace DxMessaging.Tests.Editor
                     .And.Contain(secondContext)
                     .And.Contain(fallbackContext),
                 "Copy diagnostics should retain every exact value hidden by the compact visual treatment."
+            );
+
+            Foldout routeRoster = root.Q<Foldout>(
+                DxMessagingFlowGraphWindow.DetailsRoutesFoldoutName
+            );
+            Assert.That(routeRoster, Is.Not.Null);
+            Assert.That(routeRoster.text, Is.EqualTo("Route roster (2)"));
+            Assert.That(
+                routeRoster.value,
+                Is.False,
+                "The receiver roster should remain on demand instead of adding another text wall."
+            );
+            routeRoster.value = true;
+            List<VisualElement> routeRows = routeRoster
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.DetailsRouteRowClassName
+                )
+                .ToList();
+            Assert.That(routeRows, Has.Count.EqualTo(2));
+            Assert.That(
+                routeRows
+                    .SelectMany(row => row.Query<Label>().ToList())
+                    .Select(label => label.text),
+                Does.Contain("Enemy Drone")
+                    .And.Contain("HUD Console")
+                    .And.Contain("HUD Target")
+                    .And.Contain("Registration")
+                    .And.Contain("Targeted"),
+                "Expanding the route metric should identify each receiver, exact registration, and route context."
+            );
+            Assert.That(routeRows.All(row => row.focusable), Is.True);
+            Assert.That(
+                routeRows.All(row =>
+                    row.ClassListContains(DxMessagingEditorTheme.DetailLinkClassName)
+                ),
+                Is.True,
+                "Route rows should expose the same keyboard and persistent visual affordance as other detail links."
+            );
+            EditorSurfaceCapture.InvokeInheritedPanelMethod(
+                root.panel,
+                "ValidateLayout",
+                Array.Empty<object>()
+            );
+            Color expectedRouteLinkSurface = EditorGUIUtility.isProSkin
+                ? new Color32(44, 44, 44, 255)
+                : new Color32(255, 255, 255, 255);
+            Assert.That(
+                routeRows.All(row =>
+                    ColorsApproximatelyEqual(
+                        row.resolvedStyle.backgroundColor,
+                        expectedRouteLinkSurface
+                    )
+                ),
+                Is.True,
+                "The card cascade must preserve a visible resting-state link surface on every selectable route row."
+            );
+            using (ClickEvent click = ClickEvent.GetPooled())
+            {
+                click.target = routeRows[0];
+                routeRows[0].SendEvent(click);
+            }
+            Assert.That(
+                selectedItemKey,
+                Is.EqualTo(DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(snapshot.Edges[0])),
+                "A route-roster row should select the exact graph route."
+            );
+
+            DxMessagingFlowGraphWindow.RefreshGraphContent(
+                root,
+                snapshot,
+                viewState,
+                onSelectionChanged: key => selectedItemKey = key
+            );
+            Assert.That(
+                root.Q<Foldout>(DxMessagingFlowGraphWindow.DetailsRoutesFoldoutName).value,
+                Is.True,
+                "Refresh should preserve the route roster disclosure."
+            );
+        }
+
+        [Test]
+        public void MessageEvidenceKeepsAmbiguousAndNonSceneHierarchyContextsInert()
+        {
+            const string messageTypeName = "FilteredEvidenceMessage";
+            FlowGraphMessageNode message = new(
+                messageTypeName,
+                registrationCount: 2,
+                callCount: 2,
+                recentContexts: new[]
+                {
+                    "Root/Duplicate (GameObject)",
+                    "Config (CombatConfig)",
+                    "Root/Context Only (GameObject)",
+                },
+                recentContextComponentIds: new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["Root/Context Only (GameObject)"] = "component:context-only",
+                }
+            );
+            FlowGraphSnapshot snapshot = new(
+                new[]
+                {
+                    new FlowGraphComponentNode(
+                        "component:visible-duplicate",
+                        "Root/Duplicate",
+                        "MessagingComponent",
+                        true,
+                        1,
+                        1,
+                        1,
+                        0
+                    ),
+                    new FlowGraphComponentNode(
+                        "component:filtered-duplicate",
+                        "Root/Duplicate",
+                        "MessagingComponent",
+                        true,
+                        0,
+                        0,
+                        0,
+                        0
+                    ),
+                    new FlowGraphComponentNode(
+                        "component:config-name",
+                        "Config",
+                        "MessagingComponent",
+                        true,
+                        1,
+                        1,
+                        1,
+                        0
+                    ),
+                    new FlowGraphComponentNode(
+                        "component:context-only",
+                        "Root/Context Only",
+                        "MessagingComponent",
+                        true,
+                        0,
+                        0,
+                        0,
+                        0
+                    ),
+                },
+                new[] { message },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        messageTypeName,
+                        "component:visible-duplicate",
+                        "Root/Duplicate",
+                        "Targeted",
+                        1,
+                        1
+                    ),
+                    new FlowGraphEdge(
+                        messageTypeName,
+                        "component:config-name",
+                        "Config",
+                        "Targeted",
+                        1,
+                        1
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(
+                    filterText: messageTypeName,
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateMessageSelectionKey(message)
+                ),
+                onSelectionChanged: _ => Assert.Fail("An ambiguous context selected a component.")
+            );
+
+            List<VisualElement> contextTrails = root.Q<Foldout>(
+                    DxMessagingFlowGraphWindow.DetailsEvidenceFoldoutName
+                )
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.DetailsHierarchyTrailClassName
+                )
+                .ToList();
+            Assert.That(contextTrails, Has.Count.EqualTo(3));
+            Assert.That(
+                contextTrails.All(trail =>
+                    !trail.ClassListContains(DxMessagingEditorTheme.DetailLinkClassName)
+                    && !trail.focusable
+                ),
+                Is.True,
+                "A duplicate path, a ScriptableObject-shaped context, and a unique component hidden by the filter must remain plain evidence."
+            );
+
+            Assert.That(
+                DxMessagingFlowGraphWindow.RefreshGraphContent(
+                    root,
+                    snapshot,
+                    new FlowGraphViewState(
+                        filterText: messageTypeName,
+                        selectedItemKey: DxMessagingFlowGraphWindow.CreateMessageSelectionKey(
+                            message
+                        )
+                    ),
+                    onSelectionChanged: _ =>
+                        Assert.Fail("A filtered-out context selected a component.")
+                ),
+                Is.True
+            );
+            Assert.That(
+                root.Q<Foldout>(DxMessagingFlowGraphWindow.DetailsEvidenceFoldoutName)
+                    .Query<VisualElement>(className: DxMessagingEditorTheme.DetailLinkClassName)
+                    .ToList(),
+                Is.Empty,
+                "Refreshing a filtered message selection must not turn off-graph contexts into dead links."
+            );
+        }
+
+        [Test]
+        public void RouteRosterDistinguishesMultipleRoutesToOneReceiver()
+        {
+            const string messageTypeName = "DamageApplied";
+            FlowGraphComponentNode receiver = new(
+                "component:receiver",
+                "Root/Receiver",
+                "MessagingComponent",
+                true,
+                1,
+                3,
+                4,
+                0
+            );
+            FlowGraphMessageNode message = new(messageTypeName, 3, 4);
+            FlowGraphSnapshot snapshot = new(
+                new[] { receiver },
+                new[] { message },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        messageTypeName,
+                        receiver.Id,
+                        receiver.HierarchyPath,
+                        "Targeted",
+                        1,
+                        2,
+                        context: "Root/Receiver (GameObject)",
+                        contextId: 101
+                    ),
+                    new FlowGraphEdge(
+                        messageTypeName,
+                        receiver.Id,
+                        receiver.HierarchyPath,
+                        "Targeted",
+                        1,
+                        1,
+                        context: "Root/Receiver (GameObject)",
+                        contextId: 202
+                    ),
+                    new FlowGraphEdge(
+                        messageTypeName,
+                        receiver.Id,
+                        receiver.HierarchyPath,
+                        "TargetedPostProcessor",
+                        1,
+                        1,
+                        context: "Root/Receiver (GameObject)",
+                        contextId: 303
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            EditorWindow window = CreateTrackedEditorWindow();
+            EditorWindowTestUtility.ShowWindow(window);
+            VisualElement root = window.rootVisualElement;
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateMessageSelectionKey(message)
+                ),
+                onSelectionChanged: _ => { }
+            );
+            Foldout roster = root.Q<Foldout>(DxMessagingFlowGraphWindow.DetailsRoutesFoldoutName);
+            roster.value = true;
+            List<VisualElement> rows = roster
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.DetailsRouteRowClassName
+                )
+                .ToList();
+
+            Assert.That(rows, Has.Count.EqualTo(3));
+            Assert.That(
+                rows.Select(row => row.tooltip),
+                Is.EquivalentTo(
+                    new[]
+                    {
+                        $"{messageTypeName} -> Root/Receiver [component:receiver] (Targeted, Root/Receiver (GameObject), context #101)",
+                        $"{messageTypeName} -> Root/Receiver [component:receiver] (Targeted, Root/Receiver (GameObject), context #202)",
+                        $"{messageTypeName} -> Root/Receiver [component:receiver] (TargetedPostProcessor, Root/Receiver (GameObject), context #303)",
+                    }
+                )
+            );
+            Assert.That(
+                rows.SelectMany(row => row.Query<Label>().ToList()).Select(label => label.text),
+                Does.Contain("Context ID")
+                    .And.Contain("101")
+                    .And.Contain("202")
+                    .And.Contain("303")
+                    .And.Contain("Targeted")
+                    .And.Contain("TargetedPostProcessor")
+            );
+        }
+
+        [Test]
+        public void RouteRosterDistinguishesDuplicateReceiverPaths()
+        {
+            const string messageTypeName = "DuplicateReceiverMessage";
+            FlowGraphComponentNode firstReceiver = new(
+                "component:first",
+                "Root/Duplicate",
+                "MessagingComponent",
+                true,
+                1,
+                1,
+                1,
+                0
+            );
+            FlowGraphComponentNode secondReceiver = new(
+                "component:second",
+                "Root/Duplicate",
+                "MessagingComponent",
+                true,
+                1,
+                1,
+                1,
+                0
+            );
+            FlowGraphMessageNode message = new(messageTypeName, 2, 2);
+            FlowGraphSnapshot snapshot = new(
+                new[] { firstReceiver, secondReceiver },
+                new[] { message },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        messageTypeName,
+                        firstReceiver.Id,
+                        firstReceiver.HierarchyPath,
+                        "Untargeted",
+                        1,
+                        1
+                    ),
+                    new FlowGraphEdge(
+                        messageTypeName,
+                        secondReceiver.Id,
+                        secondReceiver.HierarchyPath,
+                        "Untargeted",
+                        1,
+                        1
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            EditorWindow window = CreateTrackedEditorWindow();
+            EditorWindowTestUtility.ShowWindow(window);
+            VisualElement root = window.rootVisualElement;
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateMessageSelectionKey(message)
+                ),
+                onSelectionChanged: _ => { }
+            );
+            Foldout roster = root.Q<Foldout>(DxMessagingFlowGraphWindow.DetailsRoutesFoldoutName);
+            roster.value = true;
+            List<VisualElement> rows = roster
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.DetailsRouteRowClassName
+                )
+                .ToList();
+
+            Assert.That(rows, Has.Count.EqualTo(2));
+            Assert.That(
+                rows.SelectMany(row => row.Query<Label>().ToList()).Select(label => label.text),
+                Does.Contain("Receiver ID")
+                    .And.Contain(firstReceiver.Id)
+                    .And.Contain(secondReceiver.Id)
+            );
+            Assert.That(
+                rows.Select(row => row.tooltip),
+                Is.EquivalentTo(
+                    new[]
+                    {
+                        $"{messageTypeName} -> Root/Duplicate [component:first] (Untargeted, <none>)",
+                        $"{messageTypeName} -> Root/Duplicate [component:second] (Untargeted, <none>)",
+                    }
+                ),
+                "Receiver IDs must distinguish routes whose path, registration, context, and activity are identical."
+            );
+        }
+
+        [Test]
+        public void RouteRosterBoundsRowsAndPopulatesOverflowOnDemand()
+        {
+            const string messageTypeName = "DenseMessage";
+            FlowGraphMessageNode message = new(messageTypeName, 10, 55);
+            FlowGraphComponentNode[] components = Enumerable
+                .Range(0, 10)
+                .Select(index => new FlowGraphComponentNode(
+                    $"component:{index}",
+                    $"Root/Receiver {index}",
+                    "MessagingComponent",
+                    true,
+                    1,
+                    1,
+                    index + 1,
+                    0
+                ))
+                .ToArray();
+            FlowGraphEdge[] edges = components
+                .Select(
+                    (component, index) =>
+                        new FlowGraphEdge(
+                            messageTypeName,
+                            component.Id,
+                            component.HierarchyPath,
+                            "Untargeted",
+                            1,
+                            index + 1,
+                            contextId: index + 1
+                        )
+                )
+                .ToArray();
+            FlowGraphSnapshot snapshot = new(
+                components,
+                new[] { message },
+                edges,
+                Array.Empty<string>()
+            );
+            EditorWindow window = CreateTrackedEditorWindow();
+            EditorWindowTestUtility.ShowWindow(window);
+            VisualElement root = window.rootVisualElement;
+            FlowGraphViewState viewState = new(
+                selectedItemKey: DxMessagingFlowGraphWindow.CreateMessageSelectionKey(message)
+            );
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                viewState,
+                onSelectionChanged: _ => { }
+            );
+            Foldout roster = root.Q<Foldout>(DxMessagingFlowGraphWindow.DetailsRoutesFoldoutName);
+            roster.value = true;
+            Foldout overflow = roster.Q<Foldout>(
+                DxMessagingFlowGraphWindow.DetailsRoutesOverflowFoldoutName
+            );
+
+            Assert.That(roster.text, Is.EqualTo("Route roster (10)"));
+            Assert.That(
+                roster
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.DetailsRouteRowClassName
+                    )
+                    .ToList(),
+                Has.Count.EqualTo(8)
+            );
+            Assert.That(overflow, Is.Not.Null);
+            Assert.That(overflow.text, Is.EqualTo("2 more routes"));
+            overflow.value = true;
+            Assert.That(
+                roster
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.DetailsRouteRowClassName
+                    )
+                    .ToList(),
+                Has.Count.EqualTo(10)
+            );
+
+            DxMessagingFlowGraphWindow.RefreshGraphContent(
+                root,
+                snapshot,
+                viewState,
+                onSelectionChanged: _ => { }
+            );
+            Assert.That(
+                root.Q<Foldout>(DxMessagingFlowGraphWindow.DetailsRoutesFoldoutName).value,
+                Is.True
+            );
+            Assert.That(
+                root.Q<Foldout>(DxMessagingFlowGraphWindow.DetailsRoutesOverflowFoldoutName).value,
+                Is.True,
+                "Both levels of a dense route roster should survive a details refresh."
+            );
+        }
+
+        [Test]
+        public void MessageWithoutVisibleRoutesShowsNonInteractiveRosterEmptyState()
+        {
+            FlowGraphMessageNode quietMessage = new("QuietMessage", 0, 0);
+            FlowGraphMessageNode routedMessage = new("RoutedMessage", 1, 1);
+            FlowGraphComponentNode receiver = new(
+                "component:receiver",
+                "Root/Receiver",
+                "MessagingComponent",
+                true,
+                1,
+                1,
+                1,
+                0
+            );
+            FlowGraphSnapshot snapshot = new(
+                new[] { receiver },
+                new[] { quietMessage, routedMessage },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        routedMessage.MessageTypeName,
+                        receiver.Id,
+                        receiver.HierarchyPath,
+                        "Untargeted",
+                        1,
+                        1
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateMessageSelectionKey(
+                        quietMessage
+                    )
+                )
+            );
+
+            Assert.That(
+                root.Q<Foldout>(DxMessagingFlowGraphWindow.DetailsRoutesFoldoutName),
+                Is.Null
+            );
+            VisualElement emptyRoster = root.Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.DetailsSectionClassName
+                )
+                .ToList()
+                .Single(section => section.Q<Label>().text == "ROUTE ROSTER");
+            Assert.That(
+                emptyRoster.Query<Label>().ToList().Select(label => label.text),
+                Does.Contain("Routes").And.Contain("none")
+            );
+        }
+
+        [Test]
+        public void DetailKeyboardSelectionRefreshesAndRestoresGraphFocus()
+        {
+            const string messageTypeName = "KeyboardMessage";
+            FlowGraphComponentNode receiver = new(
+                "component:receiver",
+                "Root/Receiver",
+                "MessagingComponent",
+                true,
+                1,
+                1,
+                1,
+                0
+            );
+            FlowGraphMessageNode message = new(messageTypeName, 1, 1);
+            FlowGraphSnapshot snapshot = new(
+                new[] { receiver },
+                new[] { message },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        messageTypeName,
+                        receiver.Id,
+                        receiver.HierarchyPath,
+                        "Targeted",
+                        1,
+                        1,
+                        recentTracedDeliveryCount: 1,
+                        context: "Root/Receiver (GameObject)",
+                        contextId: 101
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            EditorWindow window = CreateTrackedEditorWindow();
+            EditorWindowTestUtility.ShowWindow(window);
+            VisualElement root = window.rootVisualElement;
+            string selectedItemKey = DxMessagingFlowGraphWindow.CreateMessageSelectionKey(message);
+            Action<string> select = null;
+            select = key =>
+            {
+                selectedItemKey = key;
+                DxMessagingFlowGraphWindow.RefreshGraphContent(
+                    root,
+                    snapshot,
+                    new FlowGraphViewState(selectedItemKey: key),
+                    onSelectionChanged: select
+                );
+            };
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(selectedItemKey: selectedItemKey),
+                onSelectionChanged: select
+            );
+            root.Q<Foldout>(DxMessagingFlowGraphWindow.DetailsTechnicalFoldoutName).value = true;
+            VisualElement receiverLink = root.Q<VisualElement>(
+                DxMessagingFlowGraphWindow.DetailsRelationshipReceiverLinkName
+            );
+            receiverLink.Focus();
+            Assert.That(
+                root.panel.focusController.focusedElement,
+                Is.SameAs(receiverLink),
+                "The test must begin with keyboard focus on the detail link."
+            );
+
+            using (
+                KeyDownEvent keyDown = KeyDownEvent.GetPooled(
+                    '\n',
+                    KeyCode.Return,
+                    EventModifiers.None
+                )
+            )
+            {
+                keyDown.target = receiverLink;
+                receiverLink.SendEvent(keyDown);
+            }
+            string receiverSelectionKey = DxMessagingFlowGraphWindow.CreateComponentSelectionKey(
+                receiver
+            );
+            Assert.That(selectedItemKey, Is.EqualTo(receiverSelectionKey));
+            VisualElement focused = root.panel.focusController.focusedElement as VisualElement;
+            Assert.That(focused, Is.Not.Null);
+            Assert.That(focused.userData as string, Is.EqualTo(receiverSelectionKey));
+            Assert.That(
+                focused.ClassListContains(DxMessagingFlowGraphWindow.GraphReceiverNodeClassName),
+                Is.True,
+                "A keyboard detail selection should rebuild the details and move focus to the matching graph node."
+            );
+            VisualElement activeReceiver = root.Q<VisualElement>(
+                DxMessagingFlowGraphWindow.DetailsRelationshipReceiverLinkName
+            );
+            VisualElement selectableMessage = root.Q<VisualElement>(
+                DxMessagingFlowGraphWindow.DetailsRelationshipMessageLinkName
+            );
+            Assert.That(
+                activeReceiver.ClassListContains(DxMessagingEditorTheme.DetailActiveClassName),
+                Is.True
+            );
+            Assert.That(activeReceiver.focusable, Is.False);
+            Assert.That(
+                selectableMessage.ClassListContains(DxMessagingEditorTheme.DetailLinkClassName),
+                Is.True,
+                "After selecting the receiver, endpoint treatments should invert without leaving a no-op link."
             );
         }
 
@@ -2942,6 +3680,21 @@ namespace DxMessaging.Tests.Editor
                     .Select(row => row.tooltip),
                 Does.Not.Contain("<none>"),
                 "A missing trace context should not render as a hierarchy inside a relationship."
+            );
+            Label globalObserverBadge = observerHeader
+                .Query<Label>()
+                .ToList()
+                .FirstOrDefault(label =>
+                    label.text == "GLOBAL OBSERVER"
+                    && label.ClassListContains(DxMessagingEditorTheme.TypeBadgeClassName)
+                );
+            Assert.That(globalObserverBadge, Is.Not.Null);
+            Assert.That(
+                globalObserverBadge.ClassListContains(
+                    DxMessagingEditorTheme.TypeBadgeGlobalObserverClassName
+                ),
+                Is.True,
+                "Global-observer badges should use the brand taxonomy color instead of black text on a transparent background."
             );
 
             DxMessagingFlowGraphWindow.BuildGraphUi(
@@ -9798,7 +10551,7 @@ namespace DxMessaging.Tests.Editor
             messageBus.DiagnosticsMode = true;
             messageBus._emissionBuffer.Clear();
             messageBus._emissionBuffer.Add(
-                new MessageEmissionData(new EvidenceOnlyFlowGraphMessage())
+                new MessageEmissionData(new EvidenceOnlyFlowGraphMessage(), (InstanceId)host)
             );
 
             FlowGraphSnapshot snapshot = DxMessagingFlowGraphWindow.CaptureSnapshot(
@@ -9818,6 +10571,85 @@ namespace DxMessaging.Tests.Editor
             Assert.That(snapshot.MessageNodes[0].RecentLocalMessageCount, Is.EqualTo(0));
             Assert.That(snapshot.MessageNodes[0].MessageKindName, Is.EqualTo("GLOBAL"));
             Assert.That(snapshot.MessageNodes[0].RecentEmissionSites, Is.Not.Empty);
+            Assert.That(
+                snapshot.MessageNodes[0].RecentContexts,
+                Is.EqualTo(new[] { "FlowGraphEvidenceOnlyHost (GameObject)" })
+            );
+            Assert.That(
+                snapshot.MessageNodes[0].RecentContextComponentIds[
+                    "FlowGraphEvidenceOnlyHost (GameObject)"
+                ],
+                Is.EqualTo(snapshot.ComponentNodes[0].Id),
+                "Capture should retain the exact graph component behind a display breadcrumb."
+            );
+        }
+
+        [Test]
+        public void CaptureSnapshotDoesNotInferContextComponentFromDuplicateHierarchyText()
+        {
+            GameObject parent = CreateTrackedObject("FlowGraphDuplicateContextRoot");
+            GameObject receiver = new("Duplicate");
+            receiver.transform.SetParent(parent.transform);
+            MessagingComponent messagingComponent = receiver.AddComponent<MessagingComponent>();
+            GameObject nonGraphContext = new("Duplicate");
+            nonGraphContext.transform.SetParent(parent.transform);
+            MessageBus messageBus = MessageHandler.MessageBus as MessageBus;
+            Assert.That(messageBus, Is.Not.Null);
+
+            messageBus.DiagnosticsMode = true;
+            messageBus._emissionBuffer.Clear();
+            messageBus._emissionBuffer.Add(
+                new MessageEmissionData(
+                    new EvidenceOnlyFlowGraphMessage(),
+                    (InstanceId)nonGraphContext
+                )
+            );
+
+            FlowGraphSnapshot snapshot = DxMessagingFlowGraphWindow.CaptureSnapshot(
+                new[] { messagingComponent }
+            );
+            FlowGraphMessageNode message = snapshot.MessageNodes.Single();
+            string context = "FlowGraphDuplicateContextRoot/Duplicate (GameObject)";
+
+            Assert.That(message.RecentContexts, Is.EqualTo(new[] { context }));
+            Assert.That(
+                message.RecentContextComponentIds,
+                Is.Empty,
+                "A same-path GameObject without a MessagingComponent must not be inferred as the graph receiver."
+            );
+            messageBus._emissionBuffer.Clear();
+        }
+
+        [Test]
+        public void CaptureSnapshotKeepsDestroyedComponentContextAsInertEvidence()
+        {
+            GameObject receiver = CreateTrackedObject("FlowGraphDestroyedComponentReceiver");
+            MessagingComponent messagingComponent = receiver.AddComponent<MessagingComponent>();
+            GameObject transient = CreateTrackedObject("FlowGraphDestroyedComponentContext");
+            InstanceId destroyedContext = transient.transform;
+            int destroyedContextId = destroyedContext.Id;
+            Object.DestroyImmediate(transient);
+            MessageBus messageBus = MessageHandler.MessageBus as MessageBus;
+            Assert.That(messageBus, Is.Not.Null);
+
+            messageBus.DiagnosticsMode = true;
+            messageBus._emissionBuffer.Clear();
+            messageBus._emissionBuffer.Add(
+                new MessageEmissionData(new EvidenceOnlyFlowGraphMessage(), destroyedContext)
+            );
+
+            FlowGraphSnapshot snapshot = null;
+            Assert.DoesNotThrow(() =>
+                snapshot = DxMessagingFlowGraphWindow.CaptureSnapshot(new[] { messagingComponent })
+            );
+            FlowGraphMessageNode message = snapshot.MessageNodes.Single();
+            Assert.That(
+                message.RecentContexts,
+                Is.EqualTo(new[] { "Instance " + destroyedContextId })
+            );
+            Assert.That(message.RecentContextComponentIds, Is.Empty);
+
+            messageBus._emissionBuffer.Clear();
         }
 
         [Test]
@@ -10702,6 +11534,15 @@ namespace DxMessaging.Tests.Editor
                 },
                 Array.Empty<string>()
             );
+        }
+
+        private static bool ColorsApproximatelyEqual(Color actual, Color expected)
+        {
+            const float tolerance = 0.001f;
+            return Mathf.Abs(actual.r - expected.r) <= tolerance
+                && Mathf.Abs(actual.g - expected.g) <= tolerance
+                && Mathf.Abs(actual.b - expected.b) <= tolerance
+                && Mathf.Abs(actual.a - expected.a) <= tolerance;
         }
 
         private static string GetCopiedDiagnostics(VisualElement root)

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -2018,9 +2018,11 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
-        public void DetailKeyboardSelectionRefreshesAndRestoresGraphFocus()
+        public void DetailFocusSurvivesChangingBackgroundRefreshAndSelection()
         {
             const string messageTypeName = "KeyboardMessage";
+            const string existingContext = "Root/Receiver (GameObject)";
+            const string addedContext = "Root/Receiver/Child (GameObject)";
             FlowGraphComponentNode receiver = new(
                 "component:receiver",
                 "Root/Receiver",
@@ -2031,37 +2033,62 @@ namespace DxMessaging.Tests.Editor
                 1,
                 0
             );
-            FlowGraphMessageNode message = new(messageTypeName, 1, 1);
+            FlowGraphMessageNode message = new(
+                messageTypeName,
+                1,
+                1,
+                recentContexts: new[] { existingContext },
+                recentContextComponentIds: new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    [existingContext] = receiver.Id,
+                }
+            );
+            FlowGraphMessageNode refreshedMessage = new(
+                messageTypeName,
+                1,
+                1,
+                recentContexts: new[] { addedContext, existingContext },
+                recentContextComponentIds: new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    [addedContext] = receiver.Id,
+                    [existingContext] = receiver.Id,
+                }
+            );
+            FlowGraphEdge edge = new(
+                messageTypeName,
+                receiver.Id,
+                receiver.HierarchyPath,
+                "Targeted",
+                1,
+                1,
+                recentTracedDeliveryCount: 1,
+                context: existingContext,
+                contextId: 101
+            );
             FlowGraphSnapshot snapshot = new(
                 new[] { receiver },
                 new[] { message },
-                new[]
-                {
-                    new FlowGraphEdge(
-                        messageTypeName,
-                        receiver.Id,
-                        receiver.HierarchyPath,
-                        "Targeted",
-                        1,
-                        1,
-                        recentTracedDeliveryCount: 1,
-                        context: "Root/Receiver (GameObject)",
-                        contextId: 101
-                    ),
-                },
+                new[] { edge },
+                Array.Empty<string>()
+            );
+            FlowGraphSnapshot refreshedSnapshot = new(
+                new[] { receiver },
+                new[] { refreshedMessage },
+                new[] { edge },
                 Array.Empty<string>()
             );
             EditorWindow window = CreateTrackedEditorWindow();
             EditorWindowTestUtility.ShowWindow(window);
             VisualElement root = window.rootVisualElement;
             string selectedItemKey = DxMessagingFlowGraphWindow.CreateMessageSelectionKey(message);
+            FlowGraphSnapshot currentSnapshot = snapshot;
             Action<string> select = null;
             select = key =>
             {
                 selectedItemKey = key;
                 DxMessagingFlowGraphWindow.RefreshGraphContent(
                     root,
-                    snapshot,
+                    currentSnapshot,
                     new FlowGraphViewState(selectedItemKey: key),
                     onSelectionChanged: select
                 );
@@ -2081,6 +2108,42 @@ namespace DxMessaging.Tests.Editor
                 root.panel.focusController.focusedElement,
                 Is.SameAs(receiverLink),
                 "The test must begin with keyboard focus on the detail link."
+            );
+
+            currentSnapshot = refreshedSnapshot;
+            DxMessagingFlowGraphWindow.RefreshGraphContent(
+                root,
+                currentSnapshot,
+                new FlowGraphViewState(selectedItemKey: selectedItemKey),
+                onSelectionChanged: select
+            );
+            receiverLink = root.Q<VisualElement>(
+                DxMessagingFlowGraphWindow.DetailsRelationshipReceiverLinkName
+            );
+            Assert.That(
+                selectedItemKey,
+                Is.EqualTo(DxMessagingFlowGraphWindow.CreateMessageSelectionKey(message)),
+                "A background refresh must not change the selected item."
+            );
+            Assert.That(
+                root.panel.focusController.focusedElement,
+                Is.SameAs(receiverLink),
+                "A background refresh should preserve focus on the recreated detail link instead of moving it to an unselected graph node."
+            );
+            Assert.That(
+                receiverLink.ClassListContains(DxMessagingEditorTheme.DetailLinkClassName),
+                Is.True
+            );
+            Assert.That(
+                root.Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.DetailsHierarchyTrailClassName
+                    )
+                    .ToList()
+                    .Count(trail =>
+                        trail.ClassListContains(DxMessagingEditorTheme.DetailLinkClassName)
+                    ),
+                Is.EqualTo(2),
+                "The changing snapshot must contain two earlier context links targeting the same receiver so focus restoration cannot rely on a same-key ordinal."
             );
 
             using (

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -1150,6 +1150,243 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
+        public void BuildGraphUiStructuresMessageEvidenceAsCompactHierarchyAndRelationships()
+        {
+            string messageTypeName =
+                $"{typeof(FlowGraphMessage).FullName} [{typeof(FlowGraphMessage).Assembly.GetName().Name}]";
+            string firstContext = "World/Combat/Enemy Drone (GameObject)";
+            string secondContext = "World/UI/HUD Console (GameObject)";
+            string fallbackContext = "Instance 4242";
+            string callSite =
+                "DxMessaging.Tests.Editor.DiagnosticsToolingExerciser:EmitOneOfEach () "
+                + "(at Packages/com.wallstop-studios.dxmessaging/Tests/Editor/DxMessagingFlowGraphWindowTests.cs:1)";
+            FlowGraphMessageNode message = new(
+                messageTypeName,
+                registrationCount: 2,
+                callCount: 5,
+                recentTracedDeliveryCount: 4,
+                messageKindName: "TARGETED",
+                recentEmissionSites: new[] { callSite },
+                recentContexts: new[] { firstContext, secondContext, fallbackContext }
+            );
+            FlowGraphSnapshot snapshot = new(
+                new[]
+                {
+                    new FlowGraphComponentNode(
+                        "component:enemy",
+                        "World/Combat/Enemy Drone",
+                        "MessagingComponent",
+                        activeInHierarchy: true,
+                        listenerCount: 1,
+                        registrationCount: 1,
+                        callCount: 3,
+                        localMessageCount: 0
+                    ),
+                    new FlowGraphComponentNode(
+                        "component:hud",
+                        "World/UI/HUD Console",
+                        "MessagingComponent",
+                        activeInHierarchy: true,
+                        listenerCount: 1,
+                        registrationCount: 1,
+                        callCount: 2,
+                        localMessageCount: 0
+                    ),
+                },
+                new[] { message },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        messageTypeName,
+                        "component:enemy",
+                        "World/Combat/Enemy Drone",
+                        "Targeted",
+                        registrationCount: 1,
+                        callCount: 3,
+                        context: firstContext,
+                        recentTracedDeliveryCount: 3,
+                        contextId: 4242
+                    ),
+                    new FlowGraphEdge(
+                        messageTypeName,
+                        "component:hud",
+                        "World/UI/HUD Console",
+                        "Targeted",
+                        registrationCount: 1,
+                        callCount: 2,
+                        context: secondContext,
+                        recentTracedDeliveryCount: 1
+                    ),
+                },
+                new[]
+                {
+                    new FlowGraphTracePath(
+                        messageTypeName,
+                        firstContext,
+                        "component:enemy",
+                        "World/Combat/Enemy Drone",
+                        "Targeted",
+                        recentTracedDeliveryCount: 2,
+                        contextId: 4242
+                    ),
+                    new FlowGraphTracePath(
+                        messageTypeName,
+                        secondContext,
+                        "component:hud",
+                        "World/UI/HUD Console",
+                        "Targeted",
+                        recentTracedDeliveryCount: 1
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateMessageSelectionKey(message)
+                )
+            );
+
+            Foldout evidence = root.Q<Foldout>(
+                DxMessagingFlowGraphWindow.DetailsEvidenceFoldoutName
+            );
+            List<VisualElement> hierarchyRows = evidence
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.DetailsHierarchyRowClassName
+                )
+                .ToList();
+            Assert.That(
+                hierarchyRows.Count,
+                Is.EqualTo(3),
+                "Each captured context should render as one hierarchy trail instead of one comma-joined value."
+            );
+            Assert.That(
+                hierarchyRows.Select(row => row.tooltip),
+                Is.EquivalentTo(new[] { firstContext, secondContext, fallbackContext }),
+                "Compact hierarchy trails should retain each exact captured context in their tooltips."
+            );
+            Assert.That(
+                hierarchyRows[0].Query<Label>().ToList().Select(label => label.text),
+                Does.Contain("World").And.Contain("Combat").And.Contain("Enemy Drone"),
+                "The trail should expose hierarchy levels as separate scannable labels."
+            );
+            Assert.That(
+                hierarchyRows[2].Query<Label>().ToList().Select(label => label.text),
+                Does.Contain(fallbackContext),
+                "Instance-id fallbacks should remain readable when no slash hierarchy was captured."
+            );
+            Assert.That(
+                hierarchyRows[0]
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.DetailsHierarchySegmentClassName
+                    )
+                    .ToList()
+                    .All(segment => segment.style.flexShrink.value > 0f),
+                Is.True,
+                "Breadcrumb groups should shrink at narrow widths without orphaning their separators."
+            );
+            Assert.That(
+                evidence.Query<Label>().ToList().Select(label => label.text),
+                Does.Contain("Contexts"),
+                "Message-level evidence should keep a neutral role because captured contexts are not route-filtered."
+            );
+            VisualElement sourceRow = evidence.Q<VisualElement>(
+                className: DxMessagingFlowGraphWindow.DetailsSourceRowClassName
+            );
+            Assert.That(
+                sourceRow,
+                Is.Not.Null,
+                "Captured provenance should render as one source record with its action and file identity."
+            );
+            Assert.That(
+                sourceRow.Query<Label>().ToList().Select(label => label.text),
+                Does.Contain("DiagnosticsToolingExerciser.EmitOneOfEach()")
+                    .And.Contain("DxMessagingFlowGraphWindowTests.cs:1"),
+                "Source records should separate a compact symbol from its file and line."
+            );
+            Assert.That(
+                sourceRow.Q<Button>(name: DxMessagingFlowGraphWindow.SourceLinkButtonName),
+                Is.Not.Null,
+                "A resolvable source record should keep its source action beside the compact identity."
+            );
+            Assert.That(
+                evidence.Query<Label>().ToList().Select(label => label.text),
+                Does.Not.Contain(messageTypeName).And.Not.Contain(callSite),
+                "Evidence should keep exact identities in tooltips and copy text instead of rendering raw strings."
+            );
+            List<VisualElement> relationships = root.Q<Foldout>(
+                    DxMessagingFlowGraphWindow.DetailsTechnicalFoldoutName
+                )
+                .Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.DetailsRelationshipClassName
+                )
+                .ToList();
+            Assert.That(
+                relationships.Count,
+                Is.EqualTo(1),
+                "Matching busiest route and trace-path evidence should share one directed relationship."
+            );
+            Assert.That(
+                relationships
+                    .SelectMany(row => row.Query<Label>().ToList())
+                    .Select(label => label.text),
+                Does.Contain("BUSIEST ROUTE + TRACE PATH")
+                    .And.Contain("3 route traces")
+                    .And.Contain("2 path deliveries"),
+                "A merged relationship should preserve both independently counted activities."
+            );
+            Assert.That(
+                relationships
+                    .SelectMany(row => row.Query<Label>().ToList())
+                    .Select(label => label.text),
+                Does.Contain("FlowGraphMessage")
+                    .And.Contain("Enemy Drone")
+                    .And.Not.Contain(messageTypeName),
+                "Relationship cards should use compact identities and hierarchy leaves rather than report sentences."
+            );
+            foreach (VisualElement relationship in relationships)
+            {
+                AssertCompleteBorder(relationship, DxMessagingEditorPalette.Targeted);
+                Assert.That(
+                    relationship
+                        .Query<VisualElement>(
+                            className: DxMessagingFlowGraphWindow.DetailsHierarchyRowClassName
+                        )
+                        .ToList(),
+                    Is.Empty,
+                    "A production-shaped context should not duplicate its matching receiver hierarchy."
+                );
+            }
+            VisualElement details = root.Q<VisualElement>(
+                DxMessagingFlowGraphWindow.DetailsPaneName
+            );
+            IEnumerable<string> renderedLabels = details
+                .Query<Label>()
+                .ToList()
+                .Select(label => label.text ?? string.Empty);
+            Assert.That(
+                renderedLabels.Any(text =>
+                    text.Contains(" [") || text.Contains("(at ") || text.Contains(" |")
+                ),
+                Is.False,
+                "The selected details surface should not regress to raw captured identities or report prose."
+            );
+            string copiedDiagnostics = GetCopiedDiagnostics(root);
+            Assert.That(
+                copiedDiagnostics,
+                Does.Contain(messageTypeName)
+                    .And.Contain(callSite)
+                    .And.Contain(firstContext)
+                    .And.Contain(secondContext)
+                    .And.Contain(fallbackContext),
+                "Copy diagnostics should retain every exact value hidden by the compact visual treatment."
+            );
+        }
+
+        [Test]
         public void BuildGraphUiStructuresComponentEvidenceAndLinksMessageTypes()
         {
             string firstMessageType = typeof(FlowGraphMessage).FullName;
@@ -1232,6 +1469,178 @@ namespace DxMessaging.Tests.Editor
                 messageTypeRows.Select(row => row.tooltip),
                 Is.EquivalentTo(new[] { firstMessageType, secondMessageType }),
                 "Compact rows should retain exact type identity in their tooltips."
+            );
+        }
+
+        [Test]
+        public void BuildGraphUiQualifiesCompactMessageTypesThatShareAnIdentity()
+        {
+            const string firstMessageType = "Alpha.Events.Damage [Assembly.One]";
+            const string secondMessageType = "Alpha.Events.Damage [Assembly.Two]";
+            const string thirdMessageType = "Beta.Events.Damage [Assembly.One]";
+            FlowGraphComponentNode component = new(
+                "component:receiver",
+                "Root/Receiver",
+                "MessagingComponent",
+                activeInHierarchy: true,
+                listenerCount: 1,
+                registrationCount: 3,
+                callCount: 3,
+                localMessageCount: 0
+            );
+            FlowGraphSnapshot snapshot = new(
+                new[] { component },
+                new[]
+                {
+                    new FlowGraphMessageNode(firstMessageType, 1, 1),
+                    new FlowGraphMessageNode(secondMessageType, 1, 1),
+                    new FlowGraphMessageNode(thirdMessageType, 1, 1),
+                },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        firstMessageType,
+                        component.Id,
+                        component.HierarchyPath,
+                        "Untargeted",
+                        registrationCount: 1,
+                        callCount: 1
+                    ),
+                    new FlowGraphEdge(
+                        secondMessageType,
+                        component.Id,
+                        component.HierarchyPath,
+                        "Untargeted",
+                        registrationCount: 1,
+                        callCount: 1
+                    ),
+                    new FlowGraphEdge(
+                        thirdMessageType,
+                        component.Id,
+                        component.HierarchyPath,
+                        "Untargeted",
+                        registrationCount: 1,
+                        callCount: 1
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateComponentSelectionKey(
+                        component
+                    )
+                )
+            );
+
+            Dictionary<string, string[]> labelsByIdentity = root.Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.DetailsMessageTypeRowClassName
+                )
+                .ToList()
+                .ToDictionary(
+                    row => row.tooltip,
+                    row => row.Query<Label>().ToList().Select(label => label.text).ToArray(),
+                    StringComparer.Ordinal
+                );
+            Assert.That(
+                labelsByIdentity.Keys,
+                Is.EquivalentTo(new[] { firstMessageType, secondMessageType, thirdMessageType })
+            );
+            Assert.That(
+                labelsByIdentity[firstMessageType],
+                Does.Contain("Damage")
+                    .And.Contain("Alpha.Events")
+                    .And.Contain("Assembly.One assembly")
+            );
+            Assert.That(
+                labelsByIdentity[secondMessageType],
+                Does.Contain("Damage")
+                    .And.Contain("Alpha.Events")
+                    .And.Contain("Assembly.Two assembly")
+            );
+            Assert.That(
+                labelsByIdentity[thirdMessageType],
+                Does.Contain("Damage")
+                    .And.Contain("Beta.Events")
+                    .And.Contain("Assembly.One assembly")
+            );
+        }
+
+        [Test]
+        public void BuildGraphUiKeepsDistinctContextRelationshipsSeparate()
+        {
+            const string messageTypeName = "Combat.Damage";
+            const string context = "World/Combat/Enemy Drone (GameObject)";
+            FlowGraphComponentNode component = new(
+                "component:receiver",
+                "World/Combat/Enemy Drone",
+                "MessagingComponent",
+                activeInHierarchy: true,
+                listenerCount: 1,
+                registrationCount: 1,
+                callCount: 1,
+                localMessageCount: 0
+            );
+            FlowGraphMessageNode message = new(messageTypeName, 1, 1);
+            FlowGraphSnapshot snapshot = new(
+                new[] { component },
+                new[] { message },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        messageTypeName,
+                        component.Id,
+                        component.HierarchyPath,
+                        "Targeted",
+                        registrationCount: 1,
+                        callCount: 1,
+                        recentTracedDeliveryCount: 4,
+                        context: context,
+                        contextId: 101
+                    ),
+                },
+                new[]
+                {
+                    new FlowGraphTracePath(
+                        messageTypeName,
+                        context,
+                        component.Id,
+                        component.HierarchyPath,
+                        "Targeted",
+                        recentTracedDeliveryCount: 4,
+                        contextId: 202
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            VisualElement root = new();
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                snapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateMessageSelectionKey(message)
+                )
+            );
+
+            List<VisualElement> relationships = root.Query<VisualElement>(
+                    className: DxMessagingFlowGraphWindow.DetailsRelationshipClassName
+                )
+                .ToList();
+            Assert.That(
+                relationships,
+                Has.Count.EqualTo(2),
+                "Matching hierarchy text must not merge relationships captured from distinct Unity contexts."
+            );
+            Assert.That(
+                relationships
+                    .SelectMany(relationship => relationship.Query<Label>().ToList())
+                    .Select(label => label.text),
+                Does.Contain("BUSIEST TRACED ROUTE").And.Contain("BUSIEST TRACE PATH")
             );
         }
 
@@ -2410,7 +2819,8 @@ namespace DxMessaging.Tests.Editor
                         "Root/Observer",
                         "GlobalAcceptAll",
                         registrationCount: 1,
-                        callCount: 2
+                        callCount: 2,
+                        recentTracedDeliveryCount: 2
                     ),
                 },
                 new[]
@@ -2500,6 +2910,39 @@ namespace DxMessaging.Tests.Editor
                 Is.EqualTo("2"),
                 "Trace coverage should total deliveries from concrete GlobalAcceptAll paths."
             );
+            VisualElement observerDetails = root.Q<VisualElement>(
+                DxMessagingFlowGraphWindow.DetailsPaneName
+            );
+            VisualElement observerHeader = observerDetails.Q<VisualElement>(
+                className: DxMessagingEditorTheme.DetailHeadClassName
+            );
+            Assert.That(
+                observerHeader
+                    .Query<Label>()
+                    .ToList()
+                    .Count(label =>
+                        label.text == DxMessagingFlowGraphWindow.GlobalObserverMessageName
+                    ),
+                Is.EqualTo(1),
+                "The observer header should not repeat ANY MESSAGE as metadata."
+            );
+            Assert.That(
+                observerDetails
+                    .Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.DetailsRelationshipClassName
+                    )
+                    .ToList()
+                    .SelectMany(relationship =>
+                        relationship
+                            .Query<VisualElement>(
+                                className: DxMessagingFlowGraphWindow.DetailsHierarchyRowClassName
+                            )
+                            .ToList()
+                    )
+                    .Select(row => row.tooltip),
+                Does.Not.Contain("<none>"),
+                "A missing trace context should not render as a hierarchy inside a relationship."
+            );
 
             DxMessagingFlowGraphWindow.BuildGraphUi(
                 root,
@@ -2520,7 +2963,20 @@ namespace DxMessaging.Tests.Editor
                     .Select(label => label.text)
             );
             Assert.That(structuredRouteDetails, Does.Contain("GLOBAL OBSERVER"));
-            Assert.That(structuredRouteDetails, Does.Contain("Combat.DamageApplied"));
+            Assert.That(structuredRouteDetails, Does.Contain("DamageApplied"));
+            Assert.That(
+                root.Query<VisualElement>(
+                        className: DxMessagingFlowGraphWindow.DetailsRelationshipClassName
+                    )
+                    .ToList(),
+                Is.Empty,
+                "An already-selected edge should not repeat itself as aggregate busiest relationships."
+            );
+            Assert.That(
+                GetCopiedDiagnostics(root),
+                Does.Contain("Combat.DamageApplied"),
+                "The compact observer relationship should retain the exact message identity in copied diagnostics."
+            );
             Assert.That(structuredRouteDetails, Does.Contain("2"));
         }
 
@@ -2892,7 +3348,7 @@ namespace DxMessaging.Tests.Editor
             Assert.That(details, Is.Not.Null);
             Assert.That(
                 details.Q<Label>(DxMessagingFlowGraphWindow.DetailsTitleLabelName).text,
-                Does.Contain("InventoryChanged -> Root/Alpha")
+                Does.Contain("InventoryChanged -> Alpha")
             );
             Assert.That(
                 GetCopiedDiagnostics(details),
@@ -8475,7 +8931,7 @@ namespace DxMessaging.Tests.Editor
                 );
                 Assert.That(
                     root.Q<Label>(DxMessagingFlowGraphWindow.DetailsTitleLabelName).text,
-                    Does.Contain("ScoreChanged -> Root/Beta")
+                    Does.Contain("ScoreChanged -> Beta")
                 );
                 Assert.That(
                     root.Q<VisualElement>(DxMessagingFlowGraphWindow.RouteMapName)

--- a/Tests/Editor/EditorSurfaceCapture.cs
+++ b/Tests/Editor/EditorSurfaceCapture.cs
@@ -269,7 +269,7 @@ namespace DxMessaging.Tests.Editor
             return new RectInt(cropX, cropY, cropWidth, cropHeight);
         }
 
-        private static void InvokeInheritedPanelMethod(
+        internal static void InvokeInheritedPanelMethod(
             IPanel panel,
             string methodName,
             object[] arguments

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -147,9 +147,11 @@ message source** when Unity can resolve the captured type to its declaration.
 Component evidence lists each visible message type as a compact row with its
 full identity in a tooltip and an **Open source** action when the declaration is
 available. It shows eight rows before a collapsed remainder so dense receivers
-do not replace the graph with a long list. Captured call sites keep their text
-and source action on the same row; stale asset paths remain readable without a
-dead button.
+do not replace the graph with a long list. Captured object contexts use
+breadcrumb trails such as `World > Combat > Enemy Drone`, with the exact
+captured value in the tooltip. Captured call sites separate a compact
+`Type.Method()` identity from the file and line, and keep the source action on
+the same row; stale asset paths remain readable without a dead button.
 The graph does not invent a sender object because targeted emission APIs carry
 a target, not a sender.
 Global accept-all registrations appear as
@@ -165,8 +167,13 @@ The window opens without selecting a node or route, so the canvas leads without
 a details wall. The selected item inspector sits directly below the canvas only
 after an intentional selection. Route selections show the route path and
 activity metrics first; emission evidence and diagnostics start collapsed.
-Diagnostics split route health from trace coverage. Use **Copy diagnostics** to
-copy the complete newline-oriented report without rendering it in the window.
+Diagnostics split route health from trace coverage. For component and message
+selections, their distinct busiest route and trace path use bordered, directed
+relationship records with compact message and receiver identities instead of
+report sentences. A selected route already shows that relationship above its
+evidence, so its diagnostics omit redundant aggregate relationship records. Use
+**Copy diagnostics** to copy the complete newline-oriented report without
+rendering it in the window.
 Opening evidence or diagnostics remains stable when background source indexing
 refreshes the selected item.
 Expand **Analysis and Raw Data** only when you need the textual route map,

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -144,6 +144,12 @@ registration delivery record when token diagnostics captured them. A call site
 identifies the emitting script, method, file, and line. Use **Open call site**
 to open that exact line. Message and route selections also provide **Open
 message source** when Unity can resolve the captured type to its declaration.
+Component evidence lists each visible message type as a compact row with its
+full identity in a tooltip and an **Open source** action when the declaration is
+available. It shows eight rows before a collapsed remainder so dense receivers
+do not replace the graph with a long list. Captured call sites keep their text
+and source action on the same row; stale asset paths remain readable without a
+dead button.
 The graph does not invent a sender object because targeted emission APIs carry
 a target, not a sender.
 Global accept-all registrations appear as
@@ -158,8 +164,11 @@ of moving extra message types into a text overflow list.
 The window opens without selecting a node or route, so the canvas leads without
 a details wall. The selected item inspector sits directly below the canvas only
 after an intentional selection. Route selections show the route path and
-activity metrics first; emission evidence, trace evidence, and the
-newline-oriented technical report each start collapsed.
+activity metrics first; emission evidence and diagnostics start collapsed.
+Diagnostics split route health from trace coverage. Use **Copy diagnostics** to
+copy the complete newline-oriented report without rendering it in the window.
+Opening evidence or diagnostics remains stable when background source indexing
+refreshes the selected item.
 Expand **Analysis and Raw Data** only when you need the textual route map,
 message and target lanes, trace activity, or topology lists. Inside that
 section, concrete routes sort before `GlobalAcceptAll`; call volume, recent

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -149,14 +149,16 @@ full identity in a tooltip and an **Open source** action when the declaration is
 available. It shows eight rows before a collapsed remainder so dense receivers
 do not replace the graph with a long list. Captured object contexts use
 breadcrumb trails such as `World > Combat > Enemy Drone`, with the exact
-captured value in the tooltip. Captured call sites separate a compact
+captured value in the tooltip. A trail selects its matching graph component
+when the filtered capture resolves exactly one; unresolved instance fallbacks
+remain plain text instead of presenting a dead action. Captured call sites separate a compact
 `Type.Method()` identity from the file and line, and keep the source action on
 the same row; stale asset paths remain readable without a dead button.
 The graph does not invent a sender object because targeted emission APIs carry
 a target, not a sender.
 Global accept-all registrations appear as
-`GLOBAL OBSERVER / ANY MESSAGE`, and their details list the concrete message
-types observed in recent trace evidence. Drag to pan, scroll to zoom, and select
+`GLOBAL OBSERVER / ANY MESSAGE` with the amber observer badge, and their details
+list the concrete message types observed in recent trace evidence. Drag to pan, scroll to zoom, and select
 a node or connection to inspect it. Use **-**, **Fit**, and **+** when a mouse
 wheel is unavailable. Automatic framing can zoom out to 20 percent for a useful
 overview of large graphs; zoom back in or pan before selecting closely spaced
@@ -170,7 +172,16 @@ activity metrics first; emission evidence and diagnostics start collapsed.
 Diagnostics split route health from trace coverage. For component and message
 selections, their distinct busiest route and trace path use bordered, directed
 relationship records with compact message and receiver identities instead of
-report sentences. A selected route already shows that relationship above its
+report sentences. Select either endpoint to move to that message or receiver.
+Captured context breadcrumbs become links only when diagnostics retained the
+exact Unity-object-to-component identity and that component is visible in the
+filtered graph; ambiguous, destroyed, or filtered-out contexts remain text.
+Message details also provide a collapsed **Route roster**; expand it to see each
+receiver and stable receiver ID, exact registration subtype, route context, and
+context ID, then select any exact route. Receiver and context IDs distinguish
+routes whose hierarchy text is otherwise identical.
+The first eight rows appear immediately; larger rosters keep the remainder
+behind a nested disclosure. A selected route already shows that relationship above its
 evidence, so its diagnostics omit redundant aggregate relationship records. Use
 **Copy diagnostics** to copy the complete newline-oriented report without
 rendering it in the window.


### PR DESCRIPTION
## Summary

- replace dense evidence text with compact, source-linked rows and wrapping hierarchy breadcrumb trails
- make retained Unity-object breadcrumbs and relationship endpoints select the exact visible graph identity, with keyboard activation and focus restoration
- add a bounded, lazy Route roster that names the stable receiver ID, registration subtype, context, and context ID so visually identical hierarchy paths remain distinguishable
- present the current endpoint as active, keep other endpoints visibly selectable, and preserve persistent resting, hover, and focus affordances on route cards
- use accessible amber styling for GLOBAL OBSERVER badges in both editor skins
- keep exact type, context, and call-site data in tooltips and Copy diagnostics while separating visible symbols, paths, files, and line numbers
- align the changelog, diagnostics guide, and Diagnostics Tooling Exerciser expectations
- remove obsolete detail helpers identified by review

## Validation

- focused Flow Graph EditMode fixture: 175 passed, 0 failed; repeated warm with the same result, plus a final 175/0 review-cleanup run
- full DxMessaging Editor assembly: 621 passed, 0 failed, 0 skipped
- documentation snippet compilation: 441 passed, 0 failed
- pre-commit, CSharpier, Prettier, Markdownlint, spelling, `npm run validate:all`, and `git diff --check`
- exact-identity regressions cover ambiguous duplicate paths, filtered and destroyed contexts, duplicate receiver paths, route subtypes/context IDs, keyboard selection, focus restoration, and resolved active-skin styling
- two final independent reviews: zero actionable findings

Closes #345

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large editor-only UI refactor in Flow Graph details (~1.5k lines in one window) with new selection/focus restoration paths; no runtime messaging API changes, but regression risk is in graph interaction and snapshot context identity mapping.
> 
> **Overview**
> Reworks the Flow Graph **selection details pane** so evidence and diagnostics are scannable instead of a single text block. Dense lists become **breadcrumb hierarchies**, **source-linked message/call-site rows**, and **eight-row foldouts** for message types; **GLOBAL OBSERVER** badges use accessible amber styling on both editor skins.
> 
> **Message** selections gain a lazy **Route roster** (receiver ID, registration subtype, context, context ID) and clickable **context breadcrumbs** when capture maps a context to a unique component. **Diagnostics summary** splits **route health** and **trace coverage** into metric cards with bordered **relationship** records for busiest paths; the full text report moves to **Copy diagnostics** only.
> 
> Detail links (`dx-detail__link`) drive **graph selection** from breadcrumbs and relationship endpoints, with keyboard support and **focus restoration** after UI refresh (including when evidence foldouts stay open during source-index updates). `FlowGraphMessageNode` now carries `RecentContextComponentIds` from snapshot build for exact context→component linking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db2c45b673e798c9876a1de9d2d9a973e2955d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->