### PR TITLE
Fix entity message semantics and gate docs-only Unity CI

### DIFF
--- a/.docs-tests/DocsSnippetCompilationTests.cs
+++ b/.docs-tests/DocsSnippetCompilationTests.cs
@@ -71,6 +71,43 @@ internal sealed class DocsSnippetCompilationTests
         System.Text.RegularExpressions.RegexOptions.Compiled
     );
 
+    private static readonly System.Text.RegularExpressions.Regex PostProcessorRegistrationRegex =
+        new(
+            @"\bRegister[A-Za-z0-9_]*PostProcessor\s*<[^>]+>\s*\((?<arguments>(?:(?!\)\s*;)[\s\S]){0,600}?)\)\s*;",
+            System.Text.RegularExpressions.RegexOptions.Compiled
+        );
+
+    private static readonly System.Text.RegularExpressions.Regex AmbiguousPostProcessorOutcomeRegex =
+        new(
+            @"\b(?:Log|Track|Record|Save|Count|Publish|Apply|Show|Update|After)(?![A-Za-z]*(?:Processed|Completed|Dispatch|Message|Request))[A-Za-z]*(?:Damage|Heal|Health|Scene|Level)[A-Za-z]*\b",
+            System.Text.RegularExpressions.RegexOptions.Compiled
+                | System.Text.RegularExpressions.RegexOptions.IgnoreCase
+        );
+
+    private static readonly System.Text.RegularExpressions.Regex UntargetedEntityHealthRegex = new(
+        @"(?:DxUntargetedMessage\](?:(?!Dx(?:Untargeted|Targeted|Broadcast)Message).){0,180}?\b(?:struct|class)\s+|RegisterUntargeted(?:PostProcessor|Interceptor)?\s*<\s*)(?<type>Heal(?:Request(?:ed)?)?|HealPlayerRequested|ApplyDamage|DealDamage|DamageMessage|DamageRequested|InflictDamage|TookDamage|DamageTaken|DamageApplied|HealthLost|HealthChanged|HealthReduced|[A-Za-z0-9_]*(?:Damaged|Healed))(?![A-Za-z0-9_])",
+        System.Text.RegularExpressions.RegexOptions.Compiled
+            | System.Text.RegularExpressions.RegexOptions.Singleline
+    );
+
+    private static readonly System.Text.RegularExpressions.Regex TargetedHealthOutcomeRegex = new(
+        @"(?:DxTargetedMessage\](?:(?!Dx(?:Untargeted|Targeted|Broadcast)Message).){0,180}?\b(?:struct|class)\s+|Register(?:GameObject|Component)?Targeted(?:WithoutTargeting|PostProcessor|Interceptor)?\s*<\s*)(?<type>TookDamage|DamageTaken|DamageApplied|HealthLost|HealthChanged|HealthReduced|[A-Za-z0-9_]*(?:Damaged|Healed))(?![A-Za-z0-9_])",
+        System.Text.RegularExpressions.RegexOptions.Compiled
+            | System.Text.RegularExpressions.RegexOptions.Singleline
+    );
+
+    private static readonly System.Text.RegularExpressions.Regex BroadcastHealthCommandRegex = new(
+        @"(?:DxBroadcastMessage\](?:(?!Dx(?:Untargeted|Targeted|Broadcast)Message).){0,180}?\b(?:struct|class)\s+|Register(?:GameObject|Component)?Broadcast(?:WithoutSource|PostProcessor|Interceptor)?\s*<\s*)(?<type>Heal(?:Request(?:ed)?)?|HealPlayerRequested|ApplyDamage|DealDamage|DamageMessage|DamageRequested|InflictDamage)(?![A-Za-z0-9_])",
+        System.Text.RegularExpressions.RegexOptions.Compiled
+            | System.Text.RegularExpressions.RegexOptions.Singleline
+    );
+
+    private static readonly System.Text.RegularExpressions.Regex UntargetedEntityFactRegex = new(
+        @"(?:DxUntargetedMessage\](?:(?!Dx(?:Untargeted|Targeted|Broadcast)Message).){0,180}?\b(?:struct|class)\s+|RegisterUntargeted(?:PostProcessor|Interceptor)?\s*<\s*)(?<type>Player(?:Spawned|Died|Moved|Damaged)|ButtonClicked|EntityDamaged)(?![A-Za-z0-9_])",
+        System.Text.RegularExpressions.RegexOptions.Compiled
+            | System.Text.RegularExpressions.RegexOptions.Singleline
+    );
+
     [Test]
     public void QuickStartStep1Compiles()
     {
@@ -332,6 +369,156 @@ internal sealed class DocsSnippetCompilationTests
             "MessageAwareComponent examples must call base.RegisterMessageHandlers():"
                 + System.Environment.NewLine
                 + string.Join(System.Environment.NewLine, violations)
+        );
+    }
+
+    [Test]
+    public void PostProcessorExamplesNameProcessedDispatchInsteadOfGameplayOutcomes()
+    {
+        string[] violations = GetBroadcastExampleSources()
+            .SelectMany(source =>
+                PostProcessorRegistrationRegex
+                    .Matches(source.Text)
+                    .Cast<System.Text.RegularExpressions.Match>()
+                    .SelectMany(registration =>
+                        FindAmbiguousPostProcessorCallbacks(registration.Groups["arguments"].Value)
+                            .Select(match =>
+                                $"{source.Path}:{source.Text[..registration.Index].Count(character => character == '\n') + 1}: {match.Value}"
+                            )
+                    )
+            )
+            .ToArray();
+
+        Assert.That(
+            violations,
+            Is.Empty,
+            "Post-processor examples must name the processed request/message/dispatch instead "
+                + "of claiming that gameplay state changed:"
+                + System.Environment.NewLine
+                + string.Join(System.Environment.NewLine, violations)
+        );
+    }
+
+    [TestCase("token.RegisterBroadcastPostProcessor<T>(RecordDamage);", true)]
+    [TestCase("token.RegisterBroadcastPostProcessor<T>(CountHealth);", true)]
+    [TestCase("token.RegisterBroadcastPostProcessor<T>(PublishHealMetric);", true)]
+    [TestCase("token.RegisterBroadcastPostProcessor<T>((T m) => SaveDamageTelemetry(m));", true)]
+    [TestCase("token.RegisterBroadcastPostProcessor<T>(RecordProcessedDamageRequest);", false)]
+    [TestCase(
+        "token.RegisterTargetedPostProcessor<ApplyDamage>((ref ApplyDamage m) => RecordProcessedDamageRequest(m));",
+        false
+    )]
+    [TestCase("void RecordDamage() { } // PostProcessor documentation", false)]
+    public void PostProcessorSemanticGuardBindsNamesToRegistrations(string source, bool invalid)
+    {
+        bool actual = PostProcessorRegistrationRegex
+            .Matches(source)
+            .Cast<System.Text.RegularExpressions.Match>()
+            .Any(registration =>
+                FindAmbiguousPostProcessorCallbacks(registration.Groups["arguments"].Value).Any()
+            );
+
+        Assert.That(
+            actual,
+            Is.EqualTo(invalid),
+            $"Expected post-processor semantic classification {invalid} for: {source}"
+        );
+    }
+
+    private static IEnumerable<System.Text.RegularExpressions.Match> FindAmbiguousPostProcessorCallbacks(
+        string arguments
+    )
+    {
+        return AmbiguousPostProcessorOutcomeRegex
+            .Matches(arguments)
+            .Cast<System.Text.RegularExpressions.Match>()
+            .Where(match =>
+                !System.Text.RegularExpressions.Regex.IsMatch(
+                    arguments[..match.Index],
+                    @"\b(?:ref|in|out)\s*$"
+                )
+            );
+    }
+
+    [Test]
+    public void HomepageQuickStartRequiresNoManualSceneReferenceWiring()
+    {
+        string docsRoot = ResolveDocsRoot();
+        string homepagePath = Path.Combine(docsRoot, "index.md");
+        string snippet = ExtractFirstCodeBlock(homepagePath, "csharp");
+
+        Assert.That(snippet, Does.Not.Contain("[SerializeField]"));
+        Assert.That(snippet, Does.Contain("[DxTargetedMessage]"));
+        Assert.That(snippet, Does.Not.Contain("[DxUntargetedMessage]"));
+        Assert.That(snippet, Does.Contain("RegisterGameObjectTargeted<HealPlayerRequested>"));
+        Assert.That(snippet, Does.Contain("EmitGameObjectTargeted(_playerHealth.gameObject)"));
+        Assert.That(snippet, Does.Contain("[RequireComponent(typeof(Button))]"));
+        Assert.That(snippet, Does.Contain("onClick.AddListener"));
+        Assert.That(snippet, Does.Contain("onClick.RemoveListener"));
+    }
+
+    [Test]
+    public void EntityScopedExamplesUseMessageKindsThatRetainIdentity()
+    {
+        System.Text.RegularExpressions.Regex[] invalidPatterns =
+        {
+            UntargetedEntityHealthRegex,
+            UntargetedEntityFactRegex,
+            TargetedHealthOutcomeRegex,
+            BroadcastHealthCommandRegex,
+        };
+        string[] violations = GetBroadcastExampleSources()
+            .SelectMany(source =>
+                invalidPatterns.SelectMany(pattern =>
+                    pattern
+                        .Matches(source.Text)
+                        .Cast<System.Text.RegularExpressions.Match>()
+                        .Select(match =>
+                            $"{source.Path}:{source.Text[..match.Index].Count(character => character == '\n') + 1}: {match.Groups["type"].Value}"
+                        )
+                )
+            )
+            .ToArray();
+
+        Assert.That(
+            violations,
+            Is.Empty,
+            "Entity commands must be targeted, entity facts must be broadcast, and neither "
+                + "belongs to the untargeted global channel:"
+                + System.Environment.NewLine
+                + string.Join(System.Environment.NewLine, violations)
+        );
+    }
+
+    [TestCase("[DxUntargetedMessage] struct HealRequested { }", true)]
+    [TestCase("[DxUntargetedMessage] struct DamageSettingsChanged { }", false)]
+    [TestCase("[DxUntargetedMessage] struct HealthUiOpened { }", false)]
+    [TestCase("[DxUntargetedMessage] struct DamageSystemInitialized { }", false)]
+    [TestCase("[DxTargetedMessage] struct DamageApplied { }", true)]
+    [TestCase("[DxTargetedMessage] struct HealthReduced { }", true)]
+    [TestCase("[DxTargetedMessage] struct ApplyDamage { }", false)]
+    [TestCase("[DxBroadcastMessage] struct DamageRequested { }", true)]
+    [TestCase("[DxBroadcastMessage] struct InflictDamage { }", true)]
+    [TestCase("[DxBroadcastMessage] struct TookDamage { }", false)]
+    [TestCase("[DxUntargetedMessage] struct PlayerSpawned { }", true)]
+    [TestCase("[DxUntargetedMessage] struct GameStarted { }", false)]
+    public void EntityRouteSemanticGuardDistinguishesCommandsFactsAndGlobals(
+        string source,
+        bool invalid
+    )
+    {
+        bool actual = new[]
+        {
+            UntargetedEntityHealthRegex,
+            UntargetedEntityFactRegex,
+            TargetedHealthOutcomeRegex,
+            BroadcastHealthCommandRegex,
+        }.Any(pattern => pattern.IsMatch(source));
+
+        Assert.That(
+            actual,
+            Is.EqualTo(invalid),
+            $"Expected entity-route semantic classification {invalid} for: {source}"
         );
     }
 

--- a/.docs-tests/DocsSnippetCompilationTests.cs
+++ b/.docs-tests/DocsSnippetCompilationTests.cs
@@ -91,13 +91,13 @@ internal sealed class DocsSnippetCompilationTests
     );
 
     private static readonly System.Text.RegularExpressions.Regex TargetedHealthOutcomeRegex = new(
-        @"(?:DxTargetedMessage\](?:(?!Dx(?:Untargeted|Targeted|Broadcast)Message).){0,180}?\b(?:struct|class)\s+|Register(?:GameObject|Component)?Targeted(?:WithoutTargeting|PostProcessor|Interceptor)?\s*<\s*)(?<type>TookDamage|DamageTaken|DamageApplied|HealthLost|HealthChanged|HealthReduced|[A-Za-z0-9_]*(?:Damaged|Healed))(?![A-Za-z0-9_])",
+        @"(?:DxTargetedMessage\](?:(?!Dx(?:Untargeted|Targeted|Broadcast)Message).){0,180}?\b(?:struct|class)\s+|Register(?:GameObject|Component)?Targeted(?:WithoutTargeting)?(?:PostProcessor|Interceptor)?\s*<\s*)(?<type>TookDamage|DamageTaken|DamageApplied|HealthLost|HealthChanged|HealthReduced|[A-Za-z0-9_]*(?:Damaged|Healed))(?![A-Za-z0-9_])",
         System.Text.RegularExpressions.RegexOptions.Compiled
             | System.Text.RegularExpressions.RegexOptions.Singleline
     );
 
     private static readonly System.Text.RegularExpressions.Regex BroadcastHealthCommandRegex = new(
-        @"(?:DxBroadcastMessage\](?:(?!Dx(?:Untargeted|Targeted|Broadcast)Message).){0,180}?\b(?:struct|class)\s+|Register(?:GameObject|Component)?Broadcast(?:WithoutSource|PostProcessor|Interceptor)?\s*<\s*)(?<type>Heal(?:Request(?:ed)?)?|HealPlayerRequested|ApplyDamage|DealDamage|DamageMessage|DamageRequested|InflictDamage)(?![A-Za-z0-9_])",
+        @"(?:DxBroadcastMessage\](?:(?!Dx(?:Untargeted|Targeted|Broadcast)Message).){0,180}?\b(?:struct|class)\s+|Register(?:GameObject|Component)?Broadcast(?:WithoutSource)?(?:PostProcessor|Interceptor)?\s*<\s*)(?<type>Heal(?:Request(?:ed)?)?|HealPlayerRequested|ApplyDamage|DealDamage|DamageMessage|DamageRequested|InflictDamage)(?![A-Za-z0-9_])",
         System.Text.RegularExpressions.RegexOptions.Compiled
             | System.Text.RegularExpressions.RegexOptions.Singleline
     );
@@ -497,9 +497,13 @@ internal sealed class DocsSnippetCompilationTests
     [TestCase("[DxTargetedMessage] struct DamageApplied { }", true)]
     [TestCase("[DxTargetedMessage] struct HealthReduced { }", true)]
     [TestCase("[DxTargetedMessage] struct ApplyDamage { }", false)]
+    [TestCase("token.RegisterTargetedWithoutTargetingPostProcessor<DamageApplied>(Observe);", true)]
+    [TestCase("token.RegisterTargetedWithoutTargetingInterceptor<ApplyDamage>(Validate);", false)]
     [TestCase("[DxBroadcastMessage] struct DamageRequested { }", true)]
     [TestCase("[DxBroadcastMessage] struct InflictDamage { }", true)]
     [TestCase("[DxBroadcastMessage] struct TookDamage { }", false)]
+    [TestCase("token.RegisterBroadcastWithoutSourcePostProcessor<DamageRequested>(Observe);", true)]
+    [TestCase("token.RegisterBroadcastWithoutSourceInterceptor<TookDamage>(Observe);", false)]
     [TestCase("[DxUntargetedMessage] struct PlayerSpawned { }", true)]
     [TestCase("[DxUntargetedMessage] struct GameStarted { }", false)]
     public void EntityRouteSemanticGuardDistinguishesCommandsFactsAndGlobals(

--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -88,6 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     outputs:
+      relevant: ${{ steps.head.outputs.relevant }}
       superseded: ${{ steps.head.outputs.superseded }}
     steps:
       - name: Compare the event head against the live pull-request head
@@ -100,6 +101,7 @@ jobs:
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          relevant=true
           superseded=false
           if [ "${EVENT_NAME}" = pull_request ]; then
             live="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha)" || live=
@@ -109,7 +111,20 @@ jobs:
               echo "::notice::${EVENT_HEAD_SHA} is superseded by ${live}; skipping the performance matrix."
               superseded=true
             fi
+            if files="$(gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+              --jq '.[] | .filename, (.previous_filename // empty)')"; then
+              documentation_only_pattern='^(docs/|progress/|\.llm/|\.agents/|\.claude/|Samples~/.*\.(md|markdown)(\.meta)?$|(AGENTS|GOAL|PLAN)\.md(\.meta)?$|llms\.txt$|mkdocs\.yml$|requirements-docs\.txt$)'
+              non_documentation="$(printf '%s\n' "${files}" | grep -Ev "${documentation_only_pattern}" || true)"
+              if [ -n "${files}" ] && [ -z "${non_documentation}" ]; then
+                echo "::notice::Only documentation and agent-context files changed; skipping licensed performance benchmarks."
+                relevant=false
+              fi
+            else
+              echo "::warning::Changed-file lookup failed; running licensed performance benchmarks."
+            fi
           fi
+          echo "relevant=${relevant}" >> "${GITHUB_OUTPUT}"
           echo "superseded=${superseded}" >> "${GITHUB_OUTPUT}"
 
   runner-preflight:
@@ -121,6 +136,7 @@ jobs:
     if: >-
       ${{
         needs.head-check.outputs.superseded != 'true' &&
+        needs.head-check.outputs.relevant != 'false' &&
         (
           github.event_name != 'pull_request' ||
           (
@@ -597,16 +613,17 @@ jobs:
           )
         }}
       SUPERSEDED: ${{ needs.head-check.outputs.superseded }}
+      RELEVANT: ${{ needs.head-check.outputs.relevant }}
     steps:
       - name: Require complete performance validation
         shell: bash
         run: |
           set -euo pipefail
           test "${{ needs.head-check.result }}" = success
-          if [ "${SUPERSEDED}" = "true" ] || [ "${TRUSTED_PR}" != "true" ]; then
+          if [ "${SUPERSEDED}" = "true" ] || [ "${RELEVANT}" = "false" ] || [ "${TRUSTED_PR}" != "true" ]; then
             test "${{ needs.runner-preflight.result }}" = skipped
             test "${{ needs.perf-benchmarks.result }}" = skipped
-            echo "Licensed performance benchmarks skip superseded or untrusted pull requests."
+            echo "Licensed performance benchmarks skip superseded, documentation-only, or untrusted pull requests."
           else
             test "${{ needs.runner-preflight.result }}" = success
             test "${{ needs.perf-benchmarks.result }}" = success
@@ -620,7 +637,8 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.user.login != 'dependabot[bot]' &&
         always() &&
-        needs.head-check.outputs.superseded != 'true'
+        needs.head-check.outputs.superseded != 'true' &&
+        needs.head-check.outputs.relevant != 'false'
       }}
     needs:
       - head-check

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     outputs:
+      relevant: ${{ steps.head.outputs.relevant }}
       superseded: ${{ steps.head.outputs.superseded }}
     steps:
       - name: Compare the event head against the live pull-request head
@@ -57,6 +58,7 @@ jobs:
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          relevant=true
           superseded=false
           if [ "${EVENT_NAME}" = pull_request ]; then
             live="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha)" || live=
@@ -66,7 +68,20 @@ jobs:
               echo "::notice::${EVENT_HEAD_SHA} is superseded by ${live}; skipping the Unity matrix."
               superseded=true
             fi
+            if files="$(gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+              --jq '.[] | .filename, (.previous_filename // empty)')"; then
+              documentation_only_pattern='^(docs/|progress/|\.llm/|\.agents/|\.claude/|Samples~/.*\.(md|markdown)(\.meta)?$|(AGENTS|GOAL|PLAN)\.md(\.meta)?$|llms\.txt$|mkdocs\.yml$|requirements-docs\.txt$)'
+              non_documentation="$(printf '%s\n' "${files}" | grep -Ev "${documentation_only_pattern}" || true)"
+              if [ -n "${files}" ] && [ -z "${non_documentation}" ]; then
+                echo "::notice::Only documentation and agent-context files changed; skipping licensed Unity tests."
+                relevant=false
+              fi
+            else
+              echo "::warning::Changed-file lookup failed; running licensed Unity tests."
+            fi
           fi
+          echo "relevant=${relevant}" >> "${GITHUB_OUTPUT}"
           echo "superseded=${superseded}" >> "${GITHUB_OUTPUT}"
 
   runner-preflight:
@@ -86,6 +101,7 @@ jobs:
     if: >-
       ${{
         needs.head-check.outputs.superseded != 'true' &&
+        needs.head-check.outputs.relevant != 'false' &&
         (github.event_name != 'pull_request' ||
         (github.event.pull_request.user.login != 'dependabot[bot]' &&
           github.event.pull_request.head.repo.full_name == github.repository))
@@ -116,6 +132,7 @@ jobs:
     if: >-
       ${{
         needs.head-check.outputs.superseded != 'true' &&
+        needs.head-check.outputs.relevant != 'false' &&
         (github.event_name != 'pull_request' ||
         (github.event.pull_request.user.login != 'dependabot[bot]' &&
           github.event.pull_request.head.repo.full_name == github.repository))
@@ -504,9 +521,10 @@ jobs:
     # Exactly always() -- NEVER a falsifiable job-level if. A skipped required
     # check counts as passing and the latest run on a SHA wins, so a guard that
     # can be false on a pull_request could launder a red/pending gate into a
-    # false green. The step below validates the only three intentional skip
-    # shapes: fork PRs and Dependabot PRs skip both licensed jobs (neither can
-    # read the organization secrets those jobs require), and a superseded head
+    # false green. The step below validates the four intentional skip shapes:
+    # documentation-only, fork, and Dependabot PRs skip both licensed jobs
+    # (the latter two cannot read the organization secrets those jobs require),
+    # and a superseded head
     # skips them because the run for the current head is the one that counts.
     # A superseded run cannot launder anything -- branch protection reads only
     # the checks on the current head -- but it still has to report its shape
@@ -523,13 +541,14 @@ jobs:
           HEAD_CHECK_RESULT: ${{ needs.head-check.result }}
           RUNNER_PREFLIGHT_RESULT: ${{ needs.runner-preflight.result }}
           UNITY_TESTS_RESULT: ${{ needs.unity-tests.result }}
+          RELEVANT: ${{ needs.head-check.outputs.relevant }}
           SUPERSEDED: ${{ needs.head-check.outputs.superseded }}
           FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
           DEPENDABOT_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' }}
         run: |
           set -euo pipefail
           test "${HEAD_CHECK_RESULT}" = success
-          if [ "${SUPERSEDED}" = "true" ] || [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then
+          if [ "${SUPERSEDED}" = "true" ] || [ "${RELEVANT}" = "false" ] || [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then
             test "${RUNNER_PREFLIGHT_RESULT}" = skipped
             test "${UNITY_TESTS_RESULT}" = skipped
           else

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -96,7 +96,9 @@ editor), NOT inside the devcontainer. The container ships no local Unity build. 
 - Sandbox restriction: `using System.Reflection;` is rejected in `Unity_RunCommand` snippets -- fully qualify (`System.Reflection.Assembly`) instead.
 - The published IL2CPP-Release headline comes from the CI leg (self-hosted Windows, `scripts/unity/run-ci-tests.ps1`), not the local MCP loop; the MCP loop is the local Mono/editor signal. CI keeps short, scope-isolated host projects under `$RUNNER_WORKSPACE/dxm-u/{t,b,p}/<version>-<mode>/` so each fixed runner can reuse its own `Library` without transferring it over the network -- see [UPM Test Harness](./skills/unity-test-execution/references/upm-test-harness.md).
 - License (CI only): see [Unity License Bootstrap](./skills/unity-licensing/references/unity-license-bootstrap.md). CI activates Unity with a classic serial (`UNITY_SERIAL` + `UNITY_EMAIL` + `UNITY_PASSWORD`) and guarantees a `-returnlicense` on every exit path.
-- For source-generator tests (no Unity), use `dotnet test SourceGenerators/...Tests`.
+- For source-generator tests (no Unity), use
+  `dotnet test SourceGenerators/...Tests /p:CopyAnalyzerPayload=false`. The property keeps a local
+  Debug test build from overwriting the tracked Release analyzer payload under `Runtime/Analyzers/`.
 - For docs sample/reference guards (no Unity), use
   `dotnet test .docs-tests/WallstopStudios.DxMessaging.Docs.Tests.csproj`.
 

--- a/README.md
+++ b/README.md
@@ -254,22 +254,38 @@ No manual unsubscribe needed. Subscriptions are type-safe and lifecycle-managed.
 **Using Zenject, VContainer, or Reflex?** DxMessaging is fully DI-compatible out of the box!
 
 ```csharp
+[DxUntargetedMessage]
+public readonly struct GameStarted { }
+
 // Inject IMessageBus in any class
 public class PlayerService : IInitializable, IDisposable
 {
+    private readonly IMessageBus _messageBus;
     private readonly MessageRegistrationLease _lease;
 
-    public PlayerService(IMessageRegistrationBuilder builder)
+    public PlayerService(IMessageBus messageBus, IMessageRegistrationBuilder builder)
     {
+        _messageBus = messageBus;
         // Builder automatically resolves your container-managed bus
         _lease = builder.Build(new MessageRegistrationBuildOptions
         {
-            Configure = token => token.RegisterUntargeted<PlayerSpawned>(OnSpawn)
+            Configure = token => token.RegisterUntargeted<GameStarted>(OnGameStarted)
         });
     }
 
     public void Initialize() => _lease.Activate();
     public void Dispose() => _lease.Dispose();
+
+    public void PublishGameStarted()
+    {
+        var started = new GameStarted();
+        started.EmitUntargeted(_messageBus);
+    }
+
+    private static void OnGameStarted(GameStarted message)
+    {
+        Debug.Log("Game started");
+    }
 }
 ```
 
@@ -434,10 +450,10 @@ public class GameUI : MessageAwareComponent {
 
     protected override void RegisterMessageHandlers() {
         base.RegisterMessageHandlers();
-        _ = Token.RegisterUntargeted<HealthChanged>(OnHealth);
+        _ = Token.RegisterBroadcastWithoutSource<HealthChanged>(OnHealth);
         _ = Token.RegisterUntargeted<WaveStarted>(OnWave);
         _ = Token.RegisterUntargeted<ItemAdded>(OnItem);
-        // Listen to anything, from anywhere, no coupling
+        // Observe entity facts by source and global events without direct references
     }
 }
 ```
@@ -508,7 +524,7 @@ What DxMessaging offers:
 #### DxMessaging solution
 
 ```csharp
-void OnDamage(ref TookDamage msg) {  // Pass by ref = zero allocations
+void OnDamage(ref ApplyDamage msg) { // Pass by ref = zero allocations
     health -= msg.amount;            // No boxing, no GC pressure
 }
 // Automatic cleanup prevents common leak patterns
@@ -583,22 +599,25 @@ _ = token.RegisterBroadcastWithoutSource<TookDamage>(
 **DxMessaging solution:** Validate ONCE before ANY handler runs:
 
 ```csharp
+[DxTargetedMessage]
+public struct ApplyDamage { public int amount; }
+
 // ONE interceptor protects ALL handlers
-_ = token.RegisterBroadcastInterceptor<TookDamage>(
-    (ref InstanceId src, ref TookDamage msg) => {
+_ = token.RegisterTargetedInterceptor<ApplyDamage>(
+    (ref InstanceId target, ref ApplyDamage msg) => {
         if (msg.amount <= 0) return false;               // Cancel invalid
         if (msg.amount > 999) {
-            msg = new TookDamage(999);                   // Clamp excessive
+            msg = new ApplyDamage(999);                  // Clamp excessive
         }
-        if (IsGodModeActive(src)) return false;          // Block damage
+        if (IsGodModeActive(target)) return false;       // Block damage
         return true;
     },
     priority: -100  // Run FIRST
 );
 
 // Now ALL handlers receive clean, validated data
-_ = token.RegisterComponentTargeted<TookDamage>(player, OnDamage);
-void OnDamage(ref TookDamage msg) {
+_ = token.RegisterComponentTargeted<ApplyDamage>(player, OnDamage);
+void OnDamage(ref ApplyDamage msg) {
     // No validation needed - interceptor guarantees validity!
     health -= msg.amount;
 }

--- a/Runtime/Core/Extensions/MessageBusExtensions.cs
+++ b/Runtime/Core/Extensions/MessageBusExtensions.cs
@@ -63,8 +63,8 @@ namespace DxMessaging.Core.Extensions
         /// <example>
         /// <code>
         /// InstanceId playerId = GetPlayerId();
-        /// var change = new HealthChanged(5);
-        /// bus.EmitTargeted(playerId, change);
+        /// var command = new AdjustHealth(5);
+        /// bus.EmitTargeted(playerId, command);
         /// </code>
         /// </example>
         public static void EmitTargeted<TMessage>(

--- a/Runtime/Core/MessageBus/IMessageBus.cs
+++ b/Runtime/Core/MessageBus/IMessageBus.cs
@@ -38,12 +38,12 @@ namespace DxMessaging.Core.MessageBus
     /// <code>
     /// // Unity: register then send a targeted message
     /// var token = messagingComponent.Create(this);
-    /// token.RegisterComponentTargeted&lt;TookDamage&gt;(this, (ref TookDamage m) =&gt; OnDamage(m));
+    /// token.RegisterComponentTargeted&lt;ApplyDamage&gt;(this, (ref ApplyDamage m) =&gt; OnDamage(m));
     /// token.Enable();
     ///
     /// // Later, somewhere else
     /// DxMessaging.Core.InstanceId me = GetComponent&lt;UnityEngine.Component&gt;();
-    /// var msg = new TookDamage(5);
+    /// var msg = new ApplyDamage(5);
     /// DxMessaging.Core.MessageHandler.MessageBus.TargetedBroadcast(ref me, ref msg);
     /// </code>
     /// </example>

--- a/Runtime/Core/MessageRegistrationToken.cs
+++ b/Runtime/Core/MessageRegistrationToken.cs
@@ -231,7 +231,7 @@ namespace DxMessaging.Core
         /// <returns>A handle that allows for registration and de-registration.</returns>
         /// <example>
         /// <code>
-        /// _ = token.RegisterGameObjectTargeted&lt;TookDamage&gt;(gameObject, (ref TookDamage m) =&gt; Apply(m));
+        /// _ = token.RegisterGameObjectTargeted&lt;ApplyDamage&gt;(gameObject, (ref ApplyDamage m) =&gt; Apply(m));
         /// token.Enable();
         /// </code>
         /// </example>
@@ -258,7 +258,7 @@ namespace DxMessaging.Core
         /// <returns>A handle that allows for registration and de-registration.</returns>
         /// <example>
         /// <code>
-        /// _ = token.RegisterComponentTargeted&lt;TookDamage&gt;(this, OnDamage);
+        /// _ = token.RegisterComponentTargeted&lt;ApplyDamage&gt;(this, OnDamage);
         /// token.Enable();
         /// </code>
         /// </example>
@@ -303,7 +303,7 @@ namespace DxMessaging.Core
         /// <returns>A handle that allows for registration and de-registration.</returns>
         /// <example>
         /// <code>
-        /// _ = token.RegisterGameObjectTargetedPostProcessor&lt;TookDamage&gt;(gameObject, (ref TookDamage m) =&gt; Log(m));
+        /// _ = token.RegisterGameObjectTargetedPostProcessor&lt;ApplyDamage&gt;(gameObject, (ref ApplyDamage m) =&gt; metrics.RecordProcessedDamageRequest(m.amount));
         /// </code>
         /// </example>
         public MessageRegistrationHandle RegisterGameObjectTargetedPostProcessor<T>(
@@ -1036,7 +1036,7 @@ namespace DxMessaging.Core
         /// <returns>A handle that allows for registration and de-registration.</returns>
         /// <example>
         /// <code>
-        /// _ = token.RegisterBroadcastWithoutSource&lt;TookDamage&gt;((DxMessaging.Core.InstanceId src, TookDamage m) =&gt; TrackDamage(src, m));
+        /// _ = token.RegisterBroadcastWithoutSource&lt;TookDamage&gt;((DxMessaging.Core.InstanceId src, TookDamage m) =&gt; ShowDamageNumber(src, m));
         /// </code>
         /// </example>
         public MessageRegistrationHandle RegisterBroadcastWithoutSource<T>(
@@ -1105,7 +1105,7 @@ namespace DxMessaging.Core
         /// <returns>A handle that allows for registration and de-registration.</returns>
         /// <example>
         /// <code>
-        /// _ = token.RegisterBroadcastWithoutSourcePostProcessor&lt;TookDamage&gt;((DxMessaging.Core.InstanceId src, TookDamage m) =&gt; Log(src, m));
+        /// _ = token.RegisterBroadcastWithoutSourcePostProcessor&lt;TookDamage&gt;((DxMessaging.Core.InstanceId src, TookDamage m) =&gt; replay.RecordProcessedDamageMessage(src, m.amount));
         /// </code>
         /// </example>
         public MessageRegistrationHandle RegisterBroadcastWithoutSourcePostProcessor<T>(

--- a/Runtime/Unity/MessageAwareComponent.cs
+++ b/Runtime/Unity/MessageAwareComponent.cs
@@ -31,12 +31,12 @@ namespace DxMessaging.Unity
     ///     {
     ///         base.RegisterMessageHandlers();
     ///         // Listen for targeted damage commands to this component
-    ///         _ = Token.RegisterComponentTargeted&lt;TookDamage&gt;(this, HandleDamage);
+    ///         _ = Token.RegisterComponentTargeted&lt;ApplyDamage&gt;(this, HandleDamage);
     ///         // Listen for global difficulty changes
     ///         _ = Token.RegisterUntargeted&lt;DifficultyChanged&gt;(HandleDifficulty);
     ///     }
     ///
-    ///     private void HandleDamage(ref TookDamage msg)
+    ///     private void HandleDamage(ref ApplyDamage msg)
     ///     {
     ///         // apply damage
     ///     }

--- a/Samples~/DI/Zenject/SampleInstaller.cs
+++ b/Samples~/DI/Zenject/SampleInstaller.cs
@@ -4,6 +4,7 @@ namespace DxMessaging.Samples.DI.Zenject
     using global::System;
     using global::UnityEngine;
     using global::Zenject;
+    using global::DxMessaging.Core;
     using global::DxMessaging.Core.Attributes;
     using global::DxMessaging.Core.MessageBus;
 
@@ -27,7 +28,7 @@ namespace DxMessaging.Samples.DI.Zenject
             Container.BindInterfacesTo<PlayerSpawnTracker>().AsSingle();
         }
 
-        [DxUntargetedMessage]
+        [DxBroadcastMessage]
         [DxAutoConstructor]
         private readonly partial struct PlayerSpawned
         {
@@ -47,7 +48,9 @@ namespace DxMessaging.Samples.DI.Zenject
                     {
                         Configure = token =>
                         {
-                            _ = token.RegisterUntargeted<PlayerSpawned>(OnPlayerSpawned);
+                            _ = token.RegisterBroadcastWithoutSource<PlayerSpawned>(
+                                OnPlayerSpawned
+                            );
                         },
                     }
                 );
@@ -63,7 +66,7 @@ namespace DxMessaging.Samples.DI.Zenject
                 lease.Dispose();
             }
 
-            private static void OnPlayerSpawned(ref PlayerSpawned message)
+            private static void OnPlayerSpawned(InstanceId player, PlayerSpawned message)
             {
                 Debug.Log($"Player spawned: {message.PlayerName}");
             }

--- a/Samples~/Mini Combat/UIOverlay.cs
+++ b/Samples~/Mini Combat/UIOverlay.cs
@@ -46,6 +46,6 @@ public sealed class UIOverlay : MessageAwareComponent
     {
         int damage = Mathf.Max(0, message.amount);
         totalDamageObserved += damage;
-        damageText = $"Damage: {source} dealt {damage} (total {totalDamageObserved})";
+        damageText = $"Damage: {source} took {damage} (total {totalDamageObserved})";
     }
 }

--- a/Samples~/UI Buttons + Inspector/Messages.cs
+++ b/Samples~/UI Buttons + Inspector/Messages.cs
@@ -1,6 +1,6 @@
 using DxMessaging.Core.Attributes;
 
-[DxUntargetedMessage]
+[DxBroadcastMessage]
 [DxAutoConstructor]
 public readonly partial struct ButtonClicked
 {

--- a/Samples~/UI Buttons + Inspector/MessagingObserver.cs
+++ b/Samples~/UI Buttons + Inspector/MessagingObserver.cs
@@ -17,6 +17,8 @@ public sealed class MessagingObserver : MessageAwareComponent
     [SerializeField]
     private string lastButtonId = "None";
 
+    private InstanceId lastButtonSource;
+
     [SerializeField]
     private string lastObservedRoute = "None";
 
@@ -24,14 +26,15 @@ public sealed class MessagingObserver : MessageAwareComponent
     {
         base.RegisterMessageHandlers();
         Token.DiagnosticMode = true;
-        _ = Token.RegisterUntargeted<ButtonClicked>(OnButtonClicked);
+        _ = Token.RegisterBroadcastWithoutSource<ButtonClicked>(OnButtonClicked);
         _ = Token.RegisterGlobalAcceptAll(OnAnyUntargeted, OnAnyTargeted, OnAnyBroadcast);
     }
 
-    private void OnButtonClicked(ref ButtonClicked message)
+    private void OnButtonClicked(InstanceId source, ButtonClicked message)
     {
         typedClickCount++;
         lastButtonId = message.id;
+        lastButtonSource = source;
         if (logTypedClicks)
         {
             Debug.Log($"Button clicked: {message.id}", this);

--- a/Samples~/UI Buttons + Inspector/README.md
+++ b/Samples~/UI Buttons + Inspector/README.md
@@ -18,13 +18,13 @@ available for a project's normal `UnityEngine.UI.Button.onClick` binding.
 
 ## Message flow
 
-`UIButtonEmitter.Click()` emits an untargeted domain event and a GameObject-targeted text
+`UIButtonEmitter.Click()` emits a GameObject-sourced domain event and a GameObject-targeted text
 message:
 
 ```csharp
 string effectiveButtonId = string.IsNullOrWhiteSpace(buttonId) ? "UnnamedButton" : buttonId;
 var clicked = new ButtonClicked(effectiveButtonId);
-clicked.Emit();
+clicked.EmitGameObjectBroadcast(gameObject);
 
 var text = new StringMessage($"Clicked {effectiveButtonId}");
 text.EmitGameObjectTargeted(gameObject);
@@ -35,7 +35,7 @@ data.
 
 `MessagingObserver` demonstrates two different observation levels:
 
-- `RegisterUntargeted<ButtonClicked>` handles the typed button event.
+- `RegisterBroadcastWithoutSource<ButtonClicked>` handles the typed button event and retains its source.
 - `RegisterGlobalAcceptAll` observes route metadata for diagnostics and tooling.
 
 Use the typed registration for gameplay. Reserve accept-all listeners for diagnostics,

--- a/Samples~/UI Buttons + Inspector/UIButtonEmitter.cs
+++ b/Samples~/UI Buttons + Inspector/UIButtonEmitter.cs
@@ -28,7 +28,7 @@ public sealed class UIButtonEmitter : MonoBehaviour
     {
         string effectiveButtonId = EffectiveButtonId;
         var evt = new ButtonClicked(effectiveButtonId);
-        evt.Emit();
+        evt.EmitGameObjectBroadcast(gameObject);
 
         // Also emit a targeted string message to this GameObject.
         var text = new StringMessage($"Clicked {effectiveButtonId}");

--- a/Tests/Editor/SampleQualityContractTests.cs
+++ b/Tests/Editor/SampleQualityContractTests.cs
@@ -432,12 +432,17 @@ namespace DxMessaging.Tests.Editor
                 Assert.That(
                     GetRequiredField(observerType, "acceptAllCount").GetValue(observer),
                     Is.EqualTo(2),
-                    "The observer must see both the untargeted and targeted demo routes."
+                    "The observer must see both the broadcast and targeted demo routes."
                 );
                 Assert.That(
                     GetRequiredField(observerType, "lastButtonId").GetValue(observer),
                     Is.EqualTo("Play"),
                     "The authored button ID must reach the typed observer."
+                );
+                Assert.That(
+                    GetRequiredField(observerType, "lastButtonSource").GetValue(observer),
+                    Is.EqualTo((InstanceId)emitter.gameObject),
+                    "The clicked GameObject must remain the ButtonClicked broadcast source."
                 );
             }
             finally

--- a/docs/advanced/emit-shorthands.md
+++ b/docs/advanced/emit-shorthands.md
@@ -181,8 +181,8 @@ heal.EmitAt(this);
 _ = token.RegisterTargetedWithoutTargeting<Heal>(OnAnyHeal);
 void OnAnyHeal(ref InstanceId target, ref Heal msg)
 {
-    Debug.Log($"Someone healed {target} for {msg.amount}");
-    // You get WHO was healed as a parameter!
+    Debug.Log($"Heal requested for {target}: {msg.amount}");
+    // You get the target that received the request.
 }
 
 // Listen to ALL damage, regardless of source

--- a/docs/advanced/registration-builders.md
+++ b/docs/advanced/registration-builders.md
@@ -74,7 +74,7 @@ MessageRegistrationBuildOptions options = new MessageRegistrationBuildOptions
     ActivateOnBuild = true,
     Configure = token =>
     {
-        _ = token.RegisterUntargeted<PlayerDamaged>(OnPlayerDamaged);
+        _ = token.RegisterUntargeted<GameStarted>(OnGameStarted);
     }
 };
 
@@ -335,8 +335,8 @@ public sealed class DIIntegrationExample : MonoBehaviour
 
     private void ConfigureRegistrations(MessageRegistrationToken token)
     {
-        _ = token.RegisterUntargeted<PlayerSpawned>(OnPlayerSpawned);
-        _ = token.RegisterUntargeted<PlayerDied>(OnPlayerDied);
+        _ = token.RegisterUntargeted<GameStarted>(OnGameStarted);
+        _ = token.RegisterUntargeted<GameStopped>(OnGameStopped);
     }
 
     private void OnDestroy()
@@ -345,14 +345,14 @@ public sealed class DIIntegrationExample : MonoBehaviour
     }
 
     // Action<T> handler signatures
-    private void OnPlayerSpawned(PlayerSpawned message)
+    private void OnGameStarted(GameStarted message)
     {
-        Debug.Log($"Player spawned: {message.PlayerId}");
+        Debug.Log("Game started");
     }
 
-    private void OnPlayerDied(PlayerDied message)
+    private void OnGameStopped(GameStopped message)
     {
-        Debug.Log($"Player died: {message.PlayerId}");
+        Debug.Log("Game stopped");
     }
 }
 ```

--- a/docs/architecture/comparisons.md
+++ b/docs/architecture/comparisons.md
@@ -1223,14 +1223,14 @@ public class UI : MonoBehaviour
 // Old static event bus
 EventHub.RaiseDamage(5);
 
-// DxMessaging equivalent (global bus)
+// DxMessaging equivalent (global bus, affected player retained as source)
 var damage = new TookDamage(5);
-damage.Emit();
+damage.EmitGameObjectBroadcast(gameObject);
 
 // Or use local buses for subsystems
 var combatBus = new MessageBus();
 var combatDamage = new TookDamage(5);
-combatDamage.Emit(combatBus);
+combatDamage.EmitGameObjectBroadcast(gameObject, combatBus);
 ```
 
 ---

--- a/docs/concepts/interceptors-and-ordering.md
+++ b/docs/concepts/interceptors-and-ordering.md
@@ -150,21 +150,21 @@ using DxMessaging.Core.MessageBus;    // IMessageBus
 
 // Cancel <=0 damage and clamp high values
 IMessageBus bus = MessageHandler.MessageBus;
-MessageBusRegistration registration = bus.RegisterTargetedInterceptor<TookDamage>(
-    (ref InstanceId target, ref TookDamage m) =>
+MessageBusRegistration registration = bus.RegisterTargetedInterceptor<ApplyDamage>(
+    (ref InstanceId target, ref ApplyDamage m) =>
     {
         if (m.amount <= 0)
         {
             return false;
         }
-        m = new TookDamage(Math.Min(m.amount, 999));
+        m = new ApplyDamage(Math.Min(m.amount, 999));
         return true;
     },
     priority: 0
 );
 
 // The owning system calls this during teardown.
-bus.Deregister<TookDamage>(in registration);
+bus.Deregister<ApplyDamage>(in registration);
 ```
 
 Calls through `MessageRegistrationToken` are owned by that token. Calls made directly on

--- a/docs/concepts/listening-patterns.md
+++ b/docs/concepts/listening-patterns.md
@@ -33,7 +33,7 @@ void ShowDamageNumber(InstanceId source, TookDamage m) => damageNumbers.Show(sou
 // Record the processed message for replay after every gameplay handler has run.
 _ = token.RegisterBroadcastWithoutSourcePostProcessor<TookDamage>(RecordProcessedDamage);
 void RecordProcessedDamage(InstanceId source, TookDamage m) =>
-    replay.RecordDamage(source, m.amount);
+    replay.RecordProcessedDamageMessage(source, m.amount);
 ```
 
 The handler owns presentation state by spawning a damage number. The post-processor records
@@ -134,7 +134,7 @@ using DxMessaging.Core.MessageBus;
 public class NetworkedAttribute : Attribute { }
 
 [Networked]
-[DxUntargetedMessage]
+[DxBroadcastMessage]
 [DxAutoConstructor]
 public readonly partial struct PlayerMoved
 {
@@ -224,7 +224,7 @@ without explicit per-type registration:
 using NetworkReplicator replicator = new(networkManager, MessageHandler.MessageBus);
 
 var playerMoved = new PlayerMoved(playerPos);
-playerMoved.Emit();
+playerMoved.EmitFrom(gameObject);
 var dealDamage = new DealDamage(50f);
 dealDamage.EmitTargeted(enemyId);
 ```

--- a/docs/concepts/mental-model.md
+++ b/docs/concepts/mental-model.md
@@ -307,8 +307,8 @@ Token.RegisterTargetedWithoutTargeting<Heal>(OnAnyHeal);
 
 void OnAnyHeal(ref InstanceId target, ref Heal msg)
 {
-    // 'target' tells you who was healed
-    Debug.Log($"Someone healed {target} for {msg.amount}");
+    // 'target' tells you who received the heal request
+    Debug.Log($"Heal requested for {target}: {msg.amount}");
 }
 ```
 

--- a/docs/concepts/targeting-and-context.md
+++ b/docs/concepts/targeting-and-context.md
@@ -222,8 +222,8 @@ _ = token.RegisterTargetedWithoutTargeting<Heal>(OnAnyHeal);
 
 void OnAnyHeal(ref InstanceId target, ref Heal msg)
 {
-    Debug.Log($"Someone healed {target} for {msg.amount}");
-    // You get the target as a parameter so you know WHO was healed
+    Debug.Log($"Heal requested for {target}: {msg.amount}");
+    // You get the target that received the request.
 }
 
 // Now when ANYONE emits a heal...
@@ -234,8 +234,8 @@ heal.EmitAt(npc);       // OnAnyHeal fires with target = npc
 
 #### Use cases
 
-- Analytics ("track all damage dealt")
-- Debugging ("log every heal in the game")
+- Analytics ("track all damage requests")
+- Debugging ("log every heal request in the game")
 - Achievements ("count total kills")
 - Global UI updates ("show floating damage numbers for any entity")
 
@@ -302,14 +302,14 @@ public class Player : MessageAwareComponent
     protected override void RegisterMessageHandlers()
     {
         base.RegisterMessageHandlers();
-        // Listen only to damage targeting THIS player
+        // Listen only to damage broadcast by THIS player
         _ = Token.RegisterGameObjectBroadcast<TookDamage>(gameObject, OnPlayerTookDamage);
     }
 
     void OnPlayerTookDamage(ref TookDamage msg)
     {
-        // Player-specific logic: update health bar, play hurt sound
-        health -= msg.amount;
+        // The targeted command already changed health; react to the resulting fact.
+        UpdateHealthBar();
         PlayHurtSound();
     }
 }
@@ -335,15 +335,14 @@ public class AchievementSystem : MessageAwareComponent
     protected override void RegisterMessageHandlers()
     {
         base.RegisterMessageHandlers();
-        // Listen to ALL damage targeting ANY entity (global observer)
-        _ = Token.RegisterTargetedWithoutTargeting<DealDamage>(OnAnyDamageDealt);
+        // Listen to ALL damage requests targeting ANY entity (global observer)
+        _ = Token.RegisterTargetedWithoutTargeting<DealDamage>(OnAnyDamageRequested);
     }
 
-    void OnAnyDamageDealt(ref InstanceId target, ref DealDamage msg)
+    void OnAnyDamageRequested(ref InstanceId target, ref DealDamage msg)
     {
-        // Track total damage dealt for achievements
-        totalDamageDealt += msg.amount;
-        CheckDamageAchievements();
+        // Applied damage is a later broadcast fact.
+        requestedDamage += msg.amount;
     }
 }
 ```
@@ -364,7 +363,7 @@ Global listeners (`RegisterTargetedWithoutTargeting` / `RegisterBroadcastWithout
 
 #### Use when
 
-- The whole object is the logical target/source (e.g., "Player was healed", "Enemy took damage")
+- The whole object is the logical target/source (e.g., "Player received a heal request", "Enemy took damage")
 - Multiple components should coordinate under the same address
 - You don't care which specific component handles it
 - You want flexibility for future refactoring (adding/removing components)

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -91,11 +91,11 @@ public class GameUI : MessageAwareComponent
     {
         base.RegisterMessageHandlers();
 
-        _ = Token.RegisterGameObjectTargeted<Heal>(playerGO, OnPlayerHealed);
+        _ = Token.RegisterGameObjectTargeted<Heal>(playerGO, OnHealRequested);
         _ = Token.RegisterBroadcastWithoutSource<TookDamage>(OnAnyDamage);
     }
 
-    private void OnPlayerHealed(ref Heal m) => UpdateHealthBar(m.amount);
+    private void OnHealRequested(ref Heal m) => ShowRequestedHeal(m.amount);
     private void OnAnyDamage(InstanceId source, TookDamage m) => ShowDamageEffect(source);
 }
 ```
@@ -201,7 +201,7 @@ Checklist:
 ```csharp
 // Listen
 _ = Token.RegisterBroadcastWithoutSource<TookDamage>(OnAnyDamage);
-_ = Token.RegisterGameObjectTargeted<Heal>(playerGO, OnPlayerHealed);
+_ = Token.RegisterGameObjectTargeted<Heal>(playerGO, OnHealRequested);
 
 // Emit (broadcasts always require a source)
 var damage = new TookDamage(25);

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -185,11 +185,11 @@ Registration cleanup is automatic. Messages are type-safe.
 ### Do's
 
 - Use `MessageAwareComponent` for Unity components (automatic lifecycle)
-- Store struct in variable before emitting: `var msg = new Heal(10); msg.Emit();`
+- Store struct in variable before emitting: `var msg = new Heal(10); msg.EmitGameObjectTargeted(playerGO);`
 - Call `base.RegisterMessageHandlers()` when overriding
 
 ### Don'ts
 
-- Don't emit from temporaries: `new Heal(10).Emit()` won't compile (struct emit methods require `ref this`)
+- Don't emit from temporaries: `new Heal(10).EmitGameObjectTargeted(playerGO)` won't compile (struct emit methods require `ref this`)
 - Don't use Untargeted for commands to one object (use Targeted instead)
 - Don't forget `using DxMessaging.Core.Extensions;` for `Emit*` methods

--- a/docs/getting-started/visual-guide.md
+++ b/docs/getting-started/visual-guide.md
@@ -554,10 +554,10 @@ You get automatic lifecycle, automatic cleanup, full observability, and predicta
 
 ```csharp
 // Cancel invalid damage
-_ = token.RegisterBroadcastInterceptor<TookDamage>(
-    (ref InstanceId source, ref TookDamage msg) => {
+_ = token.RegisterTargetedInterceptor<ApplyDamage>(
+    (ref InstanceId target, ref ApplyDamage msg) => {
         if (msg.amount <= 0) return false;  // Cancel invalid damage
-        if (IsInvincible(source)) return false;  // Cancel during invincibility
+        if (IsInvincible(target)) return false;  // Cancel during invincibility
         return true;  // Allow
     }
 );

--- a/docs/guides/advanced.md
+++ b/docs/guides/advanced.md
@@ -268,17 +268,22 @@ After (DxMessaging + token lifecycle)
 using DxMessaging.Core.Attributes;
 using DxMessaging.Core.Extensions;
 using DxMessaging.Core.Messages;
+using UnityEngine;
 
-[DxUntargetedMessage]
+[DxBroadcastMessage]
 [DxAutoConstructor]
 public readonly partial struct Spawned { }
 
 // Producer
-var evt = new Spawned();
-evt.Emit();
+public sealed class Spawner : MonoBehaviour {
+    public void Spawn() {
+        var evt = new Spawned();
+        evt.EmitComponentBroadcast(this);
+    }
+}
 
 // Consumer (Unity)
-_ = token.RegisterUntargeted<Spawned>(OnSpawned);
+_ = token.RegisterComponentBroadcast<Spawned>(spawner, OnSpawned);
 void OnSpawned(ref Spawned m) => Refresh();
 ```
 

--- a/docs/guides/inspector-overlay.md
+++ b/docs/guides/inspector-overlay.md
@@ -300,10 +300,10 @@ public sealed class HealthComponent : MessageAwareComponent
     protected override void RegisterMessageHandlers()
     {
         base.RegisterMessageHandlers();
-        _ = Token.RegisterComponentTargeted<TookDamage>(this, OnHit);
+        _ = Token.RegisterComponentTargeted<ApplyDamage>(this, OnHit);
     }
 
-    private void OnHit(ref TookDamage m) => Debug.Log($"hit for {m.amount}");
+    private void OnHit(ref ApplyDamage m) => Debug.Log($"hit for {m.amount}");
 }
 ```
 

--- a/docs/guides/migration-guide.md
+++ b/docs/guides/migration-guide.md
@@ -366,7 +366,7 @@ public class Player : MonoBehaviour {
 // player.OnHealthChanged += UpdateBar;
 
 // NEW
-_ = Token.RegisterBroadcast<HealthChanged>(OnHealthChanged);
+_ = Token.RegisterGameObjectBroadcast<HealthChanged>(playerObject, OnHealthChanged);
 ```
 
 ### L Pitfall 3: Mixing Message Types Incorrectly

--- a/docs/guides/patterns.md
+++ b/docs/guides/patterns.md
@@ -173,10 +173,10 @@ Use interceptors to enforce rules before handlers run.
 using DxMessaging.Core; // MessageHandler
 
 var bus = MessageHandler.MessageBus;
-_ = token.RegisterBroadcastInterceptor<TookDamage>((ref InstanceId source, ref TookDamage m) =>
+_ = token.RegisterTargetedInterceptor<ApplyDamage>((ref InstanceId target, ref ApplyDamage m) =>
 {
     if (m.amount <= 0) return false; // cancel
-    m = new TookDamage(Math.Min(m.amount, 999)); // clamp
+    m = new ApplyDamage(Math.Min(m.amount, 999)); // clamp
     return true;
 }, priority: 0);
 ```
@@ -186,7 +186,8 @@ _ = token.RegisterBroadcastInterceptor<TookDamage>((ref InstanceId source, ref T
 Post-processors run after handlers -- ideal for metrics.
 
 ```csharp
-_ = token.RegisterUntargetedPostProcessor<SceneLoaded>((ref SceneLoaded m) => Metrics.TrackScene(m.buildIndex));
+_ = token.RegisterUntargetedPostProcessor<SceneLoaded>(
+    (ref SceneLoaded m) => Metrics.RecordProcessedSceneLoad(m.buildIndex));
 ```
 
 ## 6) Local Bus Islands
@@ -414,8 +415,8 @@ public class Boss : MessageAwareComponent {
 **Challenge:** Coordinate 20+ UI panels reacting to game state without tight coupling.
 
 ```csharp
-// Game state messages (global)
-[DxUntargetedMessage]
+// Player-owned state snapshots are broadcasts from that player.
+[DxBroadcastMessage]
 [DxAutoConstructor]
 public readonly partial struct PlayerStatsChanged {
     public readonly int health;
@@ -423,7 +424,7 @@ public readonly partial struct PlayerStatsChanged {
     public readonly int gold;
 }
 
-[DxUntargetedMessage]
+[DxBroadcastMessage]
 [DxAutoConstructor]
 public readonly partial struct InventoryChanged { public readonly int itemCount; }
 
@@ -431,40 +432,40 @@ public readonly partial struct InventoryChanged { public readonly int itemCount;
 public class HealthPanel : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
         base.RegisterMessageHandlers();
-        _ = Token.RegisterUntargeted<PlayerStatsChanged>(OnStats);
+        _ = Token.RegisterBroadcastWithoutSource<PlayerStatsChanged>(OnStats);
     }
-    void OnStats(ref PlayerStatsChanged msg) => UpdateHealth(msg.health);
+    void OnStats(InstanceId player, PlayerStatsChanged msg) => UpdateHealth(player, msg.health);
 }
 
 public class ManaPanel : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
         base.RegisterMessageHandlers();
-        _ = Token.RegisterUntargeted<PlayerStatsChanged>(OnStats);
+        _ = Token.RegisterBroadcastWithoutSource<PlayerStatsChanged>(OnStats);
     }
-    void OnStats(ref PlayerStatsChanged msg) => UpdateMana(msg.mana);
+    void OnStats(InstanceId player, PlayerStatsChanged msg) => UpdateMana(player, msg.mana);
 }
 
 public class GoldPanel : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
         base.RegisterMessageHandlers();
-        _ = Token.RegisterUntargeted<PlayerStatsChanged>(OnStats);
+        _ = Token.RegisterBroadcastWithoutSource<PlayerStatsChanged>(OnStats);
     }
-    void OnStats(ref PlayerStatsChanged msg) => UpdateGold(msg.gold);
+    void OnStats(InstanceId player, PlayerStatsChanged msg) => UpdateGold(player, msg.gold);
 }
 
 public class InventoryPanel : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
         base.RegisterMessageHandlers();
-        _ = Token.RegisterUntargeted<InventoryChanged>(OnInventory);
+        _ = Token.RegisterBroadcastWithoutSource<InventoryChanged>(OnInventory);
     }
-    void OnInventory(ref InventoryChanged msg) => Refresh();
+    void OnInventory(InstanceId player, InventoryChanged msg) => Refresh(player);
 }
 
 // Game systems emit once, all panels update
 public class PlayerStats : MonoBehaviour {
     void UpdateStats() {
         var msg = new PlayerStatsChanged(health, mana, gold);
-        msg.Emit(); // All 3 panels update automatically
+        msg.EmitGameObjectBroadcast(gameObject); // All 3 panels update automatically
     }
 }
 ```
@@ -479,13 +480,13 @@ public class PlayerStats : MonoBehaviour {
 
 ```csharp
 //  DON'T: Separate message per UI element (too granular)
-[DxUntargetedMessage] public struct HealthChanged { public int health; }
-[DxUntargetedMessage] public struct ManaChanged { public int mana; }
-[DxUntargetedMessage] public struct GoldChanged { public int gold; }
+[DxBroadcastMessage] public struct HealthChanged { public int health; }
+[DxBroadcastMessage] public struct ManaChanged { public int mana; }
+[DxBroadcastMessage] public struct GoldChanged { public int gold; }
 // This creates 3x message traffic and registration overhead
 
 //  DO: Batch related updates into one message
-[DxUntargetedMessage] public struct PlayerStatsChanged {
+[DxBroadcastMessage] public struct PlayerStatsChanged {
     public int health;
     public int mana;
     public int gold;
@@ -557,19 +558,26 @@ msg.Emit();
 **Challenge:** Validate 1000s of messages without duplicating logic.
 
 ```csharp
-// Single interceptor validates ALL damage
+[DxTargetedMessage]
+[DxAutoConstructor]
+public readonly partial struct ApplyDamage {
+    public readonly int amount;
+    public readonly DamageType damageType;
+}
+
+// Single interceptor validates ALL targeted damage commands
 public class DamageValidator : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
         base.RegisterMessageHandlers();
         // Interceptors run BEFORE handlers
-        _ = Token.RegisterBroadcastInterceptor<EntityDamaged>(ValidateDamage, priority: -100);
+        _ = Token.RegisterTargetedInterceptor<ApplyDamage>(ValidateDamage, priority: -100);
     }
 
-    bool ValidateDamage(ref InstanceId source, ref EntityDamaged msg) {
+    bool ValidateDamage(ref InstanceId target, ref ApplyDamage msg) {
         // Validation logic runs once per message, not per handler
         if (msg.amount <= 0) return false; // Cancel invalid
         if (msg.amount > 9999) {
-            msg = new EntityDamaged(9999, msg.damageType); // Clamp
+            msg = new ApplyDamage(9999, msg.damageType); // Clamp
         }
         return true; // Allow to proceed to handlers
     }
@@ -579,12 +587,14 @@ public class DamageValidator : MessageAwareComponent {
 public class CombatEntity : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
         base.RegisterMessageHandlers();
-        _ = Token.RegisterComponentBroadcast<EntityDamaged>(this, OnDamaged);
+        _ = Token.RegisterComponentTargeted<ApplyDamage>(this, OnApplyDamage);
     }
 
-    void OnDamaged(ref EntityDamaged msg) {
+    void OnApplyDamage(ref ApplyDamage msg) {
         // No need to validate - interceptor already did it
         health -= msg.amount;
+        var fact = new EntityDamaged(msg.amount, msg.damageType);
+        fact.EmitComponentBroadcast(this);
     }
 }
 ```
@@ -600,11 +610,15 @@ public class GameAnalytics : MessageAwareComponent {
     protected override void RegisterMessageHandlers() {
         base.RegisterMessageHandlers();
         // Record completed dispatch after gameplay handlers have run.
-        _ = Token.RegisterBroadcastWithoutSourcePostProcessor<EntityDamaged>(LogDamage, priority: 100);
-        _ = Token.RegisterUntargetedPostProcessor<LevelCompleted>(LogLevelComplete, priority: 100);
+        _ = Token.RegisterBroadcastWithoutSourcePostProcessor<EntityDamaged>(
+            RecordProcessedDamageMessage,
+            priority: 100);
+        _ = Token.RegisterUntargetedPostProcessor<LevelCompleted>(
+            RecordProcessedLevelCompletion,
+            priority: 100);
     }
 
-    void LogDamage(InstanceId source, EntityDamaged msg) {
+    void RecordProcessedDamageMessage(InstanceId source, EntityDamaged msg) {
         SendAnalyticsEvent("damage_message_processed", new {
             source = source.ToString(),
             amount = msg.amount,
@@ -612,8 +626,8 @@ public class GameAnalytics : MessageAwareComponent {
         });
     }
 
-    void LogLevelComplete(ref LevelCompleted msg) {
-        SendAnalyticsEvent("level_complete", new { level = msg.levelIndex });
+    void RecordProcessedLevelCompletion(ref LevelCompleted msg) {
+        SendAnalyticsEvent("level_completion_message_processed", new { level = msg.levelIndex });
     }
 }
 ```
@@ -661,7 +675,7 @@ _ = Token.RegisterUntargeted<LevelCompleted>(OnLevelComplete);
 void TakeDamage(int amount) {
     health -= amount;
     var msg = new HealthChanged(health);
-    msg.Emit(); // Emits every frame
+    msg.EmitGameObjectBroadcast(gameObject); // Emits every frame
 }
 ```
 
@@ -677,7 +691,7 @@ void TakeDamage(int amount) {
 void LateUpdate() {
     if (healthDirty) {
         var msg = new HealthChanged(health);
-        msg.Emit(); // Emits once per frame max
+        msg.EmitGameObjectBroadcast(gameObject); // Emits once per frame max
         healthDirty = false;
     }
 }
@@ -767,10 +781,11 @@ public class MatchStats : MessageAwareComponent {
 
     protected override void RegisterMessageHandlers() {
         base.RegisterMessageHandlers();
-        _ = Token.RegisterBroadcastWithoutSourcePostProcessor<PlayerDamaged>(TrackDamage);
+        _ = Token.RegisterBroadcastWithoutSourcePostProcessor<PlayerDamaged>(
+            CountProcessedDamageMessage);
     }
 
-    void TrackDamage(InstanceId source, PlayerDamaged msg) {
+    void CountProcessedDamageMessage(InstanceId source, PlayerDamaged msg) {
         processedDamageMessagesByPlayer.TryGetValue(msg.playerId, out int count);
         processedDamageMessagesByPlayer[msg.playerId] = count + 1;
     }

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -146,15 +146,15 @@ public IEnumerator InterceptorCanModifyMessage()
     MessageRegistrationToken token = GetToken(host.GetComponent<EmptyMessageAwareComponent>());
 
     int receivedAmount = 0;
-    _ = token.RegisterUntargeted<DamageMessage>(msg => receivedAmount = msg.amount);
-    _ = token.RegisterUntargetedInterceptor((ref DamageMessage msg) =>
+    _ = token.RegisterGameObjectTargeted<DamageMessage>(host, msg => receivedAmount = msg.amount);
+    _ = token.RegisterTargetedInterceptor((ref InstanceId _, ref DamageMessage msg) =>
     {
         if (msg.amount > 100) msg = new DamageMessage { amount = 100 };
         return true;
     });
 
     DamageMessage msg = new() { amount = 999 };
-    msg.EmitUntargeted();
+    msg.EmitGameObjectTargeted(host);
 
     Assert.AreEqual(100, receivedAmount, "Interceptor should clamp damage to 100.");
     yield break;

--- a/docs/guides/unity-integration.md
+++ b/docs/guides/unity-integration.md
@@ -25,11 +25,11 @@ public sealed class HealthComponent : MessageAwareComponent
     protected override void RegisterMessageHandlers()
     {
         base.RegisterMessageHandlers();
-        _ = Token.RegisterComponentTargeted<TookDamage>(this, OnTookDamage);
+        _ = Token.RegisterComponentTargeted<ApplyDamage>(this, OnApplyDamage);
         _ = Token.RegisterUntargeted<WorldRegenerated>(OnWorldRegenerated);
     }
 
-    private void OnTookDamage(ref TookDamage m) => Apply(m.amount);
+    private void OnApplyDamage(ref ApplyDamage m) => Apply(m.amount);
     private void OnWorldRegenerated(ref WorldRegenerated m) => Reset();
 }
 ```
@@ -82,14 +82,14 @@ public sealed class InventoryUI : UnityEngine.MonoBehaviour
         _messaging = GetComponent<MessagingComponent>();
         _token = _messaging.Create(this);
         _ = _token.RegisterUntargeted<WorldRegenerated>(OnWorld);
-        _ = _token.RegisterComponentTargeted<TookDamage>(this, OnDamage);
+        _ = _token.RegisterComponentTargeted<ApplyDamage>(this, OnDamage);
     }
 
     private void OnEnable() => _token.Enable();
     private void OnDisable() => _token.Disable();
 
     private void OnWorld(ref WorldRegenerated m) { /* update UI */ }
-    private void OnDamage(ref TookDamage m) { /* flash damage */ }
+    private void OnDamage(ref ApplyDamage m) { /* apply damage */ }
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,40 +43,68 @@ using DxMessaging.Core.Attributes;
 using DxMessaging.Core.Extensions;
 using DxMessaging.Unity;
 using UnityEngine;
+using UnityEngine.UI;
 
 [DxTargetedMessage]
 [DxAutoConstructor]
-public readonly partial struct Heal
+public readonly partial struct HealPlayerRequested
 {
     public readonly int Amount;
 }
 
 public sealed class PlayerHealth : MessageAwareComponent
 {
+    private const int MaximumHealth = 100;
+
+    public int CurrentHealth { get; private set; } = 50;
+
     protected override void RegisterMessageHandlers()
     {
         base.RegisterMessageHandlers();
-        Token.RegisterGameObjectTargeted<Heal>(gameObject, OnHeal);
+        _ = Token.RegisterGameObjectTargeted<HealPlayerRequested>(gameObject, OnHealRequested);
     }
 
-    private void OnHeal(ref Heal message)
+    private void OnHealRequested(ref HealPlayerRequested message)
     {
-        // Apply the heal to this player.
+        CurrentHealth = Mathf.Min(MaximumHealth, CurrentHealth + Mathf.Max(0, message.Amount));
     }
 }
 
+[RequireComponent(typeof(Button))]
 public sealed class HealButton : MonoBehaviour
 {
-    [SerializeField]
-    private GameObject _player;
+    private Button _button;
+    private PlayerHealth _playerHealth;
 
-    public void Click()
+    private void Awake()
     {
-        Heal heal = new Heal(25);
-        heal.EmitGameObjectTargeted(_player);
+        _button = GetComponent<Button>();
+        _playerHealth = GetComponentInParent<PlayerHealth>();
+        if (_playerHealth == null)
+        {
+            Debug.LogError("HealButton must be placed under a PlayerHealth component.", this);
+            return;
+        }
+        _button.onClick.AddListener(Click);
+    }
+
+    private void OnDestroy()
+    {
+        _button.onClick.RemoveListener(Click);
+    }
+
+    private void Click()
+    {
+        HealPlayerRequested request = new HealPlayerRequested(25);
+        request.EmitGameObjectTargeted(_playerHealth.gameObject);
     }
 }
 ```
+
+Put `HealButton` on a Unity `Button` under the player's `PlayerHealth` object. The component
+wires the click and finds that player automatically; there is no `On Click` event or player
+reference to assign in the Inspector. The heal request is targeted because it changes one
+player's health.
 
 ## Why Teams Use It
 

--- a/docs/integrations/reflex.md
+++ b/docs/integrations/reflex.md
@@ -63,7 +63,7 @@ using System;
 using DxMessaging.Core.Attributes;
 using DxMessaging.Core.MessageBus;
 
-[DxUntargetedMessage]
+[DxBroadcastMessage]
 [DxAutoConstructor]
 public readonly partial struct PlayerDamaged
 {
@@ -80,7 +80,7 @@ public sealed class DamageService : IDisposable
         {
             Configure = token =>
             {
-                _ = token.RegisterUntargeted<PlayerDamaged>(OnPlayerDamaged);
+                _ = token.RegisterBroadcastWithoutSource<PlayerDamaged>(OnPlayerDamaged);
             },
         };
 
@@ -99,7 +99,7 @@ public sealed class DamageService : IDisposable
         _lease.Dispose();
     }
 
-    private void OnPlayerDamaged(ref PlayerDamaged message)
+    private void OnPlayerDamaged(DxMessaging.Core.InstanceId player, PlayerDamaged message)
     {
         LastDamage = message.damage;
     }
@@ -252,7 +252,8 @@ public sealed class DamageServiceTests
         service.Initialize();
 
         PlayerDamaged message = new(25);
-        bus.EmitUntargeted(ref message);
+        DxMessaging.Core.InstanceId player = new(42);
+        bus.SourcedBroadcast(ref player, ref message);
 
         Assert.That(service.LastDamage, Is.EqualTo(25));
     }

--- a/docs/integrations/vcontainer.md
+++ b/docs/integrations/vcontainer.md
@@ -70,10 +70,11 @@ Use `IMessageRegistrationBuilder` to create message handlers in non-MonoBehaviou
 ```csharp
 using DxMessaging.Core.MessageBus;
 using DxMessaging.Core.Attributes;
+using DxMessaging.Core;
 using VContainer.Unity;
 
 // Define a message
-[DxUntargetedMessage]
+[DxBroadcastMessage]
 [DxAutoConstructor]
 public readonly partial struct PlayerSpawned
 {
@@ -92,7 +93,7 @@ public sealed class PlayerService : IStartable, IDisposable
         {
             Configure = token =>
             {
-                _ = token.RegisterUntargeted<PlayerSpawned>(OnPlayerSpawned);
+                _ = token.RegisterBroadcastWithoutSource<PlayerSpawned>(OnPlayerSpawned);
             }
         };
 
@@ -109,7 +110,7 @@ public sealed class PlayerService : IStartable, IDisposable
         _lease.Dispose();   // Clean up when container disposes
     }
 
-    private static void OnPlayerSpawned(ref PlayerSpawned message)
+    private static void OnPlayerSpawned(InstanceId player, PlayerSpawned message)
     {
         UnityEngine.Debug.Log($"Player {message.playerId} spawned!");
     }

--- a/docs/integrations/zenject.md
+++ b/docs/integrations/zenject.md
@@ -65,10 +65,11 @@ Use `IMessageRegistrationBuilder` to create message handlers in non-MonoBehaviou
 ```csharp
 using DxMessaging.Core.MessageBus;
 using DxMessaging.Core.Attributes;
+using DxMessaging.Core;
 using Zenject;
 
 // Define a message
-[DxUntargetedMessage]
+[DxBroadcastMessage]
 [DxAutoConstructor]
 public readonly partial struct PlayerSpawned
 {
@@ -87,7 +88,7 @@ public sealed class PlayerController : IInitializable, IDisposable
         {
             Configure = token =>
             {
-                _ = token.RegisterUntargeted<PlayerSpawned>(OnPlayerSpawned);
+                _ = token.RegisterBroadcastWithoutSource<PlayerSpawned>(OnPlayerSpawned);
             }
         };
 
@@ -104,7 +105,7 @@ public sealed class PlayerController : IInitializable, IDisposable
         _lease.Dispose();   // Clean up when container disposes
     }
 
-    private static void OnPlayerSpawned(ref PlayerSpawned message)
+    private static void OnPlayerSpawned(InstanceId player, PlayerSpawned message)
     {
         UnityEngine.Debug.Log($"Player {message.playerId} spawned!");
     }

--- a/docs/reference/analyzers.md
+++ b/docs/reference/analyzers.md
@@ -40,13 +40,13 @@ Pick exactly one message-shape attribute. A message can be Broadcast, Targeted, 
 //  Multiple shapes on one type
 [DxBroadcastMessage]
 [DxTargetedMessage]
-public readonly partial struct Healed { public readonly int amount; }
+public readonly partial struct Heal { public readonly int amount; }
 ```
 
 ```csharp
 //  One shape per type
 [DxTargetedMessage]
-public readonly partial struct Healed { public readonly int amount; }
+public readonly partial struct Heal { public readonly int amount; }
 ```
 
 ---

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -56,34 +56,38 @@ public class MyComponent : MessageAwareComponent {
 
 Code that runs **before** handlers. Can **validate, modify, or cancel** messages before anyone else sees them.
 
-Example: "Only allow damage between 1 and 999"
+Example: "Only allow an apply-damage request between 1 and 999"
 
 ```csharp
 // Use the type-specific interceptor variant based on your message type:
 // - RegisterUntargetedInterceptor<T> for IUntargetedMessage
 // - RegisterTargetedInterceptor<T> for ITargetedMessage
 // - RegisterBroadcastInterceptor<T> for IBroadcastMessage
-_ = token.RegisterBroadcastInterceptor<Damage>((ref InstanceId source, ref Damage msg) => {
+_ = token.RegisterTargetedInterceptor<ApplyDamage>((ref InstanceId target, ref ApplyDamage msg) => {
     if (msg.amount <= 0) return false; // Cancel
-    if (msg.amount > 999) msg = new Damage(999); // Clamp
+    if (msg.amount > 999) msg = new ApplyDamage(999); // Clamp
     return true; // Allow
 });
 ```
 
 ### Post-Processor
 
-Code that runs **after** all handlers. Perfect for **logging, analytics, or metrics** that shouldn't affect gameplay.
+Code that runs **after** all handlers. Use it to record completed dispatch for logging,
+analytics, metrics, or replay without changing gameplay state.
 
-Example: "Track every damage event for statistics"
+Example: "Count every processed damage message for telemetry"
 
 ```csharp
 // Use the type-specific post-processor variant based on your message type:
 // - RegisterUntargetedPostProcessor<T> for IUntargetedMessage
-// - RegisterBroadcastWithoutSourcePostProcessor<T> for IBroadcastMessage from any source
-_ = token.RegisterBroadcastWithoutSourcePostProcessor<Damage>((InstanceId source, Damage msg) => {
-    Analytics.LogDamage(source, msg.amount);
+// - RegisterTargetedWithoutTargetingPostProcessor<T> for ITargetedMessage to any target
+_ = token.RegisterTargetedWithoutTargetingPostProcessor<ApplyDamage>((ref InstanceId target, ref ApplyDamage msg) => {
+    Analytics.RecordProcessedDamageRequest(target, msg.amount);
 });
 ```
+
+The message payload describes the request that completed dispatch. It does not prove how a
+handler changed health or another gameplay value.
 
 ### Priority
 
@@ -121,7 +125,7 @@ To **send** a message. Like hitting "send" on an email.
 
 ```csharp
 var heal = new Heal(10);
-heal.Emit(); // Send it!
+heal.EmitGameObjectTargeted(player); // Send it to one player
 ```
 
 ### Register
@@ -129,7 +133,7 @@ heal.Emit(); // Send it!
 To **sign up** to receive messages. Like subscribing to a newsletter.
 
 ```csharp
-_ = Token.RegisterUntargeted<Heal>(OnHeal); // Subscribe
+_ = Token.RegisterGameObjectTargeted<Heal>(player, OnHeal); // Subscribe to this player
 ```
 
 ## Advanced Terms

--- a/docs/reference/helpers.md
+++ b/docs/reference/helpers.md
@@ -472,7 +472,6 @@ public readonly partial struct PlayerDamaged
 {
     public readonly int amount;
     public readonly string damageType;
-    public readonly GameObject source;
 }
 ```
 
@@ -484,13 +483,11 @@ public readonly partial struct PlayerDamaged : IBroadcastMessage<PlayerDamaged>
 {
     public readonly int amount;
     public readonly string damageType;
-    public readonly GameObject source;
 
-    public PlayerDamaged(int amount, string damageType, GameObject source)
+    public PlayerDamaged(int amount, string damageType)
     {
         this.amount = amount;
         this.damageType = damageType;
-        this.source = source;
     }
 
     public Type MessageType => typeof(PlayerDamaged);
@@ -772,13 +769,13 @@ public readonly partial struct Heal
 ```csharp
 [DxBroadcastMessage]
 [DxAutoConstructor]
-public readonly partial struct Attack
+public readonly partial struct AttackPerformed
 {
     public readonly int damage;
     [DxOptionalParameter]
     public readonly string damageType;
 }
-// Auto-generates: Attack(int damage, string damageType = default)
+// Auto-generates: AttackPerformed(int damage, string damageType = default)
 ```
 
 ### Pattern 4: Complex Message
@@ -808,9 +805,9 @@ public partial class GameEvents
 {
     [DxUntargetedMessage]
     [DxAutoConstructor]
-    public readonly partial struct LevelUp
+    public readonly partial struct DifficultyChanged
     {
-        public readonly int newLevel;
+        public readonly int difficulty;
     }
 
     [DxTargetedMessage]
@@ -822,8 +819,8 @@ public partial class GameEvents
 }
 
 // Usage:
-var levelUp = new GameEvents.LevelUp(5);
-levelUp.Emit();
+var difficulty = new GameEvents.DifficultyChanged(5);
+difficulty.Emit();
 ```
 
 #### Benefits

--- a/docs/reference/quick-reference.md
+++ b/docs/reference/quick-reference.md
@@ -32,6 +32,10 @@ public readonly partial struct SceneLoaded { public readonly int buildIndex; }
 [DxAutoConstructor]
 public readonly partial struct Heal { public readonly int amount; }
 
+[DxTargetedMessage]
+[DxAutoConstructor]
+public readonly partial struct ApplyDamage { public readonly int amount; }
+
 [DxBroadcastMessage]
 [DxAutoConstructor]
 public readonly partial struct TookDamage { public readonly int amount; }
@@ -93,7 +97,7 @@ public sealed class DamageSystem : IStartable, IDisposable
         {
             Configure = token =>
             {
-                _ = token.RegisterUntargeted<TookDamage>(OnDamage);
+                _ = token.RegisterUntargeted<CombatStarted>(OnCombatStarted);
             }
         });
     }
@@ -102,7 +106,7 @@ public sealed class DamageSystem : IStartable, IDisposable
 
     public void Dispose() => lease.Dispose();
 
-    private static void OnDamage(ref TookDamage message) { /* respond */ }
+    private static void OnCombatStarted(ref CombatStarted message) { /* respond */ }
 }
 ```
 
@@ -123,7 +127,7 @@ public sealed class DamageRules : IDisposable
     public DamageRules(IMessageBus bus)
     {
         _bus = bus;
-        _interceptor = bus.RegisterBroadcastInterceptor<TookDamage>(ClampDamage);
+        _interceptor = bus.RegisterTargetedInterceptor<ApplyDamage>(ClampDamage);
     }
 
     public void Dispose()
@@ -132,17 +136,17 @@ public sealed class DamageRules : IDisposable
         {
             return;
         }
-        _bus.Deregister<TookDamage>(in _interceptor);
+        _bus.Deregister<ApplyDamage>(in _interceptor);
         _interceptor = MessageBusRegistration.None;
     }
 
-    private static bool ClampDamage(ref InstanceId source, ref TookDamage message)
+    private static bool ClampDamage(ref InstanceId target, ref ApplyDamage message)
     {
         if (message.amount <= 0)
         {
             return false; // cancel
         }
-        message = new TookDamage(Math.Min(message.amount, 999));
+        message = new ApplyDamage(Math.Min(message.amount, 999));
         return true;
     }
 }
@@ -151,7 +155,8 @@ public sealed class DamageRules : IDisposable
 Token registrations remain token-owned:
 
 ```csharp
-_ = token.RegisterUntargetedPostProcessor<SceneLoaded>((ref SceneLoaded m) => metrics.RecordLoadedScene(m.buildIndex));
+_ = token.RegisterUntargetedPostProcessor<SceneLoaded>(
+    (ref SceneLoaded m) => metrics.RecordProcessedSceneLoad(m.buildIndex));
 ```
 
 Direct bus registrations are not token-owned. Retain each `MessageBusRegistration` on the
@@ -270,11 +275,14 @@ _ = token.RegisterUntargeted<SceneLoaded>(OnSceneLoaded, priority: 0);
 _ = token.RegisterUntargeted<SceneLoaded>(OnSceneLoadedFast, priority: 0);
 
 // Post-processor
-_ = token.RegisterUntargetedPostProcessor<SceneLoaded>(AfterSceneLoaded, priority: 0);
+_ = token.RegisterUntargetedPostProcessor<SceneLoaded>(
+    RecordProcessedSceneLoad,
+    priority: 0);
 
 void OnSceneLoaded(SceneLoaded message) => scenePresenter.Show(message.buildIndex);
 void OnSceneLoadedFast(ref SceneLoaded message) => scenePresenter.Show(message.buildIndex);
-void AfterSceneLoaded(ref SceneLoaded message) => metrics.RecordLoadedScene(message.buildIndex);
+void RecordProcessedSceneLoad(ref SceneLoaded message) =>
+    metrics.RecordProcessedSceneLoad(message.buildIndex);
 ```
 
 ### Token: Targeted (Specific)
@@ -285,10 +293,14 @@ _ = token.RegisterComponentTargeted<Heal>(this, OnHeal, priority: 0);
 _ = token.RegisterTargeted<Heal>(targetInstanceId, OnHeal, priority: 0);
 
 // Post-processor
-_ = token.RegisterTargetedPostProcessor<Heal>(targetInstanceId, AfterHeal, priority: 0);
+_ = token.RegisterTargetedPostProcessor<Heal>(
+    targetInstanceId,
+    RecordProcessedHealRequest,
+    priority: 0);
 
 void OnHeal(ref Heal message) => health.Apply(message.amount);
-void AfterHeal(ref Heal message) => metrics.RecordProcessedHealRequest(message.amount);
+void RecordProcessedHealRequest(ref Heal message) =>
+    metrics.RecordProcessedHealRequest(message.amount);
 ```
 
 ### Token: Targeted (All Targets)
@@ -298,12 +310,14 @@ void AfterHeal(ref Heal message) => metrics.RecordProcessedHealRequest(message.a
 _ = token.RegisterTargetedWithoutTargeting<Heal>(OnAnyHeal, priority: 0);
 
 // Post-processor
-_ = token.RegisterTargetedWithoutTargetingPostProcessor<Heal>(AfterAnyHeal, priority: 0);
+_ = token.RegisterTargetedWithoutTargetingPostProcessor<Heal>(
+    RecordProcessedHealRequest,
+    priority: 0);
 
 void OnAnyHeal(ref InstanceId target, ref Heal message) =>
-    combatFeed.ShowHeal(target, message.amount);
-void AfterAnyHeal(ref InstanceId target, ref Heal message) =>
-    metrics.RecordHeal(target, message.amount);
+    combatFeed.ShowRequestedHeal(target, message.amount);
+void RecordProcessedHealRequest(ref InstanceId target, ref Heal message) =>
+    metrics.RecordProcessedHealRequest(target, message.amount);
 ```
 
 ### Token: Broadcast (Specific)
@@ -314,10 +328,14 @@ _ = token.RegisterComponentBroadcast<TookDamage>(this, OnDamage, priority: 0);
 _ = token.RegisterBroadcast<TookDamage>(sourceInstanceId, OnDamage, priority: 0);
 
 // Post-processor
-_ = token.RegisterBroadcastPostProcessor<TookDamage>(sourceInstanceId, AfterDamage, priority: 0);
+_ = token.RegisterBroadcastPostProcessor<TookDamage>(
+    sourceInstanceId,
+    RecordProcessedDamageMessage,
+    priority: 0);
 
 void OnDamage(ref TookDamage message) => damageEffects.Play(message.amount);
-void AfterDamage(ref TookDamage message) => replay.RecordDamage(message.amount);
+void RecordProcessedDamageMessage(ref TookDamage message) =>
+    replay.RecordProcessedDamageMessage(message.amount);
 ```
 
 ### Token: Broadcast (All Sources)
@@ -327,12 +345,14 @@ void AfterDamage(ref TookDamage message) => replay.RecordDamage(message.amount);
 _ = token.RegisterBroadcastWithoutSource<TookDamage>(OnAnyDamage, priority: 0);
 
 // Post-processor
-_ = token.RegisterBroadcastWithoutSourcePostProcessor<TookDamage>(AfterAnyDamage, priority: 0);
+_ = token.RegisterBroadcastWithoutSourcePostProcessor<TookDamage>(
+    RecordProcessedDamageMessage,
+    priority: 0);
 
 void OnAnyDamage(ref InstanceId source, ref TookDamage message) =>
     damageNumbers.Show(source, message.amount);
-void AfterAnyDamage(ref InstanceId source, ref TookDamage message) =>
-    replay.RecordDamage(source, message.amount);
+void RecordProcessedDamageMessage(ref InstanceId source, ref TookDamage message) =>
+    replay.RecordProcessedDamageMessage(source, message.amount);
 ```
 
 ### Token: Global Observer

--- a/docs/reference/reference.md
+++ b/docs/reference/reference.md
@@ -202,8 +202,8 @@ Component.
 
 ```csharp
 // Quick string message emission
-"PlayerDied".Emit();
-"DamageDealt".Emit(targetInstanceId);
+"PlayerDied".EmitFrom(gameObject);
+"ApplyDamage".Emit(targetInstanceId);
 ```
 
 ---

--- a/scripts/__tests__/ci-aggregate-workflow.test.js
+++ b/scripts/__tests__/ci-aggregate-workflow.test.js
@@ -48,37 +48,11 @@ const UNITY_LOCK_WINDOWS = [
   ["perf-numbers.yml", "perf-benchmarks", "Run Unity Test Runner", true]
 ];
 
-const CONSOLIDATED_WORKFLOWS = [
-  "actionlint.yml",
-  "csharpier-check.yml",
-  "dotnet-tests.yml",
-  "json-format-check.yml",
-  "lint-doc-links.yml",
-  "markdownlint.yml",
-  "script-tests.yml",
-  "spellcheck.yml",
-  "validate-banner.yml",
-  "validate-docs.yml",
-  "validate-llms-txt.yml",
-  "yaml-format-lint.yml"
-];
+// prettier-ignore
+const CONSOLIDATED_WORKFLOWS = ["actionlint.yml", "csharpier-check.yml", "dotnet-tests.yml", "json-format-check.yml", "lint-doc-links.yml", "markdownlint.yml", "script-tests.yml", "spellcheck.yml", "validate-banner.yml", "validate-docs.yml", "validate-llms-txt.yml", "yaml-format-lint.yml"];
 
-const AGGREGATED_JOBS = [
-  "changes",
-  "actionlint",
-  "markdownlint",
-  "csharpier",
-  "dotnet",
-  "json-format",
-  "line-endings",
-  "spellcheck",
-  "validate-banner",
-  "validate-llms-txt",
-  "yaml-format-lint",
-  "script-tests",
-  "validate-docs",
-  "lint-doc-links"
-];
+// prettier-ignore
+const AGGREGATED_JOBS = ["changes", "actionlint", "markdownlint", "csharpier", "dotnet", "json-format", "line-endings", "spellcheck", "validate-banner", "validate-llms-txt", "yaml-format-lint", "script-tests", "validate-docs", "lint-doc-links"];
 
 // cspell:ignore ACDMRT
 const STATIC_CHILD_JOBS = [
@@ -631,13 +605,39 @@ test("Unity CI defers every post-activation return to the central action", () =>
   }
 });
 
-test("Unity Tests classifies Dependabot pull requests by immutable PR author", () => {
-  const source = fs.readFileSync(path.join(WORKFLOW_DIR, "unity-tests.yml"), "utf8");
-  const preflight = getJobBlock(source, "runner-preflight", "unity-tests.yml");
-  const licensed = getJobBlock(source, "unity-tests", "unity-tests.yml");
-  const aggregate = getJobBlock(source, "unity-ci-success", "unity-tests.yml");
-
-  for (const job of [preflight, licensed]) {
+test("licensed PR workflows fail closed and skip only documented non-code paths", () => {
+  for (const [file, aggregateId] of [
+    ["unity-tests.yml", "unity-ci-success"],
+    ["perf-numbers.yml", "perf-unity-success"]
+  ]) {
+    const source = readWorkflow(file);
+    const head = getJobBlock(source, "head-check", file);
+    const preflight = getJobBlock(source, "runner-preflight", file);
+    const aggregate = getJobBlock(source, aggregateId, file);
+    assert.match(head, /relevant: \$\{\{ steps\.head\.outputs\.relevant \}\}/);
+    assert.match(head, /Changed-file lookup failed; running licensed/);
+    assert.match(head, /echo "relevant=\$\{relevant\}" >> "\$\{GITHUB_OUTPUT\}"/);
+    const pattern = /documentation_only_pattern='([^']+)'/.exec(head);
+    const allowed = new RegExp(pattern?.[1] ?? "a^");
+    // prettier-ignore
+    for (const path of ["docs/index.md", ".llm/context.md", "Samples~/Mini Combat/README.md", "GOAL.md"])
+      assert.match(path, allowed, `${file}: ${path}`);
+    // prettier-ignore
+    for (const path of [`.github/workflows/${file}`, "Runtime/Core/MessageBus.cs", "Samples~/Mini Combat/Player.cs", "README.md"])
+      assert.doesNotMatch(path, allowed, `${file}: ${path}`);
+    assert.match(preflight, /needs\.head-check\.outputs\.relevant != 'false'/);
+    assert.match(aggregate, /RELEVANT: \$\{\{ needs\.head-check\.outputs\.relevant \}\}/);
+    assert.match(aggregate, /\[ "\$\{RELEVANT\}" = "false" \]/);
+    const gatedId = file === "unity-tests.yml" ? "unity-tests" : "comment-perf-doc";
+    const gated = getJobBlock(source, gatedId, file);
+    assert.match(gated, /needs\.head-check\.outputs\.relevant != 'false'/);
+  }
+  const unity = readWorkflow("unity-tests.yml");
+  const aggregate = getJobBlock(unity, "unity-ci-success", "unity-tests.yml");
+  for (const job of [
+    getJobBlock(unity, "runner-preflight", "unity-tests.yml"),
+    getJobBlock(unity, "unity-tests", "unity-tests.yml")
+  ]) {
     assert.match(job, /github\.event\.pull_request\.user\.login != 'dependabot\[bot\]'/);
     assert.doesNotMatch(job, /github\.actor != 'dependabot\[bot\]'/);
   }

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -814,22 +814,28 @@ def run_script(step: str) -> str:
     return "\n".join(lines)
 
 
-def run_head_check(script: str, event: str, live_head: str) -> str:
-    """Run the head-freshness script against a stub `gh` and return its decision."""
+def run_head_check(
+    script: str, event: str, live_head: str, changed_files: list[str] | None
+) -> dict[str, str]:
+    """Run the head/relevance script against a strict, endpoint-aware `gh` stub."""
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)
         stub = root / "gh"
-        # The stub answers only the live-head lookup, so a script that asked a
-        # different endpoint gets nothing and the truth table below fails. An
-        # empty live head stands for a lookup that failed, so the stub exits
-        # non-zero the way the real CLI does rather than printing nothing.
+        files_response = "\n".join(changed_files or [])
+        files_exit = 0 if changed_files is not None else 1
+        # Answer both API calls made by the production script. Keeping the
+        # endpoints distinct prevents a missing changed-file fixture from
+        # quietly exercising only the fail-closed fallback.
         stub.write_text(
             "#!/bin/sh\n"
             'case "$*" in\n'
-            "  *repos/Ambiguous-Interactive/DxMessaging/pulls/1*.head.sha*) ;;\n"
+            "  *repos/Ambiguous-Interactive/DxMessaging/pulls/1/files*)\n"
+            f"    cat <<'FILES'\n{files_response}\nFILES\n"
+            f"    exit {files_exit} ;;\n"
+            "  *repos/Ambiguous-Interactive/DxMessaging/pulls/1*.head.sha*)\n"
+            f'    [ -n "{live_head}" ] || exit 1\n    echo "{live_head}"\n    exit 0 ;;\n'
             '  *) echo "unexpected gh invocation: $*" >&2; exit 2 ;;\n'
-            "esac\n"
-            f'[ -n "{live_head}" ] || exit 1\necho "{live_head}"\n',
+            "esac\n",
             encoding="utf-8",
         )
         stub.chmod(0o755)
@@ -852,10 +858,94 @@ def run_head_check(script: str, event: str, live_head: str) -> str:
         )
         require(result.returncode == 0, f"head-check script failed: {result.stderr}")
         written = output.read_text(encoding="utf-8").strip()
+        decisions = {}
+        for line in written.splitlines():
+            key, separator, value = line.partition("=")
+            require(separator == "=" and key, f"head-check wrote malformed output: {line!r}")
+            require(key not in decisions, f"head-check wrote duplicate output: {key}")
+            decisions[key] = value
         require(
-            written.startswith("superseded="), f"head-check wrote no decision: {written!r}"
+            set(decisions) == {"relevant", "superseded"},
+            f"head-check must write exactly relevant and superseded: {written!r}",
         )
-        return written[len("superseded=") :]
+        require(
+            all(value in {"true", "false"} for value in decisions.values()),
+            f"head-check decisions must be booleans: {written!r}",
+        )
+        return decisions
+
+
+def validate_head_check_truth_table(script: str, workflow_name: str) -> None:
+    """Exercise current, renamed, mixed, empty, failed, and superseded PR shapes."""
+    if os.name == "nt":
+        return
+    # A rename is represented by both values emitted by the workflow's
+    # `.filename, (.previous_filename // empty)` query.
+    cases = (
+        ("push", "push", "", None, {"superseded": "false", "relevant": "true"}),
+        (
+            "current documentation PR",
+            "pull_request",
+            "current",
+            ["docs/guide.md"],
+            {"superseded": "false", "relevant": "false"},
+        ),
+        (
+            "renamed documentation file",
+            "pull_request",
+            "current",
+            ["docs/new-name.md", "docs/old-name.md"],
+            {"superseded": "false", "relevant": "false"},
+        ),
+        (
+            "code PR",
+            "pull_request",
+            "current",
+            ["Runtime/Core/MessageBus.cs"],
+            {"superseded": "false", "relevant": "true"},
+        ),
+        (
+            "mixed PR",
+            "pull_request",
+            "current",
+            ["docs/guide.md", "Tests/Runtime/MessageBusTests.cs"],
+            {"superseded": "false", "relevant": "true"},
+        ),
+        (
+            "empty file response",
+            "pull_request",
+            "current",
+            [],
+            {"superseded": "false", "relevant": "true"},
+        ),
+        (
+            "failed file lookup",
+            "pull_request",
+            "current",
+            None,
+            {"superseded": "false", "relevant": "true"},
+        ),
+        (
+            "failed live-head lookup",
+            "pull_request",
+            "",
+            ["docs/guide.md"],
+            {"superseded": "false", "relevant": "false"},
+        ),
+        (
+            "superseded documentation PR",
+            "pull_request",
+            "moved-on",
+            ["docs/guide.md"],
+            {"superseded": "true", "relevant": "false"},
+        ),
+    )
+    for name, event, live, files, expected in cases:
+        actual = run_head_check(script, event, live, files)
+        require(
+            actual == expected,
+            f"{workflow_name} head-check {name}: expected {expected}, got {actual}",
+        )
 
 
 def watchdog_gh_stub(routes: dict[str, tuple[int, object]], cancel_ok: bool) -> str:
@@ -3041,6 +3131,68 @@ def validate_perf_pr_policy() -> None:
     )
     for block, pattern, label in checks:
         require(re.search(pattern, block) is not None, f"performance PR policy: missing {label}")
+    head_check = job_block(source, "head-check")
+    require(
+        "      relevant: ${{ steps.head.outputs.relevant }}\n" in head_check
+        and "      superseded: ${{ steps.head.outputs.superseded }}\n" in head_check,
+        "performance head-check must publish relevance and freshness",
+    )
+    head_script = run_script(
+        step_block(head_check, "Compare the event head against the live pull-request head")
+    )
+    validate_head_check_truth_table(head_script, "performance")
+
+    aggregate = job_block(source, "perf-unity-success")
+    aggregate_step = step_block(aggregate, "Require complete performance validation")
+    aggregate_script = run_script(aggregate_step)
+    executable_aggregate = (
+        aggregate_script.replace(
+            "${{ needs.head-check.result }}", "${HEAD_CHECK_RESULT}"
+        )
+        .replace(
+            "${{ needs.runner-preflight.result }}", "${RUNNER_PREFLIGHT_RESULT}"
+        )
+        .replace(
+            "${{ needs.perf-benchmarks.result }}", "${PERF_BENCHMARKS_RESULT}"
+        )
+    )
+    require(
+        executable_aggregate != aggregate_script,
+        "performance aggregate must validate dependency results",
+    )
+    aggregate_cases = (
+        ("relevant trusted PR", "true", "true", "success", "success", 0),
+        ("documentation-only PR", "true", "false", "skipped", "skipped", 0),
+        ("untrusted PR", "false", "true", "skipped", "skipped", 0),
+        ("superseded PR", "true", "true", "skipped", "skipped", 0),
+        ("relevant PR skipped", "true", "true", "skipped", "skipped", 1),
+        ("documentation PR ran", "true", "false", "skipped", "success", 1),
+        ("untrusted PR ran", "false", "true", "success", "success", 1),
+    )
+    if os.name != "nt":
+        for name, trusted, relevant, preflight_result, benchmark_result, expected in aggregate_cases:
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "HEAD_CHECK_RESULT": "success",
+                    "TRUSTED_PR": trusted,
+                    "SUPERSEDED": "true" if name == "superseded PR" else "false",
+                    "RELEVANT": relevant,
+                    "RUNNER_PREFLIGHT_RESULT": preflight_result,
+                    "PERF_BENCHMARKS_RESULT": benchmark_result,
+                }
+            )
+            result = subprocess.run(
+                ["bash", "-c", executable_aggregate],
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            require(
+                result.returncode == expected,
+                f"performance aggregate {name}: expected {expected}, got {result.returncode}",
+            )
     modes_block = re.search(
         r"^        test-mode:\n((?:          - \w+\n)+)", benchmark, re.M
     )
@@ -3887,19 +4039,7 @@ steps:
     head_script = run_script(
         step_block(head_check, "Compare the event head against the live pull-request head")
     )
-    if os.name != "nt":
-        # The event head is always "current"; the live head is what moves.
-        # name, event, live head, expected superseded decision
-        for name, event, live, expected in (
-            ("push", "push", "", "false"),
-            ("current PR head", "pull_request", "current", "false"),
-            ("superseded PR head", "pull_request", "moved-on", "true"),
-            ("failed live lookup", "pull_request", "", "false"),
-        ):
-            require(
-                run_head_check(head_script, event, live) == expected,
-                f"head-check {name}: expected superseded={expected}",
-            )
+    validate_head_check_truth_table(head_script, "Unity")
     require(
         "environment:" not in licensed,
         "Unity job must use organization secrets without an environment approval gate",
@@ -3942,6 +4082,7 @@ steps:
         "HEAD_CHECK_RESULT": "${{ needs.head-check.result }}",
         "RUNNER_PREFLIGHT_RESULT": "${{ needs.runner-preflight.result }}",
         "UNITY_TESTS_RESULT": "${{ needs.unity-tests.result }}",
+        "RELEVANT": "${{ needs.head-check.outputs.relevant }}",
         "SUPERSEDED": "${{ needs.head-check.outputs.superseded }}",
         "FORK_PR": (
             "${{ github.event_name == 'pull_request' && "
@@ -3962,7 +4103,7 @@ steps:
     script = run_script(aggregate_step)
     expected_script = """set -euo pipefail
 test "${HEAD_CHECK_RESULT}" = success
-if [ "${SUPERSEDED}" = "true" ] || [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then
+if [ "${SUPERSEDED}" = "true" ] || [ "${RELEVANT}" = "false" ] || [ "${FORK_PR}" = "true" ] || [ "${DEPENDABOT_PR}" = "true" ]; then
   test "${RUNNER_PREFLIGHT_RESULT}" = skipped
   test "${UNITY_TESTS_RESULT}" = skipped
 else
@@ -3970,27 +4111,30 @@ else
   test "${UNITY_TESTS_RESULT}" = success
 fi"""
     require(script == expected_script, "aggregate result-shape script drifted")
-    # name, head-check, preflight, unity, SUPERSEDED, FORK_PR, DEPENDABOT_PR, exit code
+    # name, head-check, preflight, unity, SUPERSEDED, RELEVANT, FORK_PR, DEPENDABOT_PR, exit code
     cases = (
-        ("same-repository PR", "success", "success", "success", "false", "false", "false", 0),
-        ("fork PR", "success", "skipped", "skipped", "false", "true", "false", 0),
-        ("Dependabot PR", "success", "skipped", "skipped", "false", "false", "true", 0),
-        ("superseded PR", "success", "skipped", "skipped", "true", "false", "false", 0),
-        ("same-repository PR skipped Unity", "success", "success", "skipped", "false", "false", "false", 1),
-        ("fork unexpectedly ran Unity", "success", "skipped", "success", "false", "true", "false", 1),
-        ("Dependabot unexpectedly ran Unity", "success", "skipped", "success", "false", "false", "true", 1),
-        ("Dependabot unexpectedly ran preflight", "success", "success", "skipped", "false", "false", "true", 1),
-        ("superseded run still ran Unity", "success", "skipped", "success", "true", "false", "false", 1),
-        ("current head skipped Unity after a failed decision", "failure", "skipped", "skipped", "", "false", "false", 1),
+        ("same-repository PR", "success", "success", "success", "false", "true", "false", "false", 0),
+        ("documentation-only PR", "success", "skipped", "skipped", "false", "false", "false", "false", 0),
+        ("fork PR", "success", "skipped", "skipped", "false", "true", "true", "false", 0),
+        ("Dependabot PR", "success", "skipped", "skipped", "false", "true", "false", "true", 0),
+        ("superseded PR", "success", "skipped", "skipped", "true", "true", "false", "false", 0),
+        ("same-repository PR skipped Unity", "success", "success", "skipped", "false", "true", "false", "false", 1),
+        ("documentation-only PR ran Unity", "success", "skipped", "success", "false", "false", "false", "false", 1),
+        ("fork unexpectedly ran Unity", "success", "skipped", "success", "false", "true", "true", "false", 1),
+        ("Dependabot unexpectedly ran Unity", "success", "skipped", "success", "false", "true", "false", "true", 1),
+        ("Dependabot unexpectedly ran preflight", "success", "success", "skipped", "false", "true", "false", "true", 1),
+        ("superseded run still ran Unity", "success", "skipped", "success", "true", "true", "false", "false", 1),
+        ("current head skipped Unity after a failed decision", "failure", "skipped", "skipped", "", "", "false", "false", 1),
     )
     if os.name != "nt":
-        for name, head, preflight, unity, superseded, fork, dependabot, expected in cases:
+        for name, head, preflight, unity, superseded, relevant, fork, dependabot, expected in cases:
             environment = os.environ.copy()
             environment.update(
                 {
                     "HEAD_CHECK_RESULT": head,
                     "RUNNER_PREFLIGHT_RESULT": preflight,
                     "UNITY_TESTS_RESULT": unity,
+                    "RELEVANT": relevant,
                     "SUPERSEDED": superseded,
                     "FORK_PR": fork,
                     "DEPENDABOT_PR": dependabot,


### PR DESCRIPTION
## What changed

- sweep README, guides, API XML comments, integrations, and shipped samples so entity health/damage mutation requests are targeted and completed entity facts are sourced broadcasts
- make the homepage heal flow targeted and automatic, and retain the clicked GameObject as the UI sample broadcast source
- add compilation-backed, data-driven documentation semantics contracts
- add fail-closed documentation-only relevance gates for licensed Unity correctness and performance workflows while preserving their required aggregate checks
- keep the local generator test command from overwriting the shipped analyzer payload

## Why

Health is entity-owned state, so an untargeted `OnHealRequested` flow loses the identity required to mutate the correct entity. Outcome-shaped facts such as damage taken and health changed likewise need the affected entity as their broadcast source. The reopened #372 review also requested a complete Markdown and XML-comment sweep.

The workflow gate addresses #298 by avoiding licensed Unity work only for an explicit prose-only allowlist; code, workflows, package inputs, README/CHANGELOG, empty responses, and lookup failures remain fail-closed and run Unity.

## Validation

- documentation compilation/semantic tests: 582 passed
- source-generator/analyzer tests: 246 passed
- script tests: 409 passed
- `npm run validate:all`
- strict MkDocs build
- Prettier, Markdown lint, spelling, actionlint, and CSharpier
- current-head GitHub validation: all 12 Unity cells and the required aggregate passed; performance, static CI, both devcontainer architectures, docs deploy, CSharpier, and Prettier also passed

Closes #372
Closes #298

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches required Unity/perf CI skip logic and shipped sample message routing. Fail-closed defaults reduce the chance of silently skipping real code changes.
> 
> **Overview**
> **Aligns docs and samples with entity message semantics:** mutation requests like heal/damage are **targeted**, and completed entity facts like damage taken, player spawned, and button clicks are **sourced broadcasts**—not untargeted globals.
> 
> The homepage heal demo now uses a targeted `HealPlayerRequested` flow with automatic button wiring (no Inspector player reference). Samples and DI examples retain source identity via `RegisterBroadcastWithoutSource` / `EmitGameObjectBroadcast`.
> 
> Adds compilation-backed semantic guards so post-processors name processed dispatch (not gameplay outcomes) and entity routes keep the right message kind.
> 
> **Skips licensed Unity correctness and performance jobs for documentation-only PRs**, while still requiring the aggregate success checks. Mixed/code changes, empty file lists, and lookup failures remain fail-closed and run Unity. Also documents `/p:CopyAnalyzerPayload=false` for local generator tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c3111755b9a7535b5414585cf07722dd91b7bb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->