### PR TITLE
Make copied disposables safe without per-use GC

### DIFF
--- a/.docs-tests/DocsSnippetCompilationTests.cs
+++ b/.docs-tests/DocsSnippetCompilationTests.cs
@@ -8,6 +8,27 @@ namespace WallstopStudios.DxMessaging.Docs.Tests;
 [TestFixture]
 internal sealed class DocsSnippetCompilationTests
 {
+    [Test]
+    public void DocsTestSdkAcceptsAvailableNet9FeatureBands()
+    {
+        string globalJsonPath = Path.Combine(ResolveRepoRoot(), ".docs-tests", "global.json");
+        using System.Text.Json.JsonDocument document = System.Text.Json.JsonDocument.Parse(
+            File.ReadAllText(globalJsonPath)
+        );
+        System.Text.Json.JsonElement sdk = document.RootElement.GetProperty("sdk");
+
+        Assert.That(
+            sdk.GetProperty("version").GetString(),
+            Is.EqualTo("9.0.100"),
+            "The docs test SDK must use the first .NET 9 feature-band floor so Dependabot can run on any available .NET 9 SDK."
+        );
+        Assert.That(
+            sdk.GetProperty("rollForward").GetString(),
+            Is.EqualTo("latestFeature"),
+            "The docs test SDK must roll forward across installed .NET 9 feature bands."
+        );
+    }
+
     private static readonly HashSet<string> ContextOnlyDiagnosticIds = new(StringComparer.Ordinal)
     {
         "CS0103", // A surrounding example supplies the named local, field, or method.

--- a/.docs-tests/global.json
+++ b/.docs-tests/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "9.0.314",
-    "rollForward": "disable",
+    "version": "9.0.100",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix copied `GlobalMessageBusScope` and `RegistrationDisposable` values restoring or removing
   newer state. Global bus override scopes now share disposal state, unwind nested scopes safely in
   either order, ignore stale disposal after an explicit set or reset, and allocate nothing per scope
-  when retained as their concrete value type after static initialization.
+  when retained as their concrete value type while reusing established slot capacity. New peak
+  occupancy grows the slot table in fixed blocks instead of imposing a fixed 1,024 nesting cap.
   Registration handle identities now remain unique across static resets so a stale copied wrapper
   cannot remove a new registration that reused its token slot
   ([#375](https://github.com/Ambiguous-Interactive/DxMessaging/issues/375)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix copied `GlobalMessageBusScope` and `RegistrationDisposable` values restoring or removing
+  newer state. Global bus override scopes now share disposal state, unwind nested scopes safely in
+  either order, ignore stale disposal after an explicit set or reset, and allocate nothing per scope
+  when retained as their concrete value type after static initialization.
+  Registration handle identities now remain unique across static resets so a stale copied wrapper
+  cannot remove a new registration that reused its token slot
+  ([#375](https://github.com/Ambiguous-Interactive/DxMessaging/issues/375)).
 - Fix the optional Reflex integration and DI sample for Reflex 14's registration
   API while retaining support for earlier Reflex releases. The pinned Reflex
   14.3.1 test dependency also removes its obsolete non-generic TreeView usage on

--- a/Runtime/Core/DxMessagingStaticState.cs
+++ b/Runtime/Core/DxMessagingStaticState.cs
@@ -14,10 +14,9 @@ namespace DxMessaging.Core
     /// </para>
     /// <para>
     /// <strong>Important:</strong> Message type sequential IDs (managed by MessageHelperIndexer)
-    /// are intentionally NOT reset. Once a message type is assigned an ID, it retains that ID
-    /// for the lifetime of the application domain. This prevents ID collisions that would occur
-    /// if a new message type were assigned an ID that was previously used by a different type.
-    /// Resetting IDs could cause messages to be routed to the wrong handlers.
+    /// and opaque registration handle IDs are intentionally NOT reset. Once an ID is assigned, it
+    /// remains consumed for the lifetime of the application domain. This prevents stale handles or
+    /// new message types from colliding with identities issued before a reset.
     /// </para>
     /// </remarks>
     public static class DxMessagingStaticState
@@ -34,7 +33,8 @@ namespace DxMessaging.Core
         /// Resets all static variables in DxMessaging to their default values.
         /// </summary>
         /// <remarks>
-        /// Message type IDs are NOT reset by this method. See the class remarks for details.
+        /// Message type and registration handle IDs are NOT reset by this method. See the class
+        /// remarks for details.
         /// </remarks>
         public static void Reset()
         {
@@ -47,7 +47,6 @@ namespace DxMessaging.Core
                 IMessageBus.GlobalMessageBufferSize = Baseline.GlobalMessageBufferSize;
                 IMessageBus.GlobalSequentialIndex = Baseline.GlobalSequentialIndex;
 
-                MessageRegistrationHandle.SetIdSeed(Baseline.MessageRegistrationHandleSeed);
                 MessageRegistrationBuilder.SetSyntheticOwnerCounter(Baseline.SyntheticOwnerCounter);
 
                 // Capture the active global bus before ResetStatics swaps it back to the default
@@ -80,7 +79,6 @@ namespace DxMessaging.Core
             DiagnosticsTarget globalDiagnosticsTargets = IMessageBus.GlobalDiagnosticsTargets;
             int globalMessageBufferSize = IMessageBus.GlobalMessageBufferSize;
             int globalSequentialIndex = IMessageBus.GlobalSequentialIndex;
-            long messageRegistrationHandleSeed = MessageRegistrationHandle.GetCurrentIdSeed();
             int syntheticOwnerCounter = MessageRegistrationBuilder.GetSyntheticOwnerCounter();
 
             return new BaselineState(
@@ -89,7 +87,6 @@ namespace DxMessaging.Core
                 globalDiagnosticsTargets,
                 globalMessageBufferSize,
                 globalSequentialIndex,
-                messageRegistrationHandleSeed,
                 syntheticOwnerCounter
             );
         }
@@ -102,7 +99,6 @@ namespace DxMessaging.Core
                 DiagnosticsTarget globalDiagnosticsTargets,
                 int globalMessageBufferSize,
                 int globalSequentialIndex,
-                long messageRegistrationHandleSeed,
                 int syntheticOwnerCounter
             )
             {
@@ -111,7 +107,6 @@ namespace DxMessaging.Core
                 GlobalDiagnosticsTargets = globalDiagnosticsTargets;
                 GlobalMessageBufferSize = globalMessageBufferSize;
                 GlobalSequentialIndex = globalSequentialIndex;
-                MessageRegistrationHandleSeed = messageRegistrationHandleSeed;
                 SyntheticOwnerCounter = syntheticOwnerCounter;
             }
 
@@ -124,8 +119,6 @@ namespace DxMessaging.Core
             internal int GlobalMessageBufferSize { get; }
 
             internal int GlobalSequentialIndex { get; }
-
-            internal long MessageRegistrationHandleSeed { get; }
 
             internal int SyntheticOwnerCounter { get; }
         }

--- a/Runtime/Core/MessageHandler.cs
+++ b/Runtime/Core/MessageHandler.cs
@@ -60,9 +60,15 @@ namespace DxMessaging.Core
         private static IMessageBus _globalMessageBus;
 
         private static MessageBus.MessageBus _defaultGlobalMessageBus = new MessageBus.MessageBus();
-        private const int GlobalMessageBusOverrideCapacity = 1024;
-        private static readonly GlobalMessageBusOverrideState[] GlobalMessageBusOverrides =
-            new GlobalMessageBusOverrideState[GlobalMessageBusOverrideCapacity];
+        private const int GlobalMessageBusOverrideBlockShift = 10;
+        private const int GlobalMessageBusOverrideBlockSize =
+            1 << GlobalMessageBusOverrideBlockShift;
+        private const int GlobalMessageBusOverrideBlockMask = GlobalMessageBusOverrideBlockSize - 1;
+        private static GlobalMessageBusOverrideState[][] _globalMessageBusOverrideBlocks =
+        {
+            new GlobalMessageBusOverrideState[GlobalMessageBusOverrideBlockSize],
+        };
+        private static int _globalMessageBusOverrideBlockCount = 1;
         private static int _globalMessageBusOverrideFreeHead = -1;
         private static int _globalMessageBusOverrideSlotCount;
         private static int _latestGlobalMessageBusOverrideSlot = -1;
@@ -172,12 +178,14 @@ namespace DxMessaging.Core
         /// <returns>
         /// A <see cref="GlobalMessageBusScope"/> that restores the previous bus on dispose. Keep
         /// the returned concrete value type instead of converting it to <see cref="IDisposable"/>
-        /// to avoid boxing; scope creation and disposal then allocate no managed objects after
-        /// static initialization.
+        /// to avoid boxing. Scope creation and disposal allocate no managed objects while reusing
+        /// established slot capacity; a new peak occupancy grows the table in fixed blocks.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="messageBus"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException">
-        /// Thrown when 1,024 override slots are occupied. An out-of-order-disposed scope keeps its
-        /// slot until all newer scopes have ended.
+        /// Thrown when the representable override slot index space is exhausted.
         /// </exception>
         public static GlobalMessageBusScope OverrideGlobalMessageBus(IMessageBus messageBus)
         {
@@ -211,42 +219,112 @@ namespace DxMessaging.Core
             _latestGlobalMessageBusOverrideSlot = -1;
             while (slot >= 0)
             {
-                int previous = GlobalMessageBusOverrides[slot].PreviousSlot;
+                int previous = GetGlobalMessageBusOverrideState(slot).PreviousSlot;
                 ReleaseGlobalMessageBusOverrideSlot(slot);
                 slot = previous;
             }
         }
 
-        private static int AcquireGlobalMessageBusOverrideSlot()
+        private static int AcquireGlobalMessageBusOverrideSlot(out long generation)
         {
-            int slot = _globalMessageBusOverrideFreeHead;
-            if (slot >= 0)
+            while (true)
             {
-                _globalMessageBusOverrideFreeHead = GlobalMessageBusOverrides[slot].NextFree;
-            }
-            else
-            {
-                if (_globalMessageBusOverrideSlotCount >= GlobalMessageBusOverrideCapacity)
+                int slot = _globalMessageBusOverrideFreeHead;
+                if (slot >= 0)
                 {
-                    throw new InvalidOperationException(
-                        "Too many global message bus override slots are occupied at once."
-                    );
+                    _globalMessageBusOverrideFreeHead = GetGlobalMessageBusOverrideState(
+                        slot
+                    ).NextFree;
+                }
+                else
+                {
+                    if (_globalMessageBusOverrideSlotCount == int.MaxValue)
+                    {
+                        throw new InvalidOperationException(
+                            "The global message bus override slot index is exhausted."
+                        );
+                    }
+
+                    slot = _globalMessageBusOverrideSlotCount;
+                    EnsureGlobalMessageBusOverrideBlock(slot >> GlobalMessageBusOverrideBlockShift);
+                    ++_globalMessageBusOverrideSlotCount;
                 }
 
-                slot = _globalMessageBusOverrideSlotCount++;
-            }
+                ref GlobalMessageBusOverrideState state = ref GetGlobalMessageBusOverrideState(
+                    slot
+                );
+                if (state.Generation == -1)
+                {
+                    // Every nonzero 64-bit generation was issued for this slot. Burn it instead of
+                    // wrapping to a generation an ancient stale scope could still carry.
+                    continue;
+                }
+                unchecked
+                {
+                    ++state.Generation;
+                    if (state.Generation == 0)
+                    {
+                        ++state.Generation;
+                    }
+                }
 
-            return slot;
+                generation = state.Generation;
+                return slot;
+            }
         }
 
         private static void ReleaseGlobalMessageBusOverrideSlot(int slot)
         {
-            ref GlobalMessageBusOverrideState state = ref GlobalMessageBusOverrides[slot];
+            ref GlobalMessageBusOverrideState state = ref GetGlobalMessageBusOverrideState(slot);
             state.PreviousBus = null;
             state.PreviousSlot = -1;
             state.Disposed = true;
             state.NextFree = _globalMessageBusOverrideFreeHead;
             _globalMessageBusOverrideFreeHead = slot;
+        }
+
+        private static ref GlobalMessageBusOverrideState GetGlobalMessageBusOverrideState(int slot)
+        {
+            return ref _globalMessageBusOverrideBlocks[slot >> GlobalMessageBusOverrideBlockShift][
+                slot & GlobalMessageBusOverrideBlockMask
+            ];
+        }
+
+        private static void EnsureGlobalMessageBusOverrideBlock(int block)
+        {
+            if (block < _globalMessageBusOverrideBlockCount)
+            {
+                return;
+            }
+
+            int required = block + 1;
+            if (required > _globalMessageBusOverrideBlocks.Length)
+            {
+                int capacity = _globalMessageBusOverrideBlocks.Length * 2;
+                while (capacity < required)
+                {
+                    capacity *= 2;
+                }
+
+                GlobalMessageBusOverrideState[][] grown = new GlobalMessageBusOverrideState[
+                    capacity
+                ][];
+                Array.Copy(
+                    _globalMessageBusOverrideBlocks,
+                    grown,
+                    _globalMessageBusOverrideBlockCount
+                );
+                _globalMessageBusOverrideBlocks = grown;
+            }
+
+            for (int i = _globalMessageBusOverrideBlockCount; i < required; ++i)
+            {
+                _globalMessageBusOverrideBlocks[i] = new GlobalMessageBusOverrideState[
+                    GlobalMessageBusOverrideBlockSize
+                ];
+            }
+
+            _globalMessageBusOverrideBlockCount = required;
         }
 
         /// <summary>
@@ -273,19 +351,12 @@ namespace DxMessaging.Core
 
                 lock (GlobalResetLock)
                 {
-                    int slot = AcquireGlobalMessageBusOverrideSlot();
+                    int slot = AcquireGlobalMessageBusOverrideSlot(out long generation);
                     _slot = slot + 1;
-                    ref GlobalMessageBusOverrideState state = ref GlobalMessageBusOverrides[slot];
-                    unchecked
-                    {
-                        ++state.Generation;
-                        if (state.Generation == 0)
-                        {
-                            ++state.Generation;
-                        }
-                    }
-
-                    _generation = state.Generation;
+                    ref GlobalMessageBusOverrideState state = ref GetGlobalMessageBusOverrideState(
+                        slot
+                    );
+                    _generation = generation;
                     state.PreviousBus = MessageBus;
                     state.PreviousSlot = _latestGlobalMessageBusOverrideSlot;
                     state.Disposed = false;
@@ -307,7 +378,9 @@ namespace DxMessaging.Core
                 lock (GlobalResetLock)
                 {
                     int slot = _slot - 1;
-                    ref GlobalMessageBusOverrideState state = ref GlobalMessageBusOverrides[slot];
+                    ref GlobalMessageBusOverrideState state = ref GetGlobalMessageBusOverrideState(
+                        slot
+                    );
                     if (state.Generation != _generation || state.Disposed)
                     {
                         return;
@@ -322,10 +395,14 @@ namespace DxMessaging.Core
                     IMessageBus restore = state.PreviousBus;
                     int releaseSlot = slot;
                     int previousSlot = state.PreviousSlot;
-                    while (previousSlot >= 0 && GlobalMessageBusOverrides[previousSlot].Disposed)
+                    while (
+                        previousSlot >= 0 && GetGlobalMessageBusOverrideState(previousSlot).Disposed
+                    )
                     {
-                        restore = GlobalMessageBusOverrides[previousSlot].PreviousBus;
-                        int nextPreviousSlot = GlobalMessageBusOverrides[previousSlot].PreviousSlot;
+                        ref GlobalMessageBusOverrideState previousState =
+                            ref GetGlobalMessageBusOverrideState(previousSlot);
+                        restore = previousState.PreviousBus;
+                        int nextPreviousSlot = previousState.PreviousSlot;
                         ReleaseGlobalMessageBusOverrideSlot(releaseSlot);
                         releaseSlot = previousSlot;
                         previousSlot = nextPreviousSlot;

--- a/Runtime/Core/MessageHandler.cs
+++ b/Runtime/Core/MessageHandler.cs
@@ -60,6 +60,12 @@ namespace DxMessaging.Core
         private static IMessageBus _globalMessageBus;
 
         private static MessageBus.MessageBus _defaultGlobalMessageBus = new MessageBus.MessageBus();
+        private const int GlobalMessageBusOverrideCapacity = 1024;
+        private static readonly GlobalMessageBusOverrideState[] GlobalMessageBusOverrides =
+            new GlobalMessageBusOverrideState[GlobalMessageBusOverrideCapacity];
+        private static int _globalMessageBusOverrideFreeHead = -1;
+        private static int _globalMessageBusOverrideSlotCount;
+        private static int _latestGlobalMessageBusOverrideSlot = -1;
 
         /// <summary>
         /// Gets the process-wide <see cref="IMessageBus"/> used when no explicit bus is supplied.
@@ -116,7 +122,11 @@ namespace DxMessaging.Core
                 throw new ArgumentNullException(nameof(messageBus));
             }
 
-            _globalMessageBus = messageBus;
+            lock (GlobalResetLock)
+            {
+                InvalidateGlobalMessageBusOverrides();
+                SetGlobalMessageBusCore(messageBus);
+            }
         }
 
         /// <summary>
@@ -133,7 +143,11 @@ namespace DxMessaging.Core
                 throw new ArgumentNullException(nameof(messageBus));
             }
 
-            _globalMessageBus = messageBus;
+            lock (GlobalResetLock)
+            {
+                InvalidateGlobalMessageBusOverrides();
+                SetGlobalMessageBusCore(messageBus);
+            }
         }
 
         /// <summary>
@@ -146,7 +160,8 @@ namespace DxMessaging.Core
         {
             lock (GlobalResetLock)
             {
-                _globalMessageBus = _defaultGlobalMessageBus;
+                InvalidateGlobalMessageBusOverrides();
+                SetGlobalMessageBusCore(_defaultGlobalMessageBus);
             }
         }
 
@@ -154,7 +169,16 @@ namespace DxMessaging.Core
         /// Temporarily overrides the global message bus until the returned scope is disposed.
         /// </summary>
         /// <param name="messageBus">Message bus to expose for the duration of the scope.</param>
-        /// <returns>An <see cref="IDisposable"/> scope that restores the previous bus on dispose.</returns>
+        /// <returns>
+        /// A <see cref="GlobalMessageBusScope"/> that restores the previous bus on dispose. Keep
+        /// the returned concrete value type instead of converting it to <see cref="IDisposable"/>
+        /// to avoid boxing; scope creation and disposal then allocate no managed objects after
+        /// static initialization.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when 1,024 override slots are occupied. An out-of-order-disposed scope keeps its
+        /// slot until all newer scopes have ended.
+        /// </exception>
         public static GlobalMessageBusScope OverrideGlobalMessageBus(IMessageBus messageBus)
         {
             return new GlobalMessageBusScope(messageBus);
@@ -171,17 +195,74 @@ namespace DxMessaging.Core
             lock (GlobalResetLock)
             {
                 _defaultGlobalMessageBus.ResetState();
-                _globalMessageBus = _defaultGlobalMessageBus;
+                InvalidateGlobalMessageBusOverrides();
+                SetGlobalMessageBusCore(_defaultGlobalMessageBus);
             }
+        }
+
+        private static void SetGlobalMessageBusCore(IMessageBus messageBus)
+        {
+            _globalMessageBus = messageBus;
+        }
+
+        private static void InvalidateGlobalMessageBusOverrides()
+        {
+            int slot = _latestGlobalMessageBusOverrideSlot;
+            _latestGlobalMessageBusOverrideSlot = -1;
+            while (slot >= 0)
+            {
+                int previous = GlobalMessageBusOverrides[slot].PreviousSlot;
+                ReleaseGlobalMessageBusOverrideSlot(slot);
+                slot = previous;
+            }
+        }
+
+        private static int AcquireGlobalMessageBusOverrideSlot()
+        {
+            int slot = _globalMessageBusOverrideFreeHead;
+            if (slot >= 0)
+            {
+                _globalMessageBusOverrideFreeHead = GlobalMessageBusOverrides[slot].NextFree;
+            }
+            else
+            {
+                if (_globalMessageBusOverrideSlotCount >= GlobalMessageBusOverrideCapacity)
+                {
+                    throw new InvalidOperationException(
+                        "Too many global message bus override slots are occupied at once."
+                    );
+                }
+
+                slot = _globalMessageBusOverrideSlotCount++;
+            }
+
+            return slot;
+        }
+
+        private static void ReleaseGlobalMessageBusOverrideSlot(int slot)
+        {
+            ref GlobalMessageBusOverrideState state = ref GlobalMessageBusOverrides[slot];
+            state.PreviousBus = null;
+            state.PreviousSlot = -1;
+            state.Disposed = true;
+            state.NextFree = _globalMessageBusOverrideFreeHead;
+            _globalMessageBusOverrideFreeHead = slot;
         }
 
         /// <summary>
         /// Represents a disposable override scope for the global message bus.
         /// </summary>
-        public struct GlobalMessageBusScope : IDisposable
+        /// <remarks>
+        /// Copies share their disposal state. Disposing any copy ends the override once, and a
+        /// later disposal cannot restore stale state over a newer global-bus change.
+        /// Create, dispose, set, and reset global-bus configuration on Unity's main thread; message
+        /// bus operations follow DxMessaging's single-threaded runtime contract.
+        /// <para><b>Fixed in v3.2.3.</b></para>
+        /// </remarks>
+        public readonly struct GlobalMessageBusScope : IDisposable
         {
-            private readonly IMessageBus _previous;
-            private bool _disposed;
+            private readonly int _slot;
+            private readonly long _generation;
 
             internal GlobalMessageBusScope(IMessageBus messageBus)
             {
@@ -190,16 +271,26 @@ namespace DxMessaging.Core
                     throw new ArgumentNullException(nameof(messageBus));
                 }
 
-                _previous = MessageBus;
-                _disposed = false;
+                lock (GlobalResetLock)
+                {
+                    int slot = AcquireGlobalMessageBusOverrideSlot();
+                    _slot = slot + 1;
+                    ref GlobalMessageBusOverrideState state = ref GlobalMessageBusOverrides[slot];
+                    unchecked
+                    {
+                        ++state.Generation;
+                        if (state.Generation == 0)
+                        {
+                            ++state.Generation;
+                        }
+                    }
 
-                if (messageBus is MessageBus.MessageBus concrete)
-                {
-                    SetGlobalMessageBus(concrete);
-                }
-                else
-                {
-                    SetGlobalMessageBus(messageBus);
+                    _generation = state.Generation;
+                    state.PreviousBus = MessageBus;
+                    state.PreviousSlot = _latestGlobalMessageBusOverrideSlot;
+                    state.Disposed = false;
+                    SetGlobalMessageBusCore(messageBus);
+                    _latestGlobalMessageBusOverrideSlot = slot;
                 }
             }
 
@@ -208,26 +299,52 @@ namespace DxMessaging.Core
             /// </summary>
             public void Dispose()
             {
-                if (_disposed)
+                if (_slot == 0)
                 {
                     return;
                 }
 
-                if (_previous is MessageBus.MessageBus concrete)
+                lock (GlobalResetLock)
                 {
-                    SetGlobalMessageBus(concrete);
-                }
-                else if (_previous != null)
-                {
-                    SetGlobalMessageBus(_previous);
-                }
-                else
-                {
-                    ResetGlobalMessageBus();
-                }
+                    int slot = _slot - 1;
+                    ref GlobalMessageBusOverrideState state = ref GlobalMessageBusOverrides[slot];
+                    if (state.Generation != _generation || state.Disposed)
+                    {
+                        return;
+                    }
 
-                _disposed = true;
+                    state.Disposed = true;
+                    if (_latestGlobalMessageBusOverrideSlot != slot)
+                    {
+                        return;
+                    }
+
+                    IMessageBus restore = state.PreviousBus;
+                    int releaseSlot = slot;
+                    int previousSlot = state.PreviousSlot;
+                    while (previousSlot >= 0 && GlobalMessageBusOverrides[previousSlot].Disposed)
+                    {
+                        restore = GlobalMessageBusOverrides[previousSlot].PreviousBus;
+                        int nextPreviousSlot = GlobalMessageBusOverrides[previousSlot].PreviousSlot;
+                        ReleaseGlobalMessageBusOverrideSlot(releaseSlot);
+                        releaseSlot = previousSlot;
+                        previousSlot = nextPreviousSlot;
+                    }
+
+                    SetGlobalMessageBusCore(restore ?? _defaultGlobalMessageBus);
+                    ReleaseGlobalMessageBusOverrideSlot(releaseSlot);
+                    _latestGlobalMessageBusOverrideSlot = previousSlot;
+                }
             }
+        }
+
+        private struct GlobalMessageBusOverrideState
+        {
+            internal IMessageBus PreviousBus;
+            internal long Generation;
+            internal int PreviousSlot;
+            internal int NextFree;
+            internal bool Disposed;
         }
 
         /// <summary>

--- a/Runtime/Core/MessageRegistrationHandle.cs
+++ b/Runtime/Core/MessageRegistrationHandle.cs
@@ -23,16 +23,6 @@ namespace DxMessaging.Core
 
         internal int Slot => _slot;
 
-        internal static long GetCurrentIdSeed()
-        {
-            return Interlocked.Read(ref StaticIdCount);
-        }
-
-        internal static void SetIdSeed(long value)
-        {
-            _ = Interlocked.Exchange(ref StaticIdCount, value);
-        }
-
         /// <summary>
         /// Creates a new unique handle.
         /// </summary>

--- a/Runtime/Core/MessageRegistrationToken.cs
+++ b/Runtime/Core/MessageRegistrationToken.cs
@@ -3402,20 +3402,31 @@ namespace DxMessaging.Core
         }
 
         /// <summary>
-        /// Wraps a registration handle in an <see cref="IDisposable"/> that removes it on dispose.
+        /// Wraps a registration handle in a disposable value type that removes it on dispose.
         /// </summary>
         /// <param name="handle">The registration handle to remove when disposed.</param>
-        /// <returns>An <see cref="IDisposable"/> that calls <see cref="RemoveRegistration"/> once.</returns>
+        /// <returns>
+        /// A concrete <see cref="RegistrationDisposable"/> value. Keep it as that concrete type to
+        /// avoid boxing it as <see cref="IDisposable"/>.
+        /// </returns>
         public RegistrationDisposable AsDisposable(MessageRegistrationHandle handle)
         {
             return new RegistrationDisposable(this, handle);
         }
 
-        public struct RegistrationDisposable : IDisposable
+        /// <summary>
+        /// Removes one registration when disposed.
+        /// </summary>
+        /// <remarks>
+        /// Copies are safe to dispose. The token's opaque handle identity makes every disposal
+        /// after the first successful removal have no effect, including after the vacated slot is
+        /// reused by a new registration. A failed removal remains retryable through any copy.
+        /// <para><b>Fixed in v3.2.3.</b></para>
+        /// </remarks>
+        public readonly struct RegistrationDisposable : IDisposable
         {
             private readonly MessageRegistrationToken _token;
             private readonly MessageRegistrationHandle _handle;
-            private bool _valid;
 
             /// <summary>
             /// Creates a disposable wrapper that removes a registration when disposed.
@@ -3429,21 +3440,20 @@ namespace DxMessaging.Core
             {
                 _token = token;
                 _handle = handle;
-                _valid = true;
             }
 
             /// <summary>
-            /// Removes the wrapped registration the first time it is invoked.
+            /// Attempts to remove the wrapped registration. Only the first successful removal has
+            /// an effect; a failed attempt remains retryable.
             /// </summary>
             public void Dispose()
             {
-                // Best-effort idempotence; AsDisposable instances are short-lived and immutable
-                if (_valid)
+                // RemoveRegistration rejects a stale opaque handle even after its slot is reused.
+                // Keeping the wrapper stateless makes every copy follow that authoritative check.
+                if (_token != null)
                 {
                     _token.RemoveRegistration(_handle);
                 }
-
-                _valid = false;
             }
         }
 

--- a/Tests/Editor/Allocations/AllocationMatrixTests.cs
+++ b/Tests/Editor/Allocations/AllocationMatrixTests.cs
@@ -27,7 +27,7 @@ namespace DxMessaging.Tests.Editor.Allocations
     /// intentionally builds emit closures once outside the assertion zone so
     /// the closure-creation cost itself is not measured. Each test owns a
     /// dedicated <see cref="MessageBus"/> instance to keep registrations from
-    /// leaking across rows; the global static bus is left untouched.
+    /// leaking across rows; tests that exercise global overrides restore the bus captured on entry.
     /// </para>
     /// <para>
     /// <b>Cross-product reduction.</b> The matrix exercises EACH axis (kind,
@@ -215,6 +215,118 @@ namespace DxMessaging.Tests.Editor.Allocations
                     AllocationAssertions.AssertNoAllocations($"Emit-{scenario.Kind}", emit);
                 }
             );
+        }
+
+        [Test]
+        [Category("Allocation")]
+        public void GlobalMessageBusOverrideScopeIsZeroAllocAfterWarmup()
+        {
+            IMessageBus entryBus = MessageHandler.MessageBus;
+            MessageBus original = new MessageBus();
+            MessageBus overrideBus = new MessageBus();
+            MessageHandler.SetGlobalMessageBus(original);
+            Action overrideCycle = () =>
+            {
+                using MessageHandler.GlobalMessageBusScope scope =
+                    MessageHandler.OverrideGlobalMessageBus(overrideBus);
+            };
+
+            try
+            {
+                AllocationAssertions.AssertNoAllocations(
+                    nameof(GlobalMessageBusOverrideScopeIsZeroAllocAfterWarmup),
+                    overrideCycle
+                );
+                Assert.AreSame(
+                    original,
+                    MessageHandler.MessageBus,
+                    "Every measured override scope must restore the original global bus."
+                );
+            }
+            finally
+            {
+                MessageHandler.SetGlobalMessageBus(entryBus);
+            }
+        }
+
+        [Test]
+        [Category("Allocation")]
+        public void NestedAndInvalidatedGlobalMessageBusOverridesAreZeroAllocAfterWarmup()
+        {
+            IMessageBus entryBus = MessageHandler.MessageBus;
+            MessageBus original = new MessageBus();
+            MessageBus outerBus = new MessageBus();
+            MessageBus innerBus = new MessageBus();
+            MessageHandler.SetGlobalMessageBus(original);
+            Action overrideBranches = () =>
+            {
+                MessageHandler.GlobalMessageBusScope outer =
+                    MessageHandler.OverrideGlobalMessageBus(outerBus);
+                MessageHandler.GlobalMessageBusScope inner =
+                    MessageHandler.OverrideGlobalMessageBus(innerBus);
+                outer.Dispose();
+                inner.Dispose();
+
+                MessageHandler.GlobalMessageBusScope invalidated =
+                    MessageHandler.OverrideGlobalMessageBus(outerBus);
+                MessageHandler.SetGlobalMessageBus(original);
+                invalidated.Dispose();
+            };
+
+            try
+            {
+                AllocationAssertions.AssertNoAllocations(
+                    nameof(NestedAndInvalidatedGlobalMessageBusOverridesAreZeroAllocAfterWarmup),
+                    overrideBranches
+                );
+                Assert.AreSame(original, MessageHandler.MessageBus);
+            }
+            finally
+            {
+                MessageHandler.SetGlobalMessageBus(entryBus);
+            }
+        }
+
+        [Test]
+        [Category("Allocation")]
+        public void RegistrationDisposableIsZeroAllocAfterWarmup()
+        {
+            MessageBus bus = new MessageBus();
+            MessageHandler handler = new MessageHandler(HandlerOwner, bus) { active = true };
+            MessageRegistrationToken token = MessageRegistrationToken.Create(handler, bus);
+            MessageRegistrationHandle pending = default;
+            Action prepare = () =>
+                pending = token.RegisterUntargeted<SimpleUntargetedMessage>(NoOpUntargeted);
+            Action dispose = () => token.AsDisposable(pending).Dispose();
+
+            try
+            {
+                token.Enable();
+                prepare();
+                dispose();
+                long delta = AllocationProbe.MeasureMin(
+                    AllocationMeasurementAttempts,
+                    prepare,
+                    dispose
+                );
+                if (delta == AllocationProbe.Unmeasured)
+                {
+                    Assert.Ignore(
+                        "The GC.Alloc allocation probe is non-functional on this backend."
+                    );
+                }
+
+                Assert.AreEqual(
+                    0,
+                    delta,
+                    "AsDisposable and concrete RegistrationDisposable.Dispose must allocate no managed objects after warm-up."
+                );
+            }
+            finally
+            {
+                token.UnregisterAll();
+                token.Dispose();
+            }
         }
 
         /// <summary>

--- a/Tests/Editor/Allocations/AllocationMatrixTests.cs
+++ b/Tests/Editor/Allocations/AllocationMatrixTests.cs
@@ -289,6 +289,48 @@ namespace DxMessaging.Tests.Editor.Allocations
 
         [Test]
         [Category("Allocation")]
+        public void GlobalMessageBusOverrideScopeIsZeroAllocAfterGrowingBeyondOneBlock()
+        {
+            const int scopeCount = 2049;
+            IMessageBus entryBus = MessageHandler.MessageBus;
+            MessageBus original = new MessageBus();
+            MessageBus overrideBus = new MessageBus();
+            MessageHandler.GlobalMessageBusScope[] scopes =
+                new MessageHandler.GlobalMessageBusScope[scopeCount];
+            MessageHandler.SetGlobalMessageBus(original);
+            Action deepOverrideCycle = () =>
+            {
+                for (int i = 0; i < scopes.Length; ++i)
+                {
+                    scopes[i] = MessageHandler.OverrideGlobalMessageBus(overrideBus);
+                }
+
+                for (int i = scopes.Length - 1; i >= 0; --i)
+                {
+                    scopes[i].Dispose();
+                }
+            };
+
+            try
+            {
+                AllocationAssertions.AssertNoAllocations(
+                    nameof(GlobalMessageBusOverrideScopeIsZeroAllocAfterGrowingBeyondOneBlock),
+                    deepOverrideCycle
+                );
+                Assert.AreSame(
+                    original,
+                    MessageHandler.MessageBus,
+                    "Every deep measured cycle must restore the original global bus."
+                );
+            }
+            finally
+            {
+                MessageHandler.SetGlobalMessageBus(entryBus);
+            }
+        }
+
+        [Test]
+        [Category("Allocation")]
         public void RegistrationDisposableIsZeroAllocAfterWarmup()
         {
             MessageBus bus = new MessageBus();

--- a/Tests/Runtime/Core/DxMessagingStaticStateTests.cs
+++ b/Tests/Runtime/Core/DxMessagingStaticStateTests.cs
@@ -19,7 +19,8 @@ namespace DxMessaging.Tests.Runtime.Core
             MessageRegistrationHandle baselineHandle =
                 MessageRegistrationHandle.CreateMessageRegistrationHandle();
 
-            MessageRegistrationHandle.CreateMessageRegistrationHandle();
+            MessageRegistrationHandle lastPreResetHandle =
+                MessageRegistrationHandle.CreateMessageRegistrationHandle();
             MessagingDebug.enabled = true;
             MessagingDebug.LogFunction = (logLevel, message) => { };
 
@@ -47,7 +48,14 @@ namespace DxMessaging.Tests.Runtime.Core
 
             MessageRegistrationHandle resetHandle =
                 MessageRegistrationHandle.CreateMessageRegistrationHandle();
-            Assert.AreEqual(baselineHandle, resetHandle);
+            Assert.Greater(
+                resetHandle,
+                lastPreResetHandle,
+                "Reset must not reuse registration identities that stale handles may still carry. baseline={0}, lastPreReset={1}, postReset={2}",
+                baselineHandle,
+                lastPreResetHandle,
+                resetHandle
+            );
 
             object syntheticOwnerValue = syntheticOwnerField.GetValue(null);
             Assert.AreEqual(0, (int)syntheticOwnerValue);

--- a/Tests/Runtime/Core/MessageHandlerGlobalBusTests.cs
+++ b/Tests/Runtime/Core/MessageHandlerGlobalBusTests.cs
@@ -127,73 +127,244 @@ namespace DxMessaging.Tests.Runtime.Core
             Assert.AreSame(primary, MessageHandler.MessageBus);
         }
 
-        /// <summary>
-        /// Pins LIFO disposal of nested
-        /// <see cref="MessageHandler.OverrideGlobalMessageBus"/> scopes: each
-        /// scope captures the bus active at its construction, so disposing
-        /// inner-then-outer walks the chain back to the original bus.
-        /// </summary>
         [Test]
-        public void OverrideGlobalMessageBusNestedScopesRestoreInLifoOrder()
+        public void DefaultGlobalMessageBusScopeDisposalDoesNothing()
         {
-            GlobalMessageBus original = new GlobalMessageBus();
-            MessageHandler.SetGlobalMessageBus(original);
-            GlobalMessageBus outerBus = new GlobalMessageBus();
-            GlobalMessageBus innerBus = new GlobalMessageBus();
+            GlobalMessageBus current = new GlobalMessageBus();
+            MessageHandler.SetGlobalMessageBus(current);
 
-            MessageHandler.GlobalMessageBusScope outerScope =
-                MessageHandler.OverrideGlobalMessageBus(outerBus);
-            Assert.AreSame(
-                outerBus,
-                MessageHandler.MessageBus,
-                "Outer override must take effect immediately."
+            MessageHandler.GlobalMessageBusScope scope = default;
+            Assert.DoesNotThrow(
+                scope.Dispose,
+                "Disposing a default global-bus scope must be a harmless no-op."
             );
-
-            MessageHandler.GlobalMessageBusScope innerScope =
-                MessageHandler.OverrideGlobalMessageBus(innerBus);
             Assert.AreSame(
-                innerBus,
+                current,
                 MessageHandler.MessageBus,
-                "Inner override must take effect immediately."
-            );
-
-            innerScope.Dispose();
-            Assert.AreSame(
-                outerBus,
-                MessageHandler.MessageBus,
-                "Disposing the inner scope must restore the outer override bus."
-            );
-
-            outerScope.Dispose();
-            Assert.AreSame(
-                original,
-                MessageHandler.MessageBus,
-                "Disposing the outer scope must restore the original bus."
+                "A default scope must not reset or replace the current global bus."
             );
         }
 
-        /// <summary>
-        /// Pins what <see cref="MessageHandler.GlobalMessageBusScope"/>
-        /// actually does on OUT-OF-ORDER disposal (outer disposed before
-        /// inner). The implementation performs no nesting validation: each
-        /// scope independently captures the bus that was active at its own
-        /// construction and restores exactly that snapshot when disposed,
-        /// regardless of disposal order. "Sane" here means deterministic
-        /// per-scope snapshot-restore - the scope neither throws nor tries to
-        /// reconcile the stack.
-        /// </summary>
-        /// <remarks>
-        /// CONSEQUENCE (pinned below, and worth flagging to maintainers):
-        /// after disposing outer-then-inner, the globally active bus is the
-        /// OUTER override bus - the inner scope captured it as its "previous"
-        /// - NOT the original bus that was active before either override. A
-        /// caller that disposes scopes out of order is silently left on a
-        /// stale override. If GlobalMessageBusScope ever grows nesting
-        /// validation (e.g. throwing on out-of-order disposal, or restoring
-        /// the original), this test must be re-pinned deliberately.
-        /// </remarks>
+        [TestCase(true)]
+        [TestCase(false)]
+        public void CopiedGlobalMessageBusScopeDisposesExactlyOnce(bool disposeCopyFirst)
+        {
+            GlobalMessageBus original = new GlobalMessageBus();
+            MessageHandler.SetGlobalMessageBus(original);
+            GlobalMessageBus overrideBus = new GlobalMessageBus();
+            MessageHandler.GlobalMessageBusScope scope = MessageHandler.OverrideGlobalMessageBus(
+                overrideBus
+            );
+            MessageHandler.GlobalMessageBusScope copy = scope;
+
+            if (disposeCopyFirst)
+            {
+                copy.Dispose();
+            }
+            else
+            {
+                scope.Dispose();
+            }
+
+            Assert.AreSame(
+                original,
+                MessageHandler.MessageBus,
+                "The first disposal of either copy must restore the original bus. copyFirst={0}",
+                disposeCopyFirst
+            );
+
+            GlobalMessageBus intervening = new GlobalMessageBus();
+            MessageHandler.SetGlobalMessageBus(intervening);
+            if (disposeCopyFirst)
+            {
+                scope.Dispose();
+            }
+            else
+            {
+                copy.Dispose();
+            }
+
+            Assert.AreSame(
+                intervening,
+                MessageHandler.MessageBus,
+                "The stale copy must not restore over a newer global-bus change. copyFirst={0}",
+                disposeCopyFirst
+            );
+        }
+
         [Test]
-        public void OverrideGlobalMessageBusOutOfOrderDisposalRestoresConstructionSnapshots()
+        public void InterveningGlobalMessageBusChangeInvalidatesActiveScopeRestore()
+        {
+            GlobalMessageBus original = new GlobalMessageBus();
+            MessageHandler.SetGlobalMessageBus(original);
+            MessageHandler.GlobalMessageBusScope scope = MessageHandler.OverrideGlobalMessageBus(
+                new GlobalMessageBus()
+            );
+            GlobalMessageBus intervening = new GlobalMessageBus();
+
+            MessageHandler.SetGlobalMessageBus(intervening);
+            scope.Dispose();
+
+            Assert.AreSame(
+                intervening,
+                MessageHandler.MessageBus,
+                "Disposal must not restore a snapshot over a newer explicit global-bus change."
+            );
+        }
+
+        [Test]
+        public void ResetGlobalMessageBusInvalidatesActiveScopeRestore()
+        {
+            MessageHandler.SetGlobalMessageBus(new GlobalMessageBus());
+            MessageHandler.GlobalMessageBusScope scope = MessageHandler.OverrideGlobalMessageBus(
+                new GlobalMessageBus()
+            );
+
+            MessageHandler.ResetGlobalMessageBus();
+            IMessageBus resetBus = MessageHandler.MessageBus;
+            scope.Dispose();
+
+            Assert.AreSame(
+                resetBus,
+                MessageHandler.MessageBus,
+                "A scope created before ResetGlobalMessageBus must not restore stale state."
+            );
+        }
+
+        [Test]
+        public void StaticResetInvalidatesActiveScopeRestore()
+        {
+            MessageHandler.SetGlobalMessageBus(new GlobalMessageBus());
+            MessageHandler.GlobalMessageBusScope scope = MessageHandler.OverrideGlobalMessageBus(
+                new GlobalMessageBus()
+            );
+
+            DxMessagingStaticState.Reset();
+            IMessageBus resetBus = MessageHandler.MessageBus;
+            scope.Dispose();
+
+            Assert.AreSame(
+                resetBus,
+                MessageHandler.MessageBus,
+                "A scope created before DxMessagingStaticState.Reset must not restore stale state."
+            );
+        }
+
+        [Test]
+        public void OverrideGlobalMessageBusRejectsNull()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => MessageHandler.OverrideGlobalMessageBus((IMessageBus)null),
+                "A null global-bus override must fail before changing global state."
+            );
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void RecycledOverrideSlotRejectsStaleScopeGeneration(bool useStaticReset)
+        {
+            GlobalMessageBus original = new GlobalMessageBus();
+            MessageHandler.SetGlobalMessageBus(original);
+            MessageHandler.GlobalMessageBusScope stale = MessageHandler.OverrideGlobalMessageBus(
+                new GlobalMessageBus()
+            );
+
+            if (useStaticReset)
+            {
+                DxMessagingStaticState.Reset();
+            }
+            else
+            {
+                MessageHandler.SetGlobalMessageBus(original);
+            }
+
+            IMessageBus baseline = MessageHandler.MessageBus;
+            GlobalMessageBus current = new GlobalMessageBus();
+            MessageHandler.GlobalMessageBusScope currentScope =
+                MessageHandler.OverrideGlobalMessageBus(current);
+
+            stale.Dispose();
+            Assert.AreSame(
+                current,
+                MessageHandler.MessageBus,
+                "A stale generation must not end the scope that recycled its slot. staticReset={0}",
+                useStaticReset
+            );
+
+            currentScope.Dispose();
+            Assert.AreSame(
+                baseline,
+                MessageHandler.MessageBus,
+                "The recycled slot's live scope must still restore its own baseline. staticReset={0}",
+                useStaticReset
+            );
+        }
+
+        [Test]
+        public void OverrideSlotCapacityFailsWithoutMutationAndIsReusableAfterUnwind()
+        {
+            const int capacity = 1024;
+            GlobalMessageBus original = new GlobalMessageBus();
+            GlobalMessageBus overrideBus = new GlobalMessageBus();
+            MessageHandler.SetGlobalMessageBus(original);
+            MessageHandler.GlobalMessageBusScope[] scopes =
+                new MessageHandler.GlobalMessageBusScope[capacity];
+
+            for (int i = 0; i < scopes.Length; ++i)
+            {
+                scopes[i] = MessageHandler.OverrideGlobalMessageBus(overrideBus);
+            }
+
+            Assert.Throws<InvalidOperationException>(
+                () => MessageHandler.OverrideGlobalMessageBus(new GlobalMessageBus()),
+                "The first scope beyond the documented slot capacity must fail."
+            );
+            Assert.AreSame(
+                overrideBus,
+                MessageHandler.MessageBus,
+                "A capacity failure must not mutate the active global bus."
+            );
+
+            for (int i = 0; i < scopes.Length - 1; ++i)
+            {
+                scopes[i].Dispose();
+            }
+
+            Assert.Throws<InvalidOperationException>(
+                () => MessageHandler.OverrideGlobalMessageBus(overrideBus),
+                "Out-of-order-disposed ancestors keep their slots until the newest scope ends."
+            );
+            scopes[scopes.Length - 1].Dispose();
+            Assert.AreSame(
+                original,
+                MessageHandler.MessageBus,
+                "Ending the newest scope must unwind every disposed ancestor."
+            );
+
+            using (MessageHandler.OverrideGlobalMessageBus(overrideBus))
+            {
+                Assert.AreSame(
+                    overrideBus,
+                    MessageHandler.MessageBus,
+                    "Unwound slots must be reusable after capacity recovery."
+                );
+            }
+
+            Assert.AreSame(
+                original,
+                MessageHandler.MessageBus,
+                "The recovered scope must restore the pre-capacity-test bus."
+            );
+        }
+
+        [TestCase(false, false)]
+        [TestCase(false, true)]
+        [TestCase(true, false)]
+        [TestCase(true, true)]
+        public void NestedGlobalMessageBusScopeCopiesRestoreNearestActiveBus(
+            bool disposeOuterFirst,
+            bool disposeCopies
+        )
         {
             GlobalMessageBus original = new GlobalMessageBus();
             MessageHandler.SetGlobalMessageBus(original);
@@ -204,38 +375,41 @@ namespace DxMessaging.Tests.Runtime.Core
                 MessageHandler.OverrideGlobalMessageBus(outerBus);
             MessageHandler.GlobalMessageBusScope innerScope =
                 MessageHandler.OverrideGlobalMessageBus(innerBus);
+            MessageHandler.GlobalMessageBusScope outerCopy = outerScope;
+            MessageHandler.GlobalMessageBusScope innerCopy = innerScope;
             Assert.AreSame(
                 innerBus,
                 MessageHandler.MessageBus,
-                "Sanity: inner override is active before any disposal."
+                "The inner override must be active before disposal. outerFirst={0}, copies={1}",
+                disposeOuterFirst,
+                disposeCopies
             );
 
-            // Outer disposed FIRST: it restores ITS captured previous (the
-            // original bus), even though the inner scope is still open.
-            Assert.DoesNotThrow(
-                () => outerScope.Dispose(),
-                "Out-of-order disposal must not throw (no nesting validation exists)."
+            MessageHandler.GlobalMessageBusScope first = disposeOuterFirst
+                ? (disposeCopies ? outerCopy : outerScope)
+                : (disposeCopies ? innerCopy : innerScope);
+            MessageHandler.GlobalMessageBusScope second = disposeOuterFirst
+                ? (disposeCopies ? innerCopy : innerScope)
+                : (disposeCopies ? outerCopy : outerScope);
+            first.Dispose();
+
+            IMessageBus expectedAfterFirst = disposeOuterFirst ? innerBus : outerBus;
+            Assert.AreSame(
+                expectedAfterFirst,
+                MessageHandler.MessageBus,
+                "The first disposal must preserve the nearest active override. outerFirst={0}, copies={1}",
+                disposeOuterFirst,
+                disposeCopies
             );
+
+            second.Dispose();
             Assert.AreSame(
                 original,
                 MessageHandler.MessageBus,
-                "Disposing the outer scope restores the outer scope's construction snapshot (the original bus), ignoring the still-open inner scope."
+                "The second disposal must restore the original bus. outerFirst={0}, copies={1}",
+                disposeOuterFirst,
+                disposeCopies
             );
-
-            // Inner disposed SECOND: it restores ITS captured previous - the
-            // outer override bus - leaving a stale override active. See the
-            // remarks; this is the deterministic consequence of per-scope
-            // snapshot-restore without nesting validation.
-            Assert.DoesNotThrow(() => innerScope.Dispose());
-            Assert.AreSame(
-                outerBus,
-                MessageHandler.MessageBus,
-                "Disposing the inner scope restores the inner scope's construction snapshot (the OUTER override bus), not the original. Out-of-order disposal leaves a stale override active."
-            );
-
-            // Recover explicitly so no stale override leaks past this test
-            // (the fixture TearDown also restores the captured original).
-            MessageHandler.SetGlobalMessageBus(original);
         }
 
 #if UNITY_2021_3_OR_NEWER

--- a/Tests/Runtime/Core/MessageHandlerGlobalBusTests.cs
+++ b/Tests/Runtime/Core/MessageHandlerGlobalBusTests.cs
@@ -1,6 +1,7 @@
 namespace DxMessaging.Tests.Runtime.Core
 {
     using System;
+    using System.Reflection;
     using DxMessaging.Core;
     using DxMessaging.Core.MessageBus;
     using DxMessaging.Core.Messages;
@@ -301,28 +302,24 @@ namespace DxMessaging.Tests.Runtime.Core
         }
 
         [Test]
-        public void OverrideSlotCapacityFailsWithoutMutationAndIsReusableAfterUnwind()
+        public void OverrideSlotTableGrowsBeyondOneBlockAndIsReusableAfterUnwind()
         {
-            const int capacity = 1024;
+            const int scopeCount = 2049;
             GlobalMessageBus original = new GlobalMessageBus();
             GlobalMessageBus overrideBus = new GlobalMessageBus();
             MessageHandler.SetGlobalMessageBus(original);
             MessageHandler.GlobalMessageBusScope[] scopes =
-                new MessageHandler.GlobalMessageBusScope[capacity];
+                new MessageHandler.GlobalMessageBusScope[scopeCount];
 
             for (int i = 0; i < scopes.Length; ++i)
             {
                 scopes[i] = MessageHandler.OverrideGlobalMessageBus(overrideBus);
             }
 
-            Assert.Throws<InvalidOperationException>(
-                () => MessageHandler.OverrideGlobalMessageBus(new GlobalMessageBus()),
-                "The first scope beyond the documented slot capacity must fail."
-            );
             Assert.AreSame(
                 overrideBus,
                 MessageHandler.MessageBus,
-                "A capacity failure must not mutate the active global bus."
+                "The first scope in a third block must become active without a fixed-block cap."
             );
 
             for (int i = 0; i < scopes.Length - 1; ++i)
@@ -330,9 +327,10 @@ namespace DxMessaging.Tests.Runtime.Core
                 scopes[i].Dispose();
             }
 
-            Assert.Throws<InvalidOperationException>(
-                () => MessageHandler.OverrideGlobalMessageBus(overrideBus),
-                "Out-of-order-disposed ancestors keep their slots until the newest scope ends."
+            Assert.AreSame(
+                overrideBus,
+                MessageHandler.MessageBus,
+                "Out-of-order-disposed ancestors must leave the newest scope active."
             );
             scopes[scopes.Length - 1].Dispose();
             Assert.AreSame(
@@ -346,15 +344,183 @@ namespace DxMessaging.Tests.Runtime.Core
                 Assert.AreSame(
                     overrideBus,
                     MessageHandler.MessageBus,
-                    "Unwound slots must be reusable after capacity recovery."
+                    "Unwound slots must be reusable after multi-block recovery."
                 );
             }
 
             Assert.AreSame(
                 original,
                 MessageHandler.MessageBus,
-                "The recovered scope must restore the pre-capacity-test bus."
+                "The recovered scope must restore the pre-growth-test bus."
             );
+        }
+
+        [Test]
+        public void OverrideSlotStorageUsesFixedSizeSegmentsInsteadOfOneHardCapArray()
+        {
+            const int expectedBlockSize = 1024;
+            const int scopeCount = (expectedBlockSize * 2) + 1;
+            const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Static;
+            FieldInfo blocksField = typeof(MessageHandler).GetField(
+                "_globalMessageBusOverrideBlocks",
+                flags
+            );
+            FieldInfo blockSizeField = typeof(MessageHandler).GetField(
+                "GlobalMessageBusOverrideBlockSize",
+                flags
+            );
+
+            Assert.IsNotNull(
+                blocksField,
+                "Override state must use a segmented directory instead of a fixed monolithic arena."
+            );
+            Assert.IsNotNull(blockSizeField, "The fixed segment size must remain explicit.");
+            Assert.IsTrue(
+                blocksField.FieldType.IsArray
+                    && blocksField.FieldType.GetElementType()?.IsArray == true,
+                "Override storage must be a jagged array so existing state blocks never move when capacity grows."
+            );
+            Assert.AreEqual(
+                expectedBlockSize,
+                (int)blockSizeField.GetRawConstantValue(),
+                "Override storage must grow in bounded fixed-size segments."
+            );
+
+            MessageHandler.GlobalMessageBusScope[] scopes =
+                new MessageHandler.GlobalMessageBusScope[scopeCount];
+            GlobalMessageBus overrideBus = new GlobalMessageBus();
+            try
+            {
+                for (int i = 0; i < scopes.Length; ++i)
+                {
+                    scopes[i] = MessageHandler.OverrideGlobalMessageBus(overrideBus);
+                }
+
+                Array blocks = (Array)blocksField.GetValue(null);
+                int realizedBlockCount = 0;
+                foreach (Array block in blocks)
+                {
+                    if (block == null)
+                    {
+                        continue;
+                    }
+
+                    ++realizedBlockCount;
+                    Assert.AreEqual(
+                        expectedBlockSize,
+                        block.Length,
+                        "Every realized override-state segment must use the fixed block size."
+                    );
+                }
+
+                Assert.GreaterOrEqual(
+                    realizedBlockCount,
+                    3,
+                    "Crossing two boundaries must realize at least three fixed-size blocks."
+                );
+            }
+            finally
+            {
+                for (int i = scopes.Length - 1; i >= 0; --i)
+                {
+                    scopes[i].Dispose();
+                }
+            }
+        }
+
+        [Test]
+        public void OverrideSlotIndexExhaustionFailsWithoutChangingTheGlobalBus()
+        {
+            const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Static;
+            FieldInfo slotCountField = typeof(MessageHandler).GetField(
+                "_globalMessageBusOverrideSlotCount",
+                flags
+            );
+            FieldInfo freeHeadField = typeof(MessageHandler).GetField(
+                "_globalMessageBusOverrideFreeHead",
+                flags
+            );
+            GlobalMessageBus current = new GlobalMessageBus();
+            MessageHandler.SetGlobalMessageBus(current);
+            int originalSlotCount = (int)slotCountField.GetValue(null);
+            int originalFreeHead = (int)freeHeadField.GetValue(null);
+
+            try
+            {
+                slotCountField.SetValue(null, int.MaxValue);
+                freeHeadField.SetValue(null, -1);
+
+                Assert.Throws<InvalidOperationException>(
+                    () => MessageHandler.OverrideGlobalMessageBus(new GlobalMessageBus()),
+                    "A fresh slot outside the representable range must fail closed."
+                );
+                Assert.AreSame(
+                    current,
+                    MessageHandler.MessageBus,
+                    "Slot-index exhaustion must not change the active global bus."
+                );
+            }
+            finally
+            {
+                slotCountField.SetValue(null, originalSlotCount);
+                freeHeadField.SetValue(null, originalFreeHead);
+            }
+        }
+
+        [Test]
+        public void ExhaustedGenerationSlotIsBurnedAndStaleCopyCannotEndReplacement()
+        {
+            GlobalMessageBus original = new GlobalMessageBus();
+            GlobalMessageBus replacementBus = new GlobalMessageBus();
+            MessageHandler.SetGlobalMessageBus(original);
+            MessageHandler.GlobalMessageBusScope bootstrap =
+                MessageHandler.OverrideGlobalMessageBus(new GlobalMessageBus());
+            int exhaustedSlot = GetScopeSlot(bootstrap);
+            bootstrap.Dispose();
+            long originalGeneration = GetOverrideStateGeneration(exhaustedSlot);
+            SetOverrideStateGeneration(exhaustedSlot, -2);
+            MessageHandler.GlobalMessageBusScope exhaustedScope = default;
+            MessageHandler.GlobalMessageBusScope replacement = default;
+
+            try
+            {
+                exhaustedScope = MessageHandler.OverrideGlobalMessageBus(new GlobalMessageBus());
+                Assert.AreEqual(
+                    exhaustedSlot,
+                    GetScopeSlot(exhaustedScope),
+                    "The prepared slot must issue its final nonzero generation."
+                );
+                MessageHandler.GlobalMessageBusScope staleCopy = exhaustedScope;
+                exhaustedScope.Dispose();
+
+                replacement = MessageHandler.OverrideGlobalMessageBus(replacementBus);
+                Assert.AreNotEqual(
+                    exhaustedSlot,
+                    GetScopeSlot(replacement),
+                    "A slot that issued generation -1 must be burned instead of wrapping."
+                );
+
+                staleCopy.Dispose();
+                Assert.AreSame(
+                    replacementBus,
+                    MessageHandler.MessageBus,
+                    "The exhausted stale scope must not end the replacement scope."
+                );
+
+                replacement.Dispose();
+                Assert.AreSame(
+                    original,
+                    MessageHandler.MessageBus,
+                    "The replacement scope must restore the original bus."
+                );
+            }
+            finally
+            {
+                MessageHandler.SetGlobalMessageBus(original);
+                exhaustedScope.Dispose();
+                replacement.Dispose();
+                RestoreBurnedOverrideSlot(exhaustedSlot, originalGeneration);
+            }
         }
 
         [TestCase(false, false)]
@@ -410,6 +576,69 @@ namespace DxMessaging.Tests.Runtime.Core
                 disposeOuterFirst,
                 disposeCopies
             );
+        }
+
+        private static int GetScopeSlot(MessageHandler.GlobalMessageBusScope scope)
+        {
+            const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
+            FieldInfo slotField = typeof(MessageHandler.GlobalMessageBusScope).GetField(
+                "_slot",
+                flags
+            );
+            return (int)slotField.GetValue(scope) - 1;
+        }
+
+        private static long GetOverrideStateGeneration(int slot)
+        {
+            object state = GetOverrideState(slot, out _, out _);
+            return (long)GetOverrideStateField(state, "Generation").GetValue(state);
+        }
+
+        private static void SetOverrideStateGeneration(int slot, long generation)
+        {
+            object state = GetOverrideState(slot, out Array block, out int offset);
+            GetOverrideStateField(state, "Generation").SetValue(state, generation);
+            block.SetValue(state, offset);
+        }
+
+        private static void RestoreBurnedOverrideSlot(int slot, long generation)
+        {
+            const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Static;
+            FieldInfo freeHeadField = typeof(MessageHandler).GetField(
+                "_globalMessageBusOverrideFreeHead",
+                flags
+            );
+            int freeHead = (int)freeHeadField.GetValue(null);
+            object state = GetOverrideState(slot, out Array block, out int offset);
+            GetOverrideStateField(state, "PreviousBus").SetValue(state, null);
+            GetOverrideStateField(state, "Generation").SetValue(state, generation);
+            GetOverrideStateField(state, "PreviousSlot").SetValue(state, -1);
+            GetOverrideStateField(state, "NextFree").SetValue(state, freeHead);
+            GetOverrideStateField(state, "Disposed").SetValue(state, true);
+            block.SetValue(state, offset);
+            freeHeadField.SetValue(null, slot);
+        }
+
+        private static FieldInfo GetOverrideStateField(object state, string fieldName)
+        {
+            const BindingFlags flags =
+                BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance;
+            return state.GetType().GetField(fieldName, flags);
+        }
+
+        private static object GetOverrideState(int slot, out Array block, out int offset)
+        {
+            const int blockShift = 10;
+            const int blockMask = (1 << blockShift) - 1;
+            const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Static;
+            FieldInfo blocksField = typeof(MessageHandler).GetField(
+                "_globalMessageBusOverrideBlocks",
+                flags
+            );
+            Array blocks = (Array)blocksField.GetValue(null);
+            block = (Array)blocks.GetValue(slot >> blockShift);
+            offset = slot & blockMask;
+            return block.GetValue(offset);
         }
 
 #if UNITY_2021_3_OR_NEWER

--- a/Tests/Runtime/Core/TokenDisposeReuseTests.cs
+++ b/Tests/Runtime/Core/TokenDisposeReuseTests.cs
@@ -42,6 +42,175 @@ namespace DxMessaging.Tests.Runtime.Core
             DxMessagingStaticState.Reset();
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void CopiedRegistrationDisposableCannotRemoveReusedSlot(bool disposeCopyFirst)
+        {
+            BusType innerBus = new();
+            ReentrantReplayRemovalBus bus = new(innerBus);
+            MessageHandler handler = new(new InstanceId(OwnerInstanceId), bus) { active = true };
+            MessageRegistrationToken token = MessageRegistrationToken.Create(handler, bus);
+            using LeakWatcher watcher = new(
+                bus,
+                throwOnLeak: true,
+                label: nameof(CopiedRegistrationDisposableCannotRemoveReusedSlot)
+            );
+            MessageRegistrationHandle originalHandle =
+                token.RegisterUntargeted<SimpleUntargetedMessage>(
+                    (ref SimpleUntargetedMessage _) => { },
+                    priority: 1
+                );
+            token.Enable();
+            MessageRegistrationToken.RegistrationDisposable disposable = token.AsDisposable(
+                originalHandle
+            );
+            MessageRegistrationToken.RegistrationDisposable copy = disposable;
+
+            if (disposeCopyFirst)
+            {
+                copy.Dispose();
+            }
+            else
+            {
+                disposable.Dispose();
+            }
+
+            Assert.AreEqual(
+                1,
+                bus.DeregistrationAttempts,
+                "The first copy disposed must deregister the original exactly once. copyFirst={0}",
+                disposeCopyFirst
+            );
+            Assert.AreEqual(
+                0,
+                bus.RegisteredUntargeted,
+                "The original registration must be gone before its slot is reused. copyFirst={0}",
+                disposeCopyFirst
+            );
+
+            DxMessagingStaticState.Reset();
+            MessageRegistrationHandle replacementHandle =
+                token.RegisterUntargeted<SimpleUntargetedMessage>(
+                    (ref SimpleUntargetedMessage _) => { },
+                    priority: 2
+                );
+            Assert.AreEqual(
+                originalHandle.Slot,
+                replacementHandle.Slot,
+                "The regression requires the replacement to recycle the original arena slot. copyFirst={0}",
+                disposeCopyFirst
+            );
+            Assert.AreNotEqual(
+                originalHandle,
+                replacementHandle,
+                "A recycled slot must receive a new opaque identity after static reset. copyFirst={0}",
+                disposeCopyFirst
+            );
+            Assert.AreEqual(
+                1,
+                bus.RegisteredUntargeted,
+                "The replacement registration must be live before stale-copy disposal. copyFirst={0}",
+                disposeCopyFirst
+            );
+
+            if (disposeCopyFirst)
+            {
+                disposable.Dispose();
+            }
+            else
+            {
+                copy.Dispose();
+            }
+
+            Assert.AreEqual(
+                1,
+                bus.DeregistrationAttempts,
+                "The stale copy must not reach the bus after slot reuse. copyFirst={0}",
+                disposeCopyFirst
+            );
+            Assert.AreEqual(
+                1,
+                bus.RegisteredUntargeted,
+                "The stale copy must not remove the replacement registration. copyFirst={0}",
+                disposeCopyFirst
+            );
+
+            token.Dispose();
+            Assert.AreEqual(
+                2,
+                bus.DeregistrationAttempts,
+                "Token disposal must still remove the replacement registration. copyFirst={0}",
+                disposeCopyFirst
+            );
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void CopiedRegistrationDisposableRetriesFailedDeregistration(bool disposeCopyFirst)
+        {
+            BusType innerBus = new();
+            FailingDeregistrationBus bus = new(innerBus);
+            MessageHandler handler = new(new InstanceId(OwnerInstanceId), bus) { active = true };
+            MessageRegistrationToken token = MessageRegistrationToken.Create(handler, bus);
+            using LeakWatcher watcher = new(
+                bus,
+                throwOnLeak: true,
+                label: nameof(CopiedRegistrationDisposableRetriesFailedDeregistration)
+            );
+            MessageRegistrationHandle handle = token.RegisterUntargeted<SimpleUntargetedMessage>(
+                (ref SimpleUntargetedMessage _) => { }
+            );
+            token.Enable();
+            MessageRegistrationToken.RegistrationDisposable disposable = token.AsDisposable(handle);
+            MessageRegistrationToken.RegistrationDisposable copy = disposable;
+
+            MessageRegistrationToken.RegistrationDisposable first = disposeCopyFirst
+                ? copy
+                : disposable;
+            MessageRegistrationToken.RegistrationDisposable retry = disposeCopyFirst
+                ? disposable
+                : copy;
+            Assert.Throws<InvalidOperationException>(
+                first.Dispose,
+                "The first disposal must surface the bus deregistration failure."
+            );
+            Assert.AreEqual(
+                1,
+                bus.RegisteredUntargeted,
+                "A failed disposal must keep the registration live and retryable."
+            );
+
+            bus.AllowDeregistrations();
+            Assert.DoesNotThrow(
+                retry.Dispose,
+                "A copied wrapper must retry the failed deregistration."
+            );
+            Assert.AreEqual(
+                0,
+                bus.RegisteredUntargeted,
+                "The retry through a copy must remove the registration."
+            );
+            Assert.DoesNotThrow(
+                first.Dispose,
+                "A stale copy after successful retry must be harmless."
+            );
+            Assert.AreEqual(
+                0,
+                bus.RegisteredUntargeted,
+                "A stale copy must not recreate or otherwise change the removed registration."
+            );
+        }
+
+        [Test]
+        public void DefaultRegistrationDisposableDisposalDoesNothing()
+        {
+            MessageRegistrationToken.RegistrationDisposable disposable = default;
+            Assert.DoesNotThrow(
+                disposable.Dispose,
+                "Disposing a default registration wrapper must be a harmless no-op."
+            );
+        }
+
         [Test]
         public void ReplayRemovalAndSlotReuseRetainsOrphanTeardownUntilDisable()
         {

--- a/docs/advanced/runtime-configuration.md
+++ b/docs/advanced/runtime-configuration.md
@@ -59,6 +59,13 @@ var handler = new MessageHandler(new InstanceId(1)) { active = true };
 
 ### Temporarily Overriding the Global Bus
 
+> **Fixed in v3.2.3:** Override scopes are safe to copy and allocate no managed objects per scope
+> after `MessageHandler` static initialization. Keep the result as the concrete
+> `GlobalMessageBusScope` type because converting a value type to `IDisposable` boxes it. Disposing
+> any copy ends the override once. Nested scopes restore the nearest active parent even when
+> disposed out of order. A later `SetGlobalMessageBus`, `ResetGlobalMessageBus`, or
+> `DxMessagingStaticState.Reset` invalidates older scopes so they cannot restore stale state.
+
 Use `OverrideGlobalMessageBus()` when you want to temporarily replace the bus and automatically restore it later:
 
 ```csharp
@@ -86,7 +93,12 @@ Assert.AreSame(originalBus, MessageHandler.MessageBus);
 - When temporarily redirecting messages for debugging or logging
 - For scoped gameplay features that need their own message channel
 
-**Pattern:** This returns an `IDisposable`, so you can use it with `using` statements for automatic cleanup. When the scope exits (either normally or via exception), the previous bus is restored.
+**Pattern:** This returns a `GlobalMessageBusScope` struct. Use the concrete return value directly
+with a `using` statement for allocation-free cleanup after static initialization. When the scope
+exits, the nearest active previous bus is restored. The process-wide table supports 1,024 occupied
+override slots. An out-of-order-disposed parent keeps its slot until all newer scopes have ended.
+Create and dispose scopes, and set or reset the global bus, on Unity's main thread. These
+configuration APIs follow DxMessaging's single-threaded runtime contract.
 
 ### Resetting to the Default Bus
 
@@ -386,17 +398,17 @@ public class DynamicComponentManager
 
 ## Quick Reference
 
-| API                                            | Purpose                                    | Use Case                        |
-| ---------------------------------------------- | ------------------------------------------ | ------------------------------- |
-| `MessageHandler.MessageBus`                    | Access current global bus                  | Normal message emission         |
-| `MessageHandler.InitialGlobalMessageBus`       | Access original startup bus                | Diagnostics, debugging          |
-| `MessageHandler.SetGlobalMessageBus(bus)`      | Permanently replace global bus             | DI integration, test setup      |
-| `MessageHandler.OverrideGlobalMessageBus(bus)` | Temporarily override (returns IDisposable) | Test isolation, scoped features |
-| `MessageHandler.ResetGlobalMessageBus()`       | Restore original startup bus               | Test teardown, reset state      |
-| `component.Configure(bus, mode)`               | Set component's bus                        | Component configuration         |
-| `token.RetargetMessageBus(bus, mode)`          | Retarget a token                           | Fine-grained control            |
-| `MessageBusRebindMode.PreserveRegistrations`   | Keep existing registrations on old bus     | Gradual migration               |
-| `MessageBusRebindMode.RebindActive`            | Move all registrations to new bus          | Atomic switching                |
+| API                                            | Purpose                                            | Use Case                        |
+| ---------------------------------------------- | -------------------------------------------------- | ------------------------------- |
+| `MessageHandler.MessageBus`                    | Access current global bus                          | Normal message emission         |
+| `MessageHandler.InitialGlobalMessageBus`       | Access original startup bus                        | Diagnostics, debugging          |
+| `MessageHandler.SetGlobalMessageBus(bus)`      | Permanently replace global bus                     | DI integration, test setup      |
+| `MessageHandler.OverrideGlobalMessageBus(bus)` | Temporarily override with a concrete zero-GC scope | Test isolation, scoped features |
+| `MessageHandler.ResetGlobalMessageBus()`       | Restore original startup bus                       | Test teardown, reset state      |
+| `component.Configure(bus, mode)`               | Set component's bus                                | Component configuration         |
+| `token.RetargetMessageBus(bus, mode)`          | Retarget a token                                   | Fine-grained control            |
+| `MessageBusRebindMode.PreserveRegistrations`   | Keep existing registrations on old bus             | Gradual migration               |
+| `MessageBusRebindMode.RebindActive`            | Move all registrations to new bus                  | Atomic switching                |
 
 ---
 

--- a/docs/advanced/runtime-configuration.md
+++ b/docs/advanced/runtime-configuration.md
@@ -59,12 +59,14 @@ var handler = new MessageHandler(new InstanceId(1)) { active = true };
 
 ### Temporarily Overriding the Global Bus
 
-> **Fixed in v3.2.3:** Override scopes are safe to copy and allocate no managed objects per scope
-> after `MessageHandler` static initialization. Keep the result as the concrete
+> **Fixed in v3.2.3:** Override scopes are safe to copy and allocate no managed objects while
+> reusing established slot capacity. Keep the result as the concrete
 > `GlobalMessageBusScope` type because converting a value type to `IDisposable` boxes it. Disposing
 > any copy ends the override once. Nested scopes restore the nearest active parent even when
 > disposed out of order. A later `SetGlobalMessageBus`, `ResetGlobalMessageBus`, or
 > `DxMessagingStaticState.Reset` invalidates older scopes so they cannot restore stale state.
+> New peak occupancy grows the table in fixed 1,024-slot blocks instead of imposing a fixed 1,024
+> nesting cap. Growth allocates the new block and may also grow the small block directory.
 
 Use `OverrideGlobalMessageBus()` when you want to temporarily replace the bus and automatically restore it later:
 
@@ -94,9 +96,11 @@ Assert.AreSame(originalBus, MessageHandler.MessageBus);
 - For scoped gameplay features that need their own message channel
 
 **Pattern:** This returns a `GlobalMessageBusScope` struct. Use the concrete return value directly
-with a `using` statement for allocation-free cleanup after static initialization. When the scope
-exits, the nearest active previous bus is restored. The process-wide table supports 1,024 occupied
-override slots. An out-of-order-disposed parent keeps its slot until all newer scopes have ended.
+with a `using` statement for zero-GC cleanup while established slot capacity is reused. When the
+scope exits, the nearest active previous bus is restored. New peak occupancy grows the process-wide
+table in fixed 1,024-slot blocks; growth allocates a block and may also grow the small block
+directory. Grown blocks remain available for reuse until domain reload. An out-of-order-disposed
+parent keeps its slot until all newer scopes have ended.
 Create and dispose scopes, and set or reset the global bus, on Unity's main thread. These
 configuration APIs follow DxMessaging's single-threaded runtime contract.
 
@@ -398,17 +402,17 @@ public class DynamicComponentManager
 
 ## Quick Reference
 
-| API                                            | Purpose                                            | Use Case                        |
-| ---------------------------------------------- | -------------------------------------------------- | ------------------------------- |
-| `MessageHandler.MessageBus`                    | Access current global bus                          | Normal message emission         |
-| `MessageHandler.InitialGlobalMessageBus`       | Access original startup bus                        | Diagnostics, debugging          |
-| `MessageHandler.SetGlobalMessageBus(bus)`      | Permanently replace global bus                     | DI integration, test setup      |
-| `MessageHandler.OverrideGlobalMessageBus(bus)` | Temporarily override with a concrete zero-GC scope | Test isolation, scoped features |
-| `MessageHandler.ResetGlobalMessageBus()`       | Restore original startup bus                       | Test teardown, reset state      |
-| `component.Configure(bus, mode)`               | Set component's bus                                | Component configuration         |
-| `token.RetargetMessageBus(bus, mode)`          | Retarget a token                                   | Fine-grained control            |
-| `MessageBusRebindMode.PreserveRegistrations`   | Keep existing registrations on old bus             | Gradual migration               |
-| `MessageBusRebindMode.RebindActive`            | Move all registrations to new bus                  | Atomic switching                |
+| API                                            | Purpose                                     | Use Case                        |
+| ---------------------------------------------- | ------------------------------------------- | ------------------------------- |
+| `MessageHandler.MessageBus`                    | Access current global bus                   | Normal message emission         |
+| `MessageHandler.InitialGlobalMessageBus`       | Access original startup bus                 | Diagnostics, debugging          |
+| `MessageHandler.SetGlobalMessageBus(bus)`      | Permanently replace global bus              | DI integration, test setup      |
+| `MessageHandler.OverrideGlobalMessageBus(bus)` | Temporarily override; zero-GC on slot reuse | Test isolation, scoped features |
+| `MessageHandler.ResetGlobalMessageBus()`       | Restore original startup bus                | Test teardown, reset state      |
+| `component.Configure(bus, mode)`               | Set component's bus                         | Component configuration         |
+| `token.RetargetMessageBus(bus, mode)`          | Retarget a token                            | Fine-grained control            |
+| `MessageBusRebindMode.PreserveRegistrations`   | Keep existing registrations on old bus      | Gradual migration               |
+| `MessageBusRebindMode.RebindActive`            | Move all registrations to new bus           | Atomic switching                |
 
 ---
 

--- a/docs/guides/advanced.md
+++ b/docs/guides/advanced.md
@@ -26,6 +26,9 @@ Lifecycles and tokens
 - Clearing
   - A successful `token.UnregisterAll()` disables and clears staged registrations plus token-local diagnostics.
   - `token.RemoveRegistration(handle)` removes a single registration.
+  - `token.AsDisposable(handle)` returns a copy-safe concrete value type. Keep that concrete type
+    to avoid `IDisposable` boxing. Only the first successful removal has an effect; a failed removal
+    remains retryable through any copy.
 - Diagnostics
   - `token.DiagnosticMode = true` to record per-registration call counts and emissions.
 
@@ -185,7 +188,15 @@ using (MessageHandler.OverrideGlobalMessageBus(testBus))
 // previous global bus restored here
 ```
 
-The scope throws if you pass `null` and guarantees the prior bus returns even if the wrapped code throws. Pair this with `IMessageRegistrationBuilder` for clean test lifecycles.
+The concrete scope allocates no managed objects per use after `MessageHandler` static initialization
+and is safe to copy. Do not store it as `IDisposable`, which boxes the value. Nested scopes restore
+the nearest active parent even when disposed out of order. An explicit `SetGlobalMessageBus`,
+`ResetGlobalMessageBus`, or `DxMessagingStaticState.Reset` invalidates older scopes instead of
+letting them restore stale state. The scope throws for `null` and when all 1,024 process-wide
+override slots are occupied; out-of-order-disposed parents keep their slots until newer scopes end.
+Create and dispose scopes, and set or reset the global bus, on Unity's main thread. These APIs
+follow DxMessaging's single-threaded runtime contract.
+Pair this with `IMessageRegistrationBuilder` for clean test lifecycles.
 
 > **Editor note:** When the global bus is replaced with a decorated implementation, certain inspector diagnostics that rely on the concrete `MessageBus` type (e.g., registration graphs) are temporarily unavailable until the override scope ends.
 

--- a/docs/guides/advanced.md
+++ b/docs/guides/advanced.md
@@ -188,12 +188,14 @@ using (MessageHandler.OverrideGlobalMessageBus(testBus))
 // previous global bus restored here
 ```
 
-The concrete scope allocates no managed objects per use after `MessageHandler` static initialization
-and is safe to copy. Do not store it as `IDisposable`, which boxes the value. Nested scopes restore
-the nearest active parent even when disposed out of order. An explicit `SetGlobalMessageBus`,
+The concrete scope allocates no managed objects while reusing established slot capacity and is safe
+to copy. Do not store it as `IDisposable`, which boxes the value. Nested scopes restore the nearest
+active parent even when disposed out of order. An explicit `SetGlobalMessageBus`,
 `ResetGlobalMessageBus`, or `DxMessagingStaticState.Reset` invalidates older scopes instead of
-letting them restore stale state. The scope throws for `null` and when all 1,024 process-wide
-override slots are occupied; out-of-order-disposed parents keep their slots until newer scopes end.
+letting them restore stale state. The scope throws for `null`. New peak occupancy grows the table in
+fixed 1,024-slot blocks instead of imposing a fixed 1,024 nesting cap. Growth allocates the new
+block and may also grow the small block directory. Out-of-order-disposed parents keep their slots
+until newer scopes end. Grown blocks remain available for reuse until domain reload.
 Create and dispose scopes, and set or reset the global bus, on Unity's main thread. These APIs
 follow DxMessaging's single-threaded runtime contract.
 Pair this with `IMessageRegistrationBuilder` for clean test lifecycles.

--- a/progress.meta
+++ b/progress.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10bf66a111f3a6e489158a9feada8ea0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/progress/session-197-copy-safe-zero-gc-disposal.md
+++ b/progress/session-197-copy-safe-zero-gc-disposal.md
@@ -7,9 +7,9 @@ Issues: #375 copy-safe disposal and #354 docs-test SDK availability
 ## Outcome
 
 The two public disposable structs now remain safe when copied without allocating managed objects
-per operation after static initialization:
+per operation while established slot capacity is reused:
 
-- `GlobalMessageBusScope` stores a versioned index into a preallocated, reusable process-wide slot
+- `GlobalMessageBusScope` stores a versioned index into a segmented, reusable process-wide slot
   table. Copies share the authoritative slot state. Nested scopes restore the nearest active parent
   in either disposal order, explicit global-bus changes invalidate prior scopes, and stale copies
   cannot affect a scope that later recycles the same slot.
@@ -19,10 +19,12 @@ per operation after static initialization:
 - Registration handle identities no longer rewind during `DxMessagingStaticState.Reset`, preventing
   a pre-reset stale wrapper from colliding with a post-reset registration that reused its arena slot.
 
-The global override table has 1,024 occupied slots. Out-of-order-disposed ancestors retain their
-slots until all newer scopes have ended. Capacity failure, non-mutation, unwind, and reuse are
-covered and documented. Concrete scope use is zero-GC after static initialization; conversion to
-`IDisposable` boxes the value and is documented accordingly. Dispatch still reads the direct global
+The global override table starts with 1,024 slots and grows in fixed blocks when a new peak crosses
+established capacity, matching the segmented-table pattern used by UnityHelpers. Existing blocks
+never move. Out-of-order-disposed ancestors retain their slots until all newer scopes have ended.
+Growth beyond the first block, unwind, and reuse are covered and documented. Concrete scope use is
+zero-GC while established capacity is reused; a new peak allocates its block and may grow the small
+block directory. Conversion to `IDisposable` boxes the value. Dispatch still reads the direct global
 bus field and gained no per-emit work.
 
 ## Disposable Sweep
@@ -45,12 +47,13 @@ The allocation matrix now proves zero `GC.Alloc` activity after warmup for:
 
 - balanced global override creation and disposal;
 - nested slot acquisition, out-of-order unwind, and explicit invalidation;
+- repeated reuse after growing through three 1,024-slot blocks;
 - concrete `AsDisposable(handle).Dispose()` forwarding.
 
 Closures, buses, tokens, and registrations are constructed outside measured windows. Independent
 allocation review confirmed the measured paths contain no boxing, reference construction, delegate
-creation, LINQ, collection growth, or dispatch-path change. The one-time static override table is
-explicitly outside the per-operation contract.
+creation, LINQ, collection growth, or dispatch-path change. Fixed-block growth occurs only when a
+new peak crosses established capacity and is explicitly outside the steady-state contract.
 
 ## CI Improvement
 
@@ -69,6 +72,8 @@ Fresh assembly reflection proved the new runtime and allocation tests were loade
   skipped, 8 inconclusive in 294.02 seconds.
 - Post-review focused runtime fixtures: 76 passed, 0 failed in 0.24 seconds.
 - Post-review focused allocation rows: 3 passed, 0 failed in 3.85 seconds.
+- Final post-cap-removal global override fixture: 26 passed, 0 failed in 0.16 seconds.
+- Final post-cap-removal allocation rows: 4 passed, 0 failed in 4.07 seconds.
 
 The editor ended stopped, idle, outside prefab mode, with its open scene clean.
 
@@ -85,7 +90,12 @@ The editor ended stopped, idle, outside prefab mode, with its open scene clean.
 ## Review
 
 Three independent passes reviewed correctness, test coverage, and allocation behavior. Their findings
-added true generation-recycling coverage, the capacity boundary and tombstone recovery case, both
-failed-disposal retry orders, default/null cases, broader allocation branches, SDK floor correction,
-boxing and single-thread documentation, and accurate occupied-slot wording. Final allocation and
-test re-reviews reported no actionable issue.
+added true generation-recycling coverage, growth beyond the initial block and tombstone recovery,
+both failed-disposal retry orders, default/null cases, broader allocation branches, SDK floor
+correction, boxing and single-thread documentation, and removal of the initial fixed 1,024 nesting
+cap. Final re-review reported no actionable production, allocation, test, or documentation finding.
+
+## Pull Request
+
+Draft PR #385 contains the implementation and its evidence:
+https://github.com/Ambiguous-Interactive/DxMessaging/pull/385

--- a/progress/session-197-copy-safe-zero-gc-disposal.md
+++ b/progress/session-197-copy-safe-zero-gc-disposal.md
@@ -1,0 +1,91 @@
+# Session 197 - Copy-Safe Zero-GC Disposal
+
+Date: 2026-08-12
+Branch: `codex/session-197-copy-safe-disposal`
+Issues: #375 copy-safe disposal and #354 docs-test SDK availability
+
+## Outcome
+
+The two public disposable structs now remain safe when copied without allocating managed objects
+per operation after static initialization:
+
+- `GlobalMessageBusScope` stores a versioned index into a preallocated, reusable process-wide slot
+  table. Copies share the authoritative slot state. Nested scopes restore the nearest active parent
+  in either disposal order, explicit global-bus changes invalidate prior scopes, and stale copies
+  cannot affect a scope that later recycles the same slot.
+- `RegistrationDisposable` is a stateless readonly wrapper over the token and opaque registration
+  handle. The token's slot and monotonic identity validation makes every successful removal have
+  effect once, while a failed deregistration remains retryable through any copy.
+- Registration handle identities no longer rewind during `DxMessagingStaticState.Reset`, preventing
+  a pre-reset stale wrapper from colliding with a post-reset registration that reused its arena slot.
+
+The global override table has 1,024 occupied slots. Out-of-order-disposed ancestors retain their
+slots until all newer scopes have ended. Capacity failure, non-mutation, unwind, and reuse are
+covered and documented. Concrete scope use is zero-GC after static initialization; conversion to
+`IDisposable` boxes the value and is documented accordingly. Dispatch still reads the direct global
+bus field and gained no per-emit work.
+
+## Disposable Sweep
+
+The repository contains exactly two public stateful/lifecycle disposable structs, both addressed
+above. The public `MessageCache<T>.MessageCacheEnumerator`, internal `CyclicBuffer<T>` enumerator,
+and internal `RegistrationMetadataView.Enumerator` also implement `IDisposable`, but their disposal
+methods are intentional no-ops with no shared state to corrupt when copied. The private
+`MessageBus.DispatchLease` remains unchanged: all three internal call sites create and consume it
+lexically in `using` statements on the dispatch hot path, with no copy or escape. Adding external
+generation state there would add work to every emit without fixing a reachable defect.
+
+`DxMessagingRuntimeSettingsProvider.OverrideToken` is a sealed reference token rather than a
+copyable struct, but the sweep found a separate out-of-order nested restoration defect. Issue #384
+records the reproduction, allocation/API constraints, and acceptance tests for a focused fix.
+
+## Allocation Evidence
+
+The allocation matrix now proves zero `GC.Alloc` activity after warmup for:
+
+- balanced global override creation and disposal;
+- nested slot acquisition, out-of-order unwind, and explicit invalidation;
+- concrete `AsDisposable(handle).Dispose()` forwarding.
+
+Closures, buses, tokens, and registrations are constructed outside measured windows. Independent
+allocation review confirmed the measured paths contain no boxing, reference construction, delegate
+creation, LINQ, collection growth, or dispatch-path change. The one-time static override table is
+explicitly outside the per-operation contract.
+
+## CI Improvement
+
+`.docs-tests/global.json` now requests the first .NET 9 feature band (`9.0.100`) and uses
+`latestFeature`, allowing the docs tests to run with any installed stable .NET 9 feature band. A
+configuration contract guards that policy. The source-generator SDK stays exactly pinned because
+it protects the shipped analyzer payload.
+
+## Unity Evidence
+
+The shared Unity 6000.4.6f1 editor was refreshed only after a clean, stopped, main-stage preflight.
+Fresh assembly reflection proved the new runtime and allocation tests were loaded.
+
+- Full PlayMode suite before final review fixes: 997 passed, 0 failed, 1 skipped in 25.44 seconds.
+- Full EditMode main and allocation suites before final review fixes: 915 passed, 0 failed, 1
+  skipped, 8 inconclusive in 294.02 seconds.
+- Post-review focused runtime fixtures: 76 passed, 0 failed in 0.24 seconds.
+- Post-review focused allocation rows: 3 passed, 0 failed in 3.85 seconds.
+
+The editor ended stopped, idle, outside prefab mode, with its open scene clean.
+
+## Local Evidence
+
+- Documentation compilation/configuration tests: 583 passed, 0 failed.
+- Source-generator/analyzer tests: 246 passed, 0 failed, with analyzer payload copying disabled.
+- Script tests: 409 passed, 0 failed.
+- Full repository validation: passed, including package and analyzer reproducibility.
+- CSharpier, Prettier, Markdown lint, spelling, and `git diff --check`: passed.
+- The parent product-change `master` commit's Unity and performance runs completed successfully;
+  the later performance-docs update on current `master` also passed its complete static check set.
+
+## Review
+
+Three independent passes reviewed correctness, test coverage, and allocation behavior. Their findings
+added true generation-recycling coverage, the capacity boundary and tombstone recovery case, both
+failed-disposal retry orders, default/null cases, broader allocation branches, SDK floor correction,
+boxing and single-thread documentation, and accurate occupied-slot wording. Final allocation and
+test re-reviews reported no actionable issue.

--- a/progress/session-197-copy-safe-zero-gc-disposal.md.meta
+++ b/progress/session-197-copy-safe-zero-gc-disposal.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 54733ddfb9d742aa978ecd930be0833b
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## What changed

- make copied `GlobalMessageBusScope` values share versioned disposal state through a segmented reusable slot table
- grow override capacity in stable 1,024-state blocks instead of imposing a fixed 1,024 nesting cap
- preserve the nearest active nested override in either disposal order and invalidate stale scopes after explicit set/reset operations
- make `RegistrationDisposable` a stateless readonly wrapper and keep registration handle identities monotonic across static resets
- add zero-GC guards for balanced, nested, out-of-order, invalidated, registration-wrapper, and 2,049-scope reuse paths
- allow the docs-test project to run on any installed stable .NET 9 feature band
- document concrete value-type use, boxing, growth allocation, retained capacity, and the single-thread configuration contract

## Why

Both public lifecycle structs carried disposal state inside each struct copy. A copied global scope could restore stale global-bus state, while registration handles could collide after `DxMessagingStaticState.Reset` rewound the identity seed and a token slot was reused.

The first shared-state design used a fixed 1,024-entry arena. The final design follows UnityHelpers' segmented-table approach: established capacity is reused without managed allocations, while a new high-water mark allocates another fixed block and may grow the small outer directory. Existing blocks never move, and dispatch remains a direct field read with no added per-emit work.

The docs-test SDK was pinned to one exact feature band, which prevented Dependabot's updater image from running when it carried another stable .NET 9 band.

## User impact

Copied disposables can no longer restore or remove newer state. Nested global overrides unwind correctly even when disposed out of order. Failed registration removal remains retryable through any copy.

There is no fixed 1,024-scope cap. The table grows in 1,024-slot blocks. Concrete scope create/dispose is zero-GC while reusing established capacity; crossing a new peak intentionally allocates capacity. Assigning either value type to `IDisposable` still boxes and is documented.

## Validation

- Unity MCP full PlayMode: 997 passed, 0 failed, 1 skipped
- Unity MCP full EditMode main/allocation: 915 passed, 0 failed, 1 skipped, 8 inconclusive
- final global override fixture, including growth and exhaustion defenses: 26 passed, 0 failed
- final focused allocation rows, including repeated 2,049-scope reuse: 4 passed, 0 failed
- documentation tests: 583 passed
- source-generator/analyzer tests: 246 passed
- script tests: 409 passed
- `npm run validate:all`
- strict MkDocs build
- CSharpier, Prettier, Markdown lint, spelling, actionlint, and `git diff --check`
- three independent final review passes: zero actionable findings

The shared editor ended stopped, idle, on the main stage, with a clean scene.

Closes #375
Addresses #354
Follow-up: #384