### PR TITLE
Clarify handler contracts and harden workflow safety

### DIFF
--- a/.docs-tests/DocsSnippetCompilationTests.cs
+++ b/.docs-tests/DocsSnippetCompilationTests.cs
@@ -60,6 +60,17 @@ internal sealed class DocsSnippetCompilationTests
                 | System.Text.RegularExpressions.RegexOptions.IgnoreCase
         );
 
+    private static readonly System.Text.RegularExpressions.Regex RegistrationOverrideRegex = new(
+        @"protected\s+override\s+void\s+RegisterMessageHandlers\s*\(\s*\)\s*(?:\{(?<body>.*?)\}|(?<body>=>[^;\r\n]*;))",
+        System.Text.RegularExpressions.RegexOptions.Compiled
+            | System.Text.RegularExpressions.RegexOptions.Singleline
+    );
+
+    private static readonly System.Text.RegularExpressions.Regex RegistrationBaseCallRegex = new(
+        @"(?m)(?:^|=>)\s*base\s*\.\s*RegisterMessageHandlers\s*\(\s*\)\s*;\s*(?://.*)?$",
+        System.Text.RegularExpressions.RegexOptions.Compiled
+    );
+
     [Test]
     public void QuickStartStep1Compiles()
     {
@@ -295,6 +306,30 @@ internal sealed class DocsSnippetCompilationTests
             Is.Empty,
             "Handler, interceptor, callback, processor, and observer examples must use "
                 + "real delegates instead of null/default placeholders:"
+                + System.Environment.NewLine
+                + string.Join(System.Environment.NewLine, violations)
+        );
+    }
+
+    [Test]
+    public void MessageAwareComponentExamplesCallBaseRegistrationHook()
+    {
+        string[] violations = GetBroadcastExampleSources()
+            .SelectMany(source =>
+                RegistrationOverrideRegex
+                    .Matches(source.Text)
+                    .Cast<System.Text.RegularExpressions.Match>()
+                    .Where(match => !RegistrationBaseCallRegex.IsMatch(match.Groups["body"].Value))
+                    .Select(match =>
+                        $"{source.Path}:{source.Text[..match.Index].Count(character => character == '\n') + 1}"
+                    )
+            )
+            .ToArray();
+
+        Assert.That(
+            violations,
+            Is.Empty,
+            "MessageAwareComponent examples must call base.RegisterMessageHandlers():"
                 + System.Environment.NewLine
                 + string.Join(System.Environment.NewLine, violations)
         );

--- a/.github/workflows/asset-store-unsupported-upload-research.yml
+++ b/.github/workflows/asset-store-unsupported-upload-research.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: asset-store-unsupported-upload-research
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -769,7 +769,7 @@ jobs:
         shell: bash
         run: node --test scripts/
 
-      - name: Test Unity license activation retry
+      - name: Test Unity retry policies
         if: ${{ needs.changes.outputs.scripts != 'false' }}
         shell: pwsh
         run: ./scripts/__tests__/test-unity-license-activation-retry.ps1 -VerboseOutput

--- a/.github/workflows/csharpier-autofix.yml
+++ b/.github/workflows/csharpier-autofix.yml
@@ -11,6 +11,7 @@ on:
       - "**/.csharpierignore"
       - ".editorconfig"
       - "**/.editorconfig"
+      - ".github/workflows/csharpier-autofix.yml"
   pull_request_target:
     paths:
       - "**/*.cs"
@@ -21,6 +22,7 @@ on:
       - "**/.csharpierignore"
       - ".editorconfig"
       - "**/.editorconfig"
+      - ".github/workflows/csharpier-autofix.yml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/devcontainer-prebuild.yml
+++ b/.github/workflows/devcontainer-prebuild.yml
@@ -35,6 +35,7 @@ on:
       - master
     paths:
       - ".devcontainer/**"
+      - ".github/workflows/devcontainer-prebuild.yml"
   schedule:
     # Sunday 00:00 UTC — weekly rebuild keeps the image fresh and captures
     # base-image updates / CVE patches.
@@ -44,6 +45,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   prebuild:

--- a/.github/workflows/format-on-demand.yml
+++ b/.github/workflows/format-on-demand.yml
@@ -1,4 +1,5 @@
 name: Opt-in Formatting
+
 on:
   issue_comment:
     types: [created]
@@ -7,9 +8,16 @@ on:
       pr_number:
         description: PR number to format
         required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || inputs.pr_number }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
-  pull-requests: write
+  issues: write
+  pull-requests: read
+
 jobs:
   by_comment:
     name: Run on /format comment
@@ -19,6 +27,7 @@ jobs:
           github.event.issue.pull_request &&
           (contains(github.event.comment.body, '/format') || contains(github.event.comment.body, '/autofix') || contains(github.event.comment.body, '/lint-fix')) }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Resolve PR metadata and authorize request
         id: meta
@@ -35,8 +44,6 @@ jobs:
             const allowed = isMaintainer || isAuthor;
             core.setOutput('allowed', String(allowed));
             core.setOutput('pr', String(prNumber));
-            core.setOutput('base_ref', pr.base.ref);
-            core.setOutput('head_repo', pr.head.repo.full_name);
             core.setOutput('head_ref', pr.head.ref);
             core.setOutput('same_repo', String(pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`));
       - name: Exit if not authorized
@@ -44,21 +51,18 @@ jobs:
         run: |
           echo "Commenter is not authorized to trigger formatting." 1>&2
           exit 1
-      - name: Checkout PR branch (same-repo)
+      - name: Refuse fork pull requests
+        if: ${{ steps.meta.outputs.same_repo != 'true' }}
+        run: |
+          echo "Fork pull requests cannot run repository-write formatting automation." 1>&2
+          exit 1
+      - name: Checkout PR branch
         if: ${{ steps.meta.outputs.same_repo == 'true' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.meta.outputs.head_ref }}
           fetch-depth: 0
           persist-credentials: false
-      - name: Checkout PR fork head
-        if: ${{ steps.meta.outputs.same_repo != 'true' }}
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: ${{ steps.meta.outputs.head_repo }}
-          ref: ${{ steps.meta.outputs.head_ref }}
-          persist-credentials: false
-          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -113,13 +117,13 @@ jobs:
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
-      - name: Configure push credentials (same-repo)
-        if: ${{ steps.meta.outputs.same_repo == 'true' && steps.changes.outputs.has_changes == 'true' }}
+      - name: Configure push credentials
+        if: ${{ steps.changes.outputs.has_changes == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-      - name: Commit changes to PR branch (same-repo)
-        if: ${{ steps.meta.outputs.same_repo == 'true' && steps.changes.outputs.has_changes == 'true' }}
+      - name: Commit changes to PR branch
+        if: ${{ steps.changes.outputs.has_changes == 'true' }}
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           commit_message: "chore(format): apply requested formatting"
@@ -132,65 +136,16 @@ jobs:
             **/*.json
             **/*.asmdef
             **/*.yml
-      - name: Clear push credentials (same-repo)
-        if: ${{ always() && steps.meta.outputs.same_repo == 'true' && steps.changes.outputs.has_changes == 'true' }}
+      - name: Clear push credentials
+        if: ${{ always() && steps.changes.outputs.has_changes == 'true' }}
         run: git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
-      - name: Create bot branch and PR (fork)
-        if: ${{ steps.meta.outputs.same_repo != 'true' && steps.changes.outputs.has_changes == 'true' }}
-        shell: bash
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          BRANCH="bot/format/pr-${{ steps.meta.outputs.pr }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B "$BRANCH"
-          # Stage only supported text files; avoid workflows to prevent permission issues
-          # Use --renormalize to ensure LF line endings in git index per .gitattributes
-          # Renormalize each extension separately to avoid "pathspec did not match" failures
-          # yaml excluded: dotfiles (.pre-commit-config.yaml) match git ls-files but not git add globs
-          for ext in cs md json asmdef yml; do
-            if git ls-files "*.$ext" "**/*.$ext" | grep -q .; then
-              git add --renormalize -- "*.$ext" "**/*.$ext"
-            fi
-          done
-          git commit -m "chore(format): apply requested formatting for PR #${{ steps.meta.outputs.pr }}"
-          auth_header="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 | tr -d '\n')"
-          git remote add upstream "https://github.com/${GH_REPO}.git"
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch upstream
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" push upstream "$BRANCH" --force
-      - name: Open/Update formatting PR (fork)
-        if: ${{ steps.meta.outputs.same_repo != 'true' && steps.changes.outputs.has_changes == 'true' }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            const prNumber = Number(core.getInput('pr')) || Number('${{ steps.meta.outputs.pr }}');
-            const baseRef = '${{ steps.meta.outputs.base_ref }}';
-            const headBranch = `bot/format/pr-${prNumber}`;
-            const {owner, repo} = context.repo;
-            const title = `chore(format): Apply formatting to PR #${prNumber}`;
-            const body = [
-              `This automated PR applies Prettier/markdownlint/CSharpier formatting to the changes from PR #${prNumber}.`,
-              '',
-              `- Source PR (fork): #${prNumber}`,
-              `- Target branch: ${baseRef}`,
-            ].join('\n');
-            const existing = await github.rest.pulls.list({ owner, repo, state: 'open', head: `${owner}:${headBranch}` });
-            if (existing.data.length === 0) {
-              await github.rest.pulls.create({ owner, repo, head: headBranch, base: baseRef, title, body });
-            }
       - name: Comment result on PR
         if: ${{ steps.changes.outputs.has_changes == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prNumber = Number('${{ steps.meta.outputs.pr }}');
-            const sameRepo = '${{ steps.meta.outputs.same_repo }}' === 'true';
-            const body = sameRepo
-              ? 'Applied formatting as requested and pushed commits to this PR branch.'
-              : 'Opened a formatting PR against the base repository with requested fixes.';
+            const body = 'Applied formatting as requested and pushed commits to this PR branch.';
             await github.rest.issues.createComment({ ...context.repo, issue_number: prNumber, body });
       - name: No-op comment (nothing to change)
         if: ${{ steps.changes.outputs.has_changes != 'true' }}
@@ -204,35 +159,33 @@ jobs:
     name: Run via manual dispatch
     if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Resolve PR metadata
         id: meta
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
         with:
           script: |
-            const prNumber = Number(core.getInput('pr_number'));
+            const prNumber = Number(process.env.PR_NUMBER);
             if (!prNumber) core.setFailed('pr_number is required');
             const pr = (await github.rest.pulls.get({ ...context.repo, pull_number: prNumber })).data;
             core.setOutput('pr', String(prNumber));
-            core.setOutput('base_ref', pr.base.ref);
-            core.setOutput('head_repo', pr.head.repo.full_name);
             core.setOutput('head_ref', pr.head.ref);
             core.setOutput('same_repo', String(pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`));
-      - name: Checkout PR branch (same-repo)
+      - name: Refuse fork pull requests
+        if: ${{ steps.meta.outputs.same_repo != 'true' }}
+        run: |
+          echo "Fork pull requests cannot run repository-write formatting automation." 1>&2
+          exit 1
+      - name: Checkout PR branch
         if: ${{ steps.meta.outputs.same_repo == 'true' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.meta.outputs.head_ref }}
           fetch-depth: 0
           persist-credentials: false
-      - name: Checkout PR fork head
-        if: ${{ steps.meta.outputs.same_repo != 'true' }}
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: ${{ steps.meta.outputs.head_repo }}
-          ref: ${{ steps.meta.outputs.head_ref }}
-          persist-credentials: false
-          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -287,13 +240,13 @@ jobs:
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
-      - name: Configure push credentials (same-repo)
-        if: ${{ steps.meta.outputs.same_repo == 'true' && steps.changes.outputs.has_changes == 'true' }}
+      - name: Configure push credentials
+        if: ${{ steps.changes.outputs.has_changes == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-      - name: Commit changes to PR branch (same-repo)
-        if: ${{ steps.meta.outputs.same_repo == 'true' && steps.changes.outputs.has_changes == 'true' }}
+      - name: Commit changes to PR branch
+        if: ${{ steps.changes.outputs.has_changes == 'true' }}
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           commit_message: "chore(format): apply requested formatting"
@@ -306,52 +259,6 @@ jobs:
             **/*.json
             **/*.asmdef
             **/*.yml
-      - name: Clear push credentials (same-repo)
-        if: ${{ always() && steps.meta.outputs.same_repo == 'true' && steps.changes.outputs.has_changes == 'true' }}
+      - name: Clear push credentials
+        if: ${{ always() && steps.changes.outputs.has_changes == 'true' }}
         run: git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
-      - name: Create bot branch and PR (fork)
-        if: ${{ steps.meta.outputs.same_repo != 'true' && steps.changes.outputs.has_changes == 'true' }}
-        shell: bash
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          BRANCH="bot/format/pr-${{ steps.meta.outputs.pr }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B "$BRANCH"
-          # Stage only supported text files; avoid workflows to prevent permission issues
-          # Use --renormalize to ensure LF line endings in git index per .gitattributes
-          # Renormalize each extension separately to avoid "pathspec did not match" failures
-          # yaml excluded: dotfiles (.pre-commit-config.yaml) match git ls-files but not git add globs
-          for ext in cs md json asmdef yml; do
-            if git ls-files "*.$ext" "**/*.$ext" | grep -q .; then
-              git add --renormalize -- "*.$ext" "**/*.$ext"
-            fi
-          done
-          git commit -m "chore(format): apply requested formatting for PR #${{ steps.meta.outputs.pr }}"
-          auth_header="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 | tr -d '\n')"
-          git remote add upstream "https://github.com/${GH_REPO}.git"
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch upstream
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" push upstream "$BRANCH" --force
-      - name: Open/Update formatting PR (fork)
-        if: ${{ steps.meta.outputs.same_repo != 'true' && steps.changes.outputs.has_changes == 'true' }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            const prNumber = Number('${{ steps.meta.outputs.pr }}');
-            const baseRef = '${{ steps.meta.outputs.base_ref }}';
-            const headBranch = `bot/format/pr-${prNumber}`;
-            const {owner, repo} = context.repo;
-            const title = `chore(format): Apply formatting to PR #${prNumber}`;
-            const body = [
-              `This automated PR applies Prettier/markdownlint/CSharpier formatting to the changes from PR #${prNumber}.`,
-              '',
-              `- Source PR (fork): #${prNumber}`,
-              `- Target branch: ${baseRef}`,
-            ].join('\n');
-            const existing = await github.rest.pulls.list({ owner, repo, state: 'open', head: `${owner}:${headBranch}` });
-            if (existing.data.length === 0) {
-              await github.rest.pulls.create({ owner, repo, head: headBranch, base: baseRef, title, body });
-            }

--- a/.github/workflows/markdown-link-validity.yml
+++ b/.github/workflows/markdown-link-validity.yml
@@ -18,6 +18,10 @@ on:
   schedule:
     - cron: "0 6 * * *"
 
+concurrency:
+  group: markdown-link-validity
+  cancel-in-progress: true
+
 permissions:
   contents: read
   issues: write
@@ -25,6 +29,7 @@ permissions:
 jobs:
   link-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,18 +7,19 @@ on:
       - master
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 concurrency:
   group: release-drafter
   cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   update-release-draft:
     if: github.repository == 'Ambiguous-Interactive/DxMessaging'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -17,12 +17,13 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   validate:
     name: Validate Wiki Content
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       should-deploy: ${{ steps.check.outputs.should-deploy }}
     steps:
@@ -79,6 +80,9 @@ jobs:
     needs: validate
     if: needs.validate.outputs.should-deploy == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
       - name: Checkout main repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.llm/skills/unity-editor-ci/SKILL.md
+++ b/.llm/skills/unity-editor-ci/SKILL.md
@@ -113,7 +113,7 @@ Windows runners. `unity-tests.yml` is one unified matrix of four Unity versions 
   startup, `Reloading assemblies`, `Run tests on platform`, `Test results saved at`.
 - Keep action majors consistent repo-wide across `.github/workflows/` and
   `.github/workflows-disabled/`: `checkout@v7`, `cache/restore@v6`, `cache/save@v6`, `setup-node@v7`,
-  `setup-dotnet@v5`, `setup-python@v6`, `upload-artifact@v7`, `download-artifact@v8`,
+  `setup-dotnet@v6`, `setup-python@v6`, `upload-artifact@v7`, `download-artifact@v8`,
   `github-script@v9`, `create-github-app-token@v3`, `attest-build-provenance@v4`,
   `deploy-pages@v5`, `upload-pages-artifact@v5`. Verify a tag exists upstream
   (`git ls-remote --tags`) before calling a version invalid; bump all instances in one PR.

--- a/docs/advanced/emit-shorthands.md
+++ b/docs/advanced/emit-shorthands.md
@@ -434,6 +434,7 @@ public class UIManager : MessageAwareComponent
 {
     protected override void RegisterMessageHandlers()
     {
+        base.RegisterMessageHandlers();
         _ = Token.RegisterUntargeted<WaveStarted>(OnWaveStarted);
     }
 
@@ -447,6 +448,7 @@ public class AchievementTracker : MessageAwareComponent
 {
     protected override void RegisterMessageHandlers()
     {
+        base.RegisterMessageHandlers();
         // Listen to ALL enemy deaths (no specific source)
         _ = Token.RegisterBroadcastWithoutSource<EnemyDied>(OnAnyEnemyDied);
     }

--- a/docs/advanced/string-messages.md
+++ b/docs/advanced/string-messages.md
@@ -63,7 +63,8 @@ void OnTextToMe(ref StringMessage m)       => Debug.Log($"To me: {m.message}");
 Tips
 
 - Strings are great for glue and debugging; convert hot paths to typed messages for performance and clarity.
-- You can combine with interceptors/post-processors for logging and filtering.
+- Use interceptors to filter or normalize messages before handlers. Use post-processors
+  for logging or metrics after handlers finish.
 
 Related
 

--- a/docs/architecture/design-and-architecture.md
+++ b/docs/architecture/design-and-architecture.md
@@ -132,7 +132,8 @@ Message flow: Interceptors > Handlers > Post-Processors.
 
 - Interceptors may transform or cancel messages before delivery.
 - Handlers execute in priority order; lower number executes first.
-- Post-processors observe outcomes and can emit follow-up messages.
+- Post-processors observe completed dispatch and can emit follow-up messages. The message
+  payload alone does not prove which gameplay changes a handler applied.
 
 ## Why DxMessaging is Fast
 

--- a/docs/concepts/interceptors-and-ordering.md
+++ b/docs/concepts/interceptors-and-ordering.md
@@ -576,7 +576,11 @@ No **Avoid for:**
 
 Post-processors
 
-- Observe after handlers. Great for logging, analytics, or follow-up emission.
+- Observe after handlers. Use them for logging, metrics, replay records, or follow-up emission.
+- Keep gameplay and presentation state changes in handlers. A completed dispatch does not
+  reveal whether a handler applied the payload to health, inventory, UI, or another state.
+- Post-processors cannot cancel delivery. Use an interceptor when a message must be rejected
+  or normalized before handlers run.
 - Per category and scope (per target/source or all):
   - Untargeted: `RegisterUntargetedPostProcessor<T>`
   - Targeted (specific): `RegisterTargetedPostProcessor<T>(target, ...)`

--- a/docs/concepts/listening-patterns.md
+++ b/docs/concepts/listening-patterns.md
@@ -30,10 +30,14 @@ using DxMessaging.Core.Messages;
 _ = token.RegisterBroadcastWithoutSource<TookDamage>(ShowDamageNumber);
 void ShowDamageNumber(InstanceId source, TookDamage m) => damageNumbers.Show(source, m.amount);
 
-// Append replay evidence after every gameplay handler has run.
-_ = token.RegisterBroadcastWithoutSourcePostProcessor<TookDamage>(RecordDamageOutcome);
-void RecordDamageOutcome(InstanceId source, TookDamage m) => replay.RecordDamage(source, m.amount);
+// Record the processed message for replay after every gameplay handler has run.
+_ = token.RegisterBroadcastWithoutSourcePostProcessor<TookDamage>(RecordProcessedDamage);
+void RecordProcessedDamage(InstanceId source, TookDamage m) =>
+    replay.RecordDamage(source, m.amount);
 ```
+
+The handler owns presentation state by spawning a damage number. The post-processor records
+that dispatch completed. It cannot infer the target's final health from the message payload.
 
 ## Global accept-all (debug/inspection)
 

--- a/docs/concepts/targeting-and-context.md
+++ b/docs/concepts/targeting-and-context.md
@@ -301,6 +301,7 @@ public class Player : MessageAwareComponent
 {
     protected override void RegisterMessageHandlers()
     {
+        base.RegisterMessageHandlers();
         // Listen only to damage targeting THIS player
         _ = Token.RegisterGameObjectBroadcast<TookDamage>(gameObject, OnPlayerTookDamage);
     }
@@ -317,6 +318,7 @@ public class CombatLog : MessageAwareComponent
 {
     protected override void RegisterMessageHandlers()
     {
+        base.RegisterMessageHandlers();
         // Listen to ALL damage from ANY source (global observer)
         _ = Token.RegisterBroadcastWithoutSource<TookDamage>(OnAnyDamage);
     }
@@ -332,6 +334,7 @@ public class AchievementSystem : MessageAwareComponent
 {
     protected override void RegisterMessageHandlers()
     {
+        base.RegisterMessageHandlers();
         // Listen to ALL damage targeting ANY entity (global observer)
         _ = Token.RegisterTargetedWithoutTargeting<DealDamage>(OnAnyDamageDealt);
     }

--- a/docs/examples/end-to-end.md
+++ b/docs/examples/end-to-end.md
@@ -137,9 +137,12 @@ their token and need no separate bus handle:
 using HealRules healRules = new(MessageHandler.MessageBus);
 _ = token.RegisterBroadcastWithoutSourcePostProcessor<TookDamage>((InstanceId src, TookDamage m) =>
 {
-    Analytics.Log("Damage", new { src, m.amount });
+    Analytics.Log("DamageMessageProcessed", new { src, m.amount });
 });
 ```
+
+The `UIOverlay` handler above owns the floating damage presentation. This post-processor
+records the completed dispatch for telemetry; it does not claim that a health change occurred.
 
 Settings menu (untargeted)
 

--- a/docs/getting-started/visual-guide.md
+++ b/docs/getting-started/visual-guide.md
@@ -530,6 +530,7 @@ void OnDisable() { GameManager.OnScoreChanged -= Update; }  // Forgot this? LEAK
 
 ```csharp
 protected override void RegisterMessageHandlers() {
+    base.RegisterMessageHandlers();
     _ = Token.RegisterUntargeted<ScoreChanged>(Update);
 }
 // Automatic cleanup when component is destroyed.

--- a/docs/guides/patterns.md
+++ b/docs/guides/patterns.md
@@ -315,6 +315,7 @@ public class EnemyHealthBar : MessageAwareComponent {
     [SerializeField] private GameObject trackedEnemy;
 
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         // Only listens to ONE enemy, not all 100
         _ = Token.RegisterGameObjectBroadcast<EntityDamaged>(trackedEnemy, OnDamaged);
     }
@@ -327,6 +328,7 @@ public class CombatAnalytics : MessageAwareComponent {
     private readonly Dictionary<InstanceId, int> totalDamageByEntity = new();
 
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         // Listens to all 100+ entities with ONE registration
         _ = Token.RegisterBroadcastWithoutSource<EntityDamaged>(OnAnyDamage);
     }
@@ -428,6 +430,7 @@ public readonly partial struct InventoryChanged { public readonly int itemCount;
 // Each UI panel listens independently
 public class HealthPanel : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         _ = Token.RegisterUntargeted<PlayerStatsChanged>(OnStats);
     }
     void OnStats(ref PlayerStatsChanged msg) => UpdateHealth(msg.health);
@@ -435,6 +438,7 @@ public class HealthPanel : MessageAwareComponent {
 
 public class ManaPanel : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         _ = Token.RegisterUntargeted<PlayerStatsChanged>(OnStats);
     }
     void OnStats(ref PlayerStatsChanged msg) => UpdateMana(msg.mana);
@@ -442,6 +446,7 @@ public class ManaPanel : MessageAwareComponent {
 
 public class GoldPanel : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         _ = Token.RegisterUntargeted<PlayerStatsChanged>(OnStats);
     }
     void OnStats(ref PlayerStatsChanged msg) => UpdateGold(msg.gold);
@@ -449,6 +454,7 @@ public class GoldPanel : MessageAwareComponent {
 
 public class InventoryPanel : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         _ = Token.RegisterUntargeted<InventoryChanged>(OnInventory);
     }
     void OnInventory(ref InventoryChanged msg) => Refresh();
@@ -497,6 +503,7 @@ public readonly partial struct GameExit { }
 
 public class SaveSystem : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         // Priority 0 = runs FIRST
         _ = Token.RegisterUntargeted<GameExit>(OnExit, priority: 0);
     }
@@ -508,6 +515,7 @@ public class SaveSystem : MessageAwareComponent {
 
 public class AudioSystem : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         // Priority 5 = runs AFTER SaveSystem
         _ = Token.RegisterUntargeted<GameExit>(OnExit, priority: 5);
     }
@@ -519,6 +527,7 @@ public class AudioSystem : MessageAwareComponent {
 
 public class UISystem : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         // Priority 10 = runs LAST
         _ = Token.RegisterUntargeted<GameExit>(OnExit, priority: 10);
     }
@@ -551,6 +560,7 @@ msg.Emit();
 // Single interceptor validates ALL damage
 public class DamageValidator : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         // Interceptors run BEFORE handlers
         _ = Token.RegisterBroadcastInterceptor<EntityDamaged>(ValidateDamage, priority: -100);
     }
@@ -568,6 +578,7 @@ public class DamageValidator : MessageAwareComponent {
 // Handlers can trust data is valid (no duplicate checks needed)
 public class CombatEntity : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         _ = Token.RegisterComponentBroadcast<EntityDamaged>(this, OnDamaged);
     }
 
@@ -587,14 +598,14 @@ public class CombatEntity : MessageAwareComponent {
 ```csharp
 public class GameAnalytics : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
-        // Post-processors run AFTER all handlers
+        base.RegisterMessageHandlers();
+        // Record completed dispatch after gameplay handlers have run.
         _ = Token.RegisterBroadcastWithoutSourcePostProcessor<EntityDamaged>(LogDamage, priority: 100);
         _ = Token.RegisterUntargetedPostProcessor<LevelCompleted>(LogLevelComplete, priority: 100);
     }
 
     void LogDamage(InstanceId source, EntityDamaged msg) {
-        // Analytics code is completely isolated from gameplay
-        SendAnalyticsEvent("damage_dealt", new {
+        SendAnalyticsEvent("damage_message_processed", new {
             source = source.ToString(),
             amount = msg.amount,
             type = msg.damageType
@@ -607,7 +618,9 @@ public class GameAnalytics : MessageAwareComponent {
 }
 ```
 
-**Key insight:** Post-processors let you add analytics, logging, and telemetry WITHOUT touching existing handlers. Add/remove analytics system without modifying game logic.
+**Key insight:** Handlers own gameplay and presentation state. Post-processors let you add
+analytics, logging, and telemetry without modifying those handlers. A post-processor sees the
+processed message, not proof that a handler changed health or any other state.
 
 ### Performance Optimization Patterns at Scale
 
@@ -715,6 +728,7 @@ public class SelfHealthUI : MessageAwareComponent {
     [SerializeField] private GameObject localPlayerObject;
 
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         _ = Token.RegisterGameObjectBroadcast<PlayerDamaged>(localPlayerObject, OnDamage);
     }
 
@@ -726,6 +740,7 @@ public class TeamHealthUI : MessageAwareComponent {
     [SerializeField] private List<GameObject> teammateObjects;
 
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         foreach (var teammate in teammateObjects) {
             _ = Token.RegisterGameObjectBroadcast<PlayerDamaged>(teammate, OnTeammateDamage);
         }
@@ -737,6 +752,7 @@ public class TeamHealthUI : MessageAwareComponent {
 // KILL FEED (global observation)
 public class KillFeedUI : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         _ = Token.RegisterBroadcastWithoutSource<PlayerKilled>(OnAnyKill);
     }
 
@@ -747,14 +763,16 @@ public class KillFeedUI : MessageAwareComponent {
 
 // MATCH STATS (analytics)
 public class MatchStats : MessageAwareComponent {
-    private Dictionary<int, int> damageByPlayer = new();
+    private readonly Dictionary<int, int> processedDamageMessagesByPlayer = new();
 
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         _ = Token.RegisterBroadcastWithoutSourcePostProcessor<PlayerDamaged>(TrackDamage);
     }
 
     void TrackDamage(InstanceId source, PlayerDamaged msg) {
-        // Track for post-game stats
+        processedDamageMessagesByPlayer.TryGetValue(msg.playerId, out int count);
+        processedDamageMessagesByPlayer[msg.playerId] = count + 1;
     }
 }
 ```
@@ -764,7 +782,7 @@ public class MatchStats : MessageAwareComponent {
 - Self health UI: 1 registration, receives ~10 messages/sec
 - Team health UI: 4 registrations, receives ~40 messages/sec
 - Kill feed UI: 1 registration, receives ALL kills (~5 messages/sec)
-- Match stats: Post-processor, doesn't affect gameplay latency
+- Match stats: Post-processor records processed payloads without owning gameplay state
 
 **Total:** ~100 players x 10 damage/sec = 1000 messages/sec. DxMessaging handles this with negligible overhead (~0.06ms/frame).
 

--- a/docs/guides/unity-integration.md
+++ b/docs/guides/unity-integration.md
@@ -120,6 +120,7 @@ public sealed class NoStringDemos : MessageAwareComponent
 
     protected override void RegisterMessageHandlers()
     {
+        base.RegisterMessageHandlers();
         // only your registrations
     }
 }

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -356,8 +356,11 @@
   }
 
   .dxm-window .highlight code {
+    display: block;
     font-size: 0.62rem;
     line-height: 1.78;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
   }
 
   .dxm-window .highlight .filename {

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -270,6 +270,7 @@ public class UI : MonoBehaviour {
 public class UI : MessageAwareComponent {
     // No references needed! Just listen for messages.
     protected override void RegisterMessageHandlers() {
+        base.RegisterMessageHandlers();
         _ = Token.RegisterBroadcastWithoutSource<PlayerDamaged>(OnDamage);
     }
 }

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -4,6 +4,7 @@ const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
+const YAML = require("yaml");
 const { walkFiles } = require("../lib/repo-files.js");
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
@@ -99,6 +100,10 @@ function readWorkflow(file = "ci.yml") {
   return fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8");
 }
 
+function readWorkflowDocument(file) {
+  return YAML.parseDocument(readWorkflow(file));
+}
+
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -155,6 +160,94 @@ function extractShellPatternVariable(source, variableName) {
   assert.ok(pieces.length > 0, `ci.yml must build ${variableName}`);
   return pieces.join("");
 }
+
+test("active workflows keep the shared safety contract", () => {
+  const workflowFiles = fs
+    .readdirSync(WORKFLOW_DIR)
+    .filter((file) => /\.ya?ml$/.test(file))
+    .sort();
+
+  for (const file of workflowFiles) {
+    const document = readWorkflowDocument(file);
+    assert.equal(document.errors.length, 0, `${file} must parse as YAML`);
+
+    const keys = document.contents.items.map((item) => String(item.key.value));
+    assert.deepEqual(
+      keys.slice(0, 5),
+      ["name", "on", "concurrency", "permissions", "jobs"],
+      `${file} must use the canonical top-level key order`
+    );
+
+    const workflow = document.toJS();
+    assert.equal(
+      typeof workflow.concurrency["cancel-in-progress"],
+      "boolean",
+      `${file} must choose a concurrency cancellation policy`
+    );
+    assert.equal(typeof workflow.concurrency.group, "string", `${file} must have a group`);
+    assert.notEqual(workflow.concurrency.group.trim(), "", `${file} must have a nonempty group`);
+    assert.equal(
+      typeof workflow.permissions,
+      "object",
+      `${file} must declare top-level permissions`
+    );
+
+    for (const [jobId, job] of Object.entries(workflow.jobs)) {
+      assert.ok(
+        Number.isFinite(job["timeout-minutes"]) && job["timeout-minutes"] > 0,
+        `${file}:${jobId} must have a positive timeout-minutes`
+      );
+
+      for (const step of job.steps || []) {
+        if (typeof step.uses === "string" && step.uses.startsWith("actions/checkout@")) {
+          assert.equal(
+            step.with?.["persist-credentials"],
+            false,
+            `${file}:${jobId}:${step.name || step.uses} must disable persisted credentials`
+          );
+        }
+      }
+    }
+  }
+});
+
+test("opt-in formatting never executes a fork head with repository write permissions", () => {
+  const source = readWorkflow("format-on-demand.yml");
+  const workflow = readWorkflowDocument("format-on-demand.yml").toJS();
+
+  assert.equal(
+    workflow.concurrency.group,
+    "${{ github.workflow }}-${{ github.event.issue.number || inputs.pr_number }}"
+  );
+  assert.equal(workflow.concurrency["cancel-in-progress"], false);
+  assert.deepEqual(workflow.permissions, {
+    contents: "write",
+    issues: "write",
+    "pull-requests": "read"
+  });
+  assert.doesNotMatch(source, /repository:\s*\$\{\{\s*steps\.meta\.outputs\.head_repo/);
+
+  for (const jobId of ["by_comment", "by_dispatch"]) {
+    const job = workflow.jobs[jobId];
+    const refusal = job.steps.find((step) => step.name === "Refuse fork pull requests");
+    const checkouts = job.steps.filter(
+      (step) => typeof step.uses === "string" && step.uses.startsWith("actions/checkout@")
+    );
+    assert.equal(checkouts.length, 1, `${jobId} must have one same-repository checkout`);
+    const checkout = checkouts[0];
+    assert.equal(refusal.if, "${{ steps.meta.outputs.same_repo != 'true' }}", jobId);
+    assert.match(refusal.run, /exit 1/);
+    assert.notEqual(refusal["continue-on-error"], true);
+    assert.equal(checkout.if, "${{ steps.meta.outputs.same_repo == 'true' }}", jobId);
+    assert.equal(checkout.with.repository, undefined, jobId);
+  }
+
+  const dispatchMeta = workflow.jobs.by_dispatch.steps.find(
+    (step) => step.name === "Resolve PR metadata"
+  );
+  assert.equal(dispatchMeta.env.PR_NUMBER, "${{ inputs.pr_number }}");
+  assert.match(dispatchMeta.with.script, /Number\(process\.env\.PR_NUMBER\)/);
+});
 
 test("static CI checks stay consolidated behind CI Success", () => {
   const source = readWorkflow();

--- a/scripts/__tests__/test-unity-license-activation-retry.ps1
+++ b/scripts/__tests__/test-unity-license-activation-retry.ps1
@@ -1,8 +1,7 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Data-driven tests for the Unity serial-activation retry policy in
-    scripts/unity/run-ci-tests.ps1 (build-lock issue #57).
+    Data-driven tests for the Unity retry policies in scripts/unity/run-ci-tests.ps1.
 
 .DESCRIPTION
     The organization build lock's release cooldown is deliberately near-zero, so a
@@ -21,6 +20,10 @@
         (-ActivationInvoker), a fake editor that is deterministic and needs no
         external process, so this runs on ubuntu-latest, macos-latest, and Windows
         alike.
+
+    The same real-function extraction drives the Unity Package Manager cancellation
+    path through a deterministic fake editor. This guards the retry itself,
+    including its CI annotation helpers, without requiring a live UPM fault.
 #>
 [CmdletBinding()]
 param(
@@ -53,7 +56,12 @@ foreach ($name in @(
     'Get-UnityActivationRetryBudgetSeconds',
     'Get-UnityActivationRetryDelaySeconds',
     'Get-UnityActivationFailureClass',
+    'Write-CiWarning',
     'Write-CiNotice',
+    'ConvertTo-SingleLineDiagnostic',
+    'Test-UnityPackageManagerTransientFailure',
+    'Write-UnityPackageManagerTransientFailureWarnings',
+    'Invoke-UnityEditorTestsWithPackageManagerRetry',
     'Invoke-UnityLicenseActivate'
 )) {
     $fn = $ast.FindAll(
@@ -256,12 +264,87 @@ Assert-That "loop: budget 0 throws on the single failing attempt" ($r.Threw)
 $r = Invoke-FakeActivation -Plan @('ok') -BudgetSeconds 0 -Label 'budget-zero-success'
 Assert-That "loop: budget 0 success returns in exactly 1 attempt" (($r.Attempts -eq 1) -and (-not $r.Threw))
 
+# ---------------------------------------------------------------------------
+# 5. Package Manager retry path. A real 2026-08-11 CI failure reached the UPM
+#    cancellation branch but crashed before retry because Write-CiWarning was
+#    missing. Exercise the extracted production function with a deterministic
+#    fake editor so every annotation/helper dependency resolves at runtime.
+# ---------------------------------------------------------------------------
+$script:upmAttempts = 0
+$script:upmCleanupCalls = 0
+$script:upmScenario = 'transient-no-results'
+$upmLog = Join-Path $tmpRoot 'unity.log'
+$upmResults = Join-Path $tmpRoot 'results.xml'
+
+function Invoke-UnityEditor {
+    param(
+        [string]$EditorPath,
+        [string[]]$Arguments,
+        [string]$Label,
+        [string]$LogPath
+    )
+    $script:upmAttempts++
+    if ($script:upmAttempts -eq 1) {
+        if ($script:upmScenario -eq 'non-transient') {
+            Set-Content -LiteralPath $LogPath -Value 'CompilationFailedException: fixture failure' -Encoding UTF8
+        } else {
+            Set-Content -LiteralPath $LogPath -Value @(
+                'IPCStream (Upm-25512): IPC stream failed to read (Not connected)',
+                'Failed to resolve packages: operation cancelled'
+            ) -Encoding UTF8
+            if ($script:upmScenario -eq 'transient-with-results') {
+                Set-Content -LiteralPath $upmResults -Value '<test-run total="1" passed="1" failed="0" />' -Encoding UTF8
+            }
+        }
+        return 1
+    }
+
+    Set-Content -LiteralPath $LogPath -Value 'Retry completed successfully.' -Encoding UTF8
+    Set-Content -LiteralPath $upmResults -Value '<test-run total="1" passed="1" failed="0" />' -Encoding UTF8
+    return 0
+}
+
+function Clear-UnityPackageManagerRetryState {
+    param([string]$Project)
+    $script:upmCleanupCalls++
+}
+
+foreach ($case in @(
+    @{ Name = 'transient without results retries'; Scenario = 'transient-no-results'; Attempts = 2; Cleanups = 1; ExitCode = 0; PreservesLog = $true },
+    @{ Name = 'transient with results trusts results'; Scenario = 'transient-with-results'; Attempts = 1; Cleanups = 0; ExitCode = 1; PreservesLog = $false },
+    @{ Name = 'non-transient failure does not retry'; Scenario = 'non-transient'; Attempts = 1; Cleanups = 0; ExitCode = 1; PreservesLog = $false }
+)) {
+    $script:upmAttempts = 0
+    $script:upmCleanupCalls = 0
+    $script:upmScenario = $case.Scenario
+    $firstAttemptLog = Join-Path $tmpRoot 'unity.first-attempt.log'
+    Remove-Item -LiteralPath $upmLog, $upmResults, $firstAttemptLog -Force -ErrorAction SilentlyContinue
+
+    $exitCode = Invoke-UnityEditorTestsWithPackageManagerRetry `
+        -EditorPath 'fake-editor' `
+        -Arguments @('-batchmode') `
+        -Label 'fixture Unity tests' `
+        -LogPath $upmLog `
+        -ResultsPath $upmResults `
+        -Project $tmpRoot
+
+    Assert-That "UPM: $($case.Name) [exit]" ($exitCode -eq $case.ExitCode)
+    Assert-That "UPM: $($case.Name) [attempts]" ($script:upmAttempts -eq $case.Attempts)
+    Assert-That "UPM: $($case.Name) [cleanup]" ($script:upmCleanupCalls -eq $case.Cleanups)
+    Assert-That "UPM: $($case.Name) [first log]" ((Test-Path -LiteralPath $firstAttemptLog -PathType Leaf) -eq $case.PreservesLog)
+    if ($case.PreservesLog) {
+        Assert-That 'UPM: retry preserves the original cancellation signal' (
+            (Get-Content -LiteralPath $firstAttemptLog -Raw) -match 'IPC stream failed to read'
+        )
+    }
+}
+
 Remove-Item -LiteralPath $tmpRoot -Recurse -Force -ErrorAction SilentlyContinue
 
 Write-Host ""
-Write-Host "Unity license activation-retry tests: $passed passed, $failed failed."
+Write-Host "Unity retry-policy tests: $passed passed, $failed failed."
 if ($failed -gt 0) {
     exit 1
 }
-Write-Host "All Unity license activation-retry tests passed."
+Write-Host "All Unity retry-policy tests passed."
 exit 0

--- a/scripts/unity/run-ci-tests.ps1
+++ b/scripts/unity/run-ci-tests.ps1
@@ -98,6 +98,11 @@ function Write-CiNotice {
     Write-Host "::notice::$Message"
 }
 
+function Write-CiWarning {
+    param([Parameter(Mandatory = $true)][string]$Message)
+    Write-Host "::warning::$Message"
+}
+
 function Clear-NonFatalNativeExitCode {
     # GitHub Actions' pwsh wrapper exits with $LASTEXITCODE after a script returns.
     # Any native exit code that this script has already captured and deliberately

--- a/scripts/validate-js-loc-budget.js
+++ b/scripts/validate-js-loc-budget.js
@@ -96,7 +96,11 @@ const path = require("path");
 //     comparison erases the date, so a file whose only defect was a corrupt
 //     date line looked identical to a fresh generation and update exited 1
 //     while advertising itself as the fix: 17612.
-const TOTAL_BUDGET = 17612;
+// 078 Parser-backed workflow consistency and fork-execution security contracts.
+//     Actionlint cannot enforce repository key ordering, permissions, concurrency,
+//     timeouts, checkout credential persistence, or same-repository formatting
+//     guards, so issue #379 adds those checks to the existing workflow suite: 17710.
+const TOTAL_BUDGET = 17710;
 const LARGEST_FILE_COUNT = 10;
 const REPO_ROOT = path.resolve(__dirname, "..");
 


### PR DESCRIPTION
## Summary

- complete the reopened documentation sweep by giving handlers ownership of gameplay/presentation state and post-processors realistic completed-dispatch telemetry/replay jobs
- require every documented `RegisterMessageHandlers` override to call its base hook, with a repository-wide docs regression test
- wrap long homepage sample lines so the Broadcast example remains readable at narrow widths
- finish the workflow concurrency, permission, timeout, checkout, and canonical ordering contract
- prevent opt-in formatting from executing fork-controlled code with repository write permissions
- make devcontainer/CSharpier workflows trigger on changes to their own contracts and correct the Unity CI skill's setup-dotnet version
- fix the Unity Package Manager cancellation retry so a transient IPC disconnect reaches its intended clean retry

## Root causes and impact

The documentation suite compiled snippets but did not enforce the `MessageAwareComponent` base-call lifecycle contract or distinguish a processed message from proof that gameplay state changed. The homepage code panel also forced preformatted lines to stay on one line inside an overflow-hidden shell.

Workflow policy relied on review because actionlint does not enforce repository-specific ordering, concurrency, permission, timeout, or checkout rules. More seriously, the comment-triggered formatting job checked out fork heads and ran fork-controlled npm/.NET tooling while holding the base repository's write token. Fork PRs are now rejected before checkout in both entry points, and each job has exactly one directly same-repo-gated checkout.

Issue #378 remains open. The repository currently ignores and does not track `package-lock.json`; unconditional `npm ci` would fail clean checkouts until that policy is explicitly reversed. The evidence and required issue correction are recorded in #378.

The first exact-head Unity run exposed an older deterministic retry-path defect: Unity 6000.3 lost its UPM IPC stream, but `run-ci-tests.ps1` called an undefined `Write-CiWarning` before retrying. The annotation helper is now defined, and the extracted production retry function is exercised against transient-without-results, results-present, and non-transient cases.

## Validation

- 409/409 script tests
- 556/556 documentation tests
- strict MkDocs build
- focused Unity 6000.4 sample-quality fixture: 5 passed, 0 failed, 8 local fixture-dependent cases inconclusive
- actionlint and Unity PR policy validation
- complete `validate:all`
- complete all-files pre-commit suite
- Unity retry-policy fixture: 75/75 assertions, repeated 10 consecutive times
- exact-head GitHub CI: static/docs/devcontainer/performance green, 12/12 Unity legs and all aggregate gates green
- adversarial review: zero findings after the documentation/workflow rounds and the CI-failure follow-up

Closes #364
Closes #372
Closes #379

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions permissions, concurrency, and especially opt-in formatting behavior (fork PRs no longer supported), which affects contributor workflows; documentation and test-only runtime behavior are low risk.
> 
> **Overview**
> **Documentation** now treats **handlers** as owning gameplay/presentation state and **post-processors** as observing completed dispatch (telemetry, replay, metrics)—not as proof that health or other state changed. Examples that override `RegisterMessageHandlers` on `MessageAwareComponent` call `base.RegisterMessageHandlers()`, enforced by a new docs regression test. The docs homepage code panel uses wrapping so long sample lines stay readable on narrow viewports.
> 
> **GitHub Actions** adopt a shared contract: `concurrency`, top-level `permissions`, job `timeout-minutes`, checkout with `persist-credentials: false`, and canonical YAML key order—checked by new parser-backed workflow tests. Several workflows self-trigger on their own file changes; wiki sync scopes `contents: write` to the deploy job only.
> 
> **Security:** opt-in `/format` automation no longer checks out fork PR heads or runs fork-controlled tooling with repository write access; fork PRs fail before checkout. The bot-branch / secondary-PR path for forks is removed.
> 
> Minor: Unity CI skill pins `setup-dotnet@v6`; JS LOC budget reflects new test lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08e9708b294d5ce46bab32dc832b35f67bf2ede. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->