### PR TITLE
Defer per-type dispatch state until emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reduce cold untargeted-handler registration allocations when registering many
+  message types that have not emitted yet. Per-message-type dispatch snapshot
+  state now materializes on the first emission instead of the first registration
+  ([#374](https://github.com/Ambiguous-Interactive/DxMessaging/issues/374)).
 - Stop generated message and constructor source from disabling all compiler
   warnings. Generated code now participates in the consumer's warning policy,
   while repository CI compiles every shipped sample and generated output with

--- a/Runtime/Core/MessageBus/MessageBus.cs
+++ b/Runtime/Core/MessageBus/MessageBus.cs
@@ -1013,6 +1013,34 @@ namespace DxMessaging.Core.MessageBus
             return true;
         }
 
+        internal bool HasDispatchStateForTesting<TMessage>(
+            RegistrationMethod method,
+            InstanceId context
+        )
+            where TMessage : IMessage
+        {
+            switch (method)
+            {
+                case RegistrationMethod.Targeted:
+                case RegistrationMethod.Broadcast:
+                case RegistrationMethod.TargetedPostProcessor:
+                case RegistrationMethod.BroadcastPostProcessor:
+                    return ContextSinkForMethod(method)
+                            .TryGetValue<TMessage>(out ContextHandlerMap handlersByContext)
+                        && handlersByContext.TryGetValue(
+                            context,
+                            out HandlerCache<int, HandlerCache> contextHandlers
+                        )
+                        && contextHandlers.dispatchState != null;
+                default:
+                    return ScalarSinkForMethod(method)
+                            .TryGetValue<TMessage>(
+                                out HandlerCache<int, HandlerCache> scalarHandlers
+                            )
+                        && scalarHandlers.dispatchState != null;
+            }
+        }
+
         // Bumped by every mutation that can change what a DispatchPlan
         // caches or decides. Plans compare their stamp against this value at
         // every emission; the emit shells also re-compare mid-emission to
@@ -5967,7 +5995,14 @@ namespace DxMessaging.Core.MessageBus
                 return;
             }
 
-            DispatchState state = handlers.dispatchState ??= new DispatchState();
+            DispatchState state = handlers.dispatchState;
+            if (state == null)
+            {
+                // No snapshot exists before this sink's first emission, so registration has
+                // nothing to invalidate. AcquireDispatchSnapshot materializes and builds the
+                // state when that first emission arrives.
+                return;
+            }
             if (state.hasPending)
             {
                 ReleaseSnapshot(ref state.pending);

--- a/Tests/Runtime/Core/MessageBusRegistrationContractTests.cs
+++ b/Tests/Runtime/Core/MessageBusRegistrationContractTests.cs
@@ -3,6 +3,7 @@ namespace DxMessaging.Tests.Runtime.Core
 {
     using System;
     using DxMessaging.Core;
+    using DxMessaging.Core.Extensions;
     using DxMessaging.Core.MessageBus;
     using DxMessaging.Tests.Runtime.Scripts.Messages;
     using NUnit.Framework;
@@ -116,6 +117,227 @@ namespace DxMessaging.Tests.Runtime.Core
             {
                 UnityEngine.Object.DestroyImmediate(go);
             }
+        }
+
+        [Test]
+        public void DispatchStateStaysLazyUntilFirstEmission(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.WithAndWithoutPostProcessorIncludingWithoutContext)
+            )]
+                MessageScenario scenario
+        )
+        {
+            MessageBus bus = new MessageBus { DiagnosticsMode = false };
+            MessageHandler handler = new MessageHandler(new InstanceId(404), bus) { active = true };
+            MessageRegistrationToken token = MessageRegistrationToken.Create(handler, bus);
+            token.Enable();
+            int calls = 0;
+            InstanceId context = new InstanceId(405);
+
+            using (
+                new LeakWatcher(
+                    bus,
+                    label: nameof(DispatchStateStaysLazyUntilFirstEmission) + ":" + scenario
+                )
+            )
+            {
+                try
+                {
+                    _ = RegisterCountingSink(scenario, token, context, () => ++calls);
+                    Assert.IsFalse(
+                        HasDispatchState(bus, scenario, context),
+                        "[{0}] Registration must not allocate dispatch state before a matching emission.",
+                        scenario
+                    );
+
+                    EmitForScenario(scenario, bus, context);
+                    Assert.AreEqual(
+                        1,
+                        calls,
+                        "[{0}] The first emission must build and use the snapshot.",
+                        scenario
+                    );
+                    Assert.IsTrue(
+                        HasDispatchState(bus, scenario, context),
+                        "[{0}] The first emission must materialize dispatch state.",
+                        scenario
+                    );
+
+                    _ = RegisterCountingSink(scenario, token, context, () => calls += 10);
+                    EmitForScenario(scenario, bus, context);
+                    Assert.AreEqual(
+                        12,
+                        calls,
+                        "[{0}] A registration after first emission must dirty and rebuild the existing state.",
+                        scenario
+                    );
+                }
+                finally
+                {
+                    token.UnregisterAll();
+                    token.Dispose();
+                    handler.active = false;
+                }
+            }
+        }
+
+        private static bool HasDispatchState(
+            MessageBus bus,
+            MessageScenario scenario,
+            InstanceId context
+        )
+        {
+            RegistrationMethod method = GetRegistrationMethod(scenario);
+            switch (scenario.Kind)
+            {
+                case MessageKind.Untargeted:
+                    return bus.HasDispatchStateForTesting<SimpleUntargetedMessage>(method, context);
+                case MessageKind.Targeted:
+                case MessageKind.TargetedWithoutTargeting:
+                    return bus.HasDispatchStateForTesting<SimpleTargetedMessage>(method, context);
+                case MessageKind.Broadcast:
+                case MessageKind.BroadcastWithoutSource:
+                    return bus.HasDispatchStateForTesting<SimpleBroadcastMessage>(method, context);
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(scenario),
+                        scenario.Kind,
+                        "Unsupported message kind."
+                    );
+            }
+        }
+
+        private static MessageRegistrationHandle RegisterCountingSink(
+            MessageScenario scenario,
+            MessageRegistrationToken token,
+            InstanceId context,
+            Action onInvoked
+        )
+        {
+            if (scenario.UsePostProcessor)
+            {
+                switch (scenario.Kind)
+                {
+                    case MessageKind.Untargeted:
+                        return token.RegisterUntargetedPostProcessor<SimpleUntargetedMessage>(
+                            (ref SimpleUntargetedMessage _) => onInvoked()
+                        );
+                    case MessageKind.Targeted:
+                        return token.RegisterTargetedPostProcessor<SimpleTargetedMessage>(
+                            context,
+                            (ref SimpleTargetedMessage _) => onInvoked()
+                        );
+                    case MessageKind.Broadcast:
+                        return token.RegisterBroadcastPostProcessor<SimpleBroadcastMessage>(
+                            context,
+                            (ref SimpleBroadcastMessage _) => onInvoked()
+                        );
+                    case MessageKind.TargetedWithoutTargeting:
+                        return token.RegisterTargetedWithoutTargetingPostProcessor<SimpleTargetedMessage>(
+                            (ref InstanceId _, ref SimpleTargetedMessage __) => onInvoked()
+                        );
+                    case MessageKind.BroadcastWithoutSource:
+                        return token.RegisterBroadcastWithoutSourcePostProcessor<SimpleBroadcastMessage>(
+                            (ref InstanceId _, ref SimpleBroadcastMessage __) => onInvoked()
+                        );
+                    default:
+                        throw UnsupportedScenario(scenario);
+                }
+            }
+
+            switch (scenario.Kind)
+            {
+                case MessageKind.Untargeted:
+                    return token.RegisterUntargeted<SimpleUntargetedMessage>(
+                        (ref SimpleUntargetedMessage _) => onInvoked()
+                    );
+                case MessageKind.Targeted:
+                    return token.RegisterTargeted<SimpleTargetedMessage>(
+                        context,
+                        (ref SimpleTargetedMessage _) => onInvoked()
+                    );
+                case MessageKind.Broadcast:
+                    return token.RegisterBroadcast<SimpleBroadcastMessage>(
+                        context,
+                        (ref SimpleBroadcastMessage _) => onInvoked()
+                    );
+                case MessageKind.TargetedWithoutTargeting:
+                    return token.RegisterTargetedWithoutTargeting<SimpleTargetedMessage>(
+                        (ref InstanceId _, ref SimpleTargetedMessage __) => onInvoked()
+                    );
+                case MessageKind.BroadcastWithoutSource:
+                    return token.RegisterBroadcastWithoutSource<SimpleBroadcastMessage>(
+                        (ref InstanceId _, ref SimpleBroadcastMessage __) => onInvoked()
+                    );
+                default:
+                    throw UnsupportedScenario(scenario);
+            }
+        }
+
+        private static RegistrationMethod GetRegistrationMethod(MessageScenario scenario)
+        {
+            switch (scenario.Kind)
+            {
+                case MessageKind.Untargeted:
+                    return scenario.UsePostProcessor
+                        ? RegistrationMethod.UntargetedPostProcessor
+                        : RegistrationMethod.Untargeted;
+                case MessageKind.Targeted:
+                    return scenario.UsePostProcessor
+                        ? RegistrationMethod.TargetedPostProcessor
+                        : RegistrationMethod.Targeted;
+                case MessageKind.Broadcast:
+                    return scenario.UsePostProcessor
+                        ? RegistrationMethod.BroadcastPostProcessor
+                        : RegistrationMethod.Broadcast;
+                case MessageKind.TargetedWithoutTargeting:
+                    return scenario.UsePostProcessor
+                        ? RegistrationMethod.TargetedWithoutTargetingPostProcessor
+                        : RegistrationMethod.TargetedWithoutTargeting;
+                case MessageKind.BroadcastWithoutSource:
+                    return scenario.UsePostProcessor
+                        ? RegistrationMethod.BroadcastWithoutSourcePostProcessor
+                        : RegistrationMethod.BroadcastWithoutSource;
+                default:
+                    throw UnsupportedScenario(scenario);
+            }
+        }
+
+        private static void EmitForScenario(
+            MessageScenario scenario,
+            IMessageBus bus,
+            InstanceId context
+        )
+        {
+            switch (scenario.Kind)
+            {
+                case MessageKind.Untargeted:
+                    SimpleUntargetedMessage untargeted = new();
+                    untargeted.EmitUntargeted(bus);
+                    return;
+                case MessageKind.Targeted:
+                case MessageKind.TargetedWithoutTargeting:
+                    SimpleTargetedMessage targeted = new();
+                    targeted.EmitTargeted(context, bus);
+                    return;
+                case MessageKind.Broadcast:
+                case MessageKind.BroadcastWithoutSource:
+                    SimpleBroadcastMessage broadcast = new();
+                    broadcast.EmitBroadcast(context, bus);
+                    return;
+                default:
+                    throw UnsupportedScenario(scenario);
+            }
+        }
+
+        private static ArgumentOutOfRangeException UnsupportedScenario(MessageScenario scenario)
+        {
+            return new ArgumentOutOfRangeException(
+                nameof(scenario),
+                scenario.Kind,
+                "Unsupported message kind."
+            );
         }
     }
 }

--- a/docs/architecture/performance.md
+++ b/docs/architecture/performance.md
@@ -29,6 +29,12 @@ for design details.
 - **Throughput.** Reported as emits per second. Higher is better. Registration
   scenarios report wall-clock time instead, where lower is better. The published
   throughput numbers come from the Standalone (IL2CPP) leg.
+- **Cold registration storage.** Registering a per-message-type handler or
+  post-processor does not create dispatch snapshot state for its routing slot.
+  That state materializes on the first matching emission, so a slot that is
+  registered but never emitted does not retain unused snapshot bookkeeping.
+  Registrations made after the first emission still invalidate the existing
+  snapshot for the next dispatch.
 - **Allocations.** Reported as the COUNT of managed GC allocations (and a companion
   byte total) observed over one measurement batch (lower is better; `0` is best for
   hot-path dispatch). Both come from Unity's `GC.Alloc` profiler recorder, which is


### PR DESCRIPTION
## Summary

- defer per-message-type dispatch snapshot state until the first matching emission
- preserve existing dirty/rebuild behavior for registrations made after a snapshot exists
- cover all five handler routing variants and their five post-processor variants
- document the cold-registration storage behavior and the measured allocation scope

## Root cause

`StageDispatchSnapshot` created a `DispatchState` during the first registration even though no active or pending dispatch snapshot existed yet. `AcquireDispatchSnapshot` already materializes and builds this state on the first matching emission, so cold registrations retained bookkeeping they could not use.

The retained change returns early only when a routing slot has no dispatch state. Once the first emission materializes a state, later registrations continue to stage the existing snapshot for rebuild. Emit shells and handler loops are unchanged.

## Impact and measurement

A local Unity 6000.4.6f1 Editor EditMode A/B/A/B registration flood over 1,000 untargeted message types moved the two-sample median from 27,289.5 to 26,332 GC allocation calls (-3.5%). The benchmark's local output embeds the common checked-out base commit rather than an immutable candidate tree identifier, so this is directional evidence only.

Marginal untargeted, targeted, and broadcast registration rows remained at 2,030 allocation calls. Local wall-clock samples were noisy (6.344-12.835 ms), and deregistration samples had ambient recorder spikes. Exact-head Standalone diagnostics were also mixed: cold-bus registration improved 17.16%, while warm-JIT registration declined 3.23%. This PR therefore makes no timing, deregistration, or IL2CPP allocation claim.

Refs #374. The issue remains open for its broader registration/deregistration research scope.

## Validation

- expanded dispatch-state contract: 17 passed, 0 failed
- full PlayMode after runtime change: 1,007 passed, 0 failed, 1 skipped
- persistent-domain PlayMode after test expansion: 1,009 passed, 0 failed, 1 skipped
- full EditMode: 687 passed, 0 failed, 1 skipped, 8 inconclusive
- full allocation assembly: 240 passed, 0 failed
- script tests: 409 passed, 0 failed
- `npm run validate:all`
- CSharpier, Prettier, Markdown lint, spelling, mixed-line-ending, and `git diff --check`
- exact-head CI, devcontainer, performance, and four-version Unity aggregates: passed
- adversarial review plus independent remediation review: zero remaining findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core MessageBus registration/dispatch snapshot staging on a hot internal path. Behavior is narrowly scoped and covered by new contract tests, but incorrect laziness could miss snapshot invalidation after first emission.
> 
> **Overview**
> **Defers per-message-type dispatch snapshot allocation until the first matching emission**, cutting cold-registration bookkeeping for handlers and post-processors that never emit.
> 
> `StageDispatchSnapshot` no longer creates a `DispatchState` on first registration. If no snapshot exists yet, registration returns early; `AcquireDispatchSnapshot` still materializes and builds state on first emit. Registrations after that continue to dirty and rebuild as before.
> 
> Adds contract coverage across all five routing kinds and their post-processor variants, plus a short performance-doc note on cold-registration storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b814ba39d0ec9d05c2a4080789d270e0dd10199f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->