### PR TITLE
Reduce cold typed-handler storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#371](https://github.com/Ambiguous-Interactive/DxMessaging/issues/371)).
 - Reduce cold untargeted-handler registration allocations when registering many
   message types that have not emitted yet. Per-message-type dispatch snapshot
-  state now materializes on the first emission instead of the first registration
+  state now materializes on the first emission instead of the first registration,
+  and ordinary typed handlers no longer allocate global accept-all slots they cannot use
   ([#374](https://github.com/Ambiguous-Interactive/DxMessaging/issues/374)).
 - Reduce registration-order bulk deregistration from quadratic to linear time
   when one token owns many distinct same-priority handlers for the same message

--- a/Runtime/Core/Internal/TypedGlobalSlotIndex.cs
+++ b/Runtime/Core/Internal/TypedGlobalSlotIndex.cs
@@ -1,7 +1,7 @@
 namespace DxMessaging.Core.Internal
 {
     /// <summary>
-    /// Const-int positions into <c>TypedHandler&lt;T&gt;._globalSlots[]</c>.
+    /// Const-int positions into <c>TypedHandler&lt;IMessage&gt;._globalSlots[]</c>.
     /// Indices are hand-written so call sites inline as immediate operands.
     /// Array length and per-index <c>null</c>-ness are validated in DEBUG
     /// builds via <c>TypedHandler&lt;T&gt;.ValidateSlotArrays()</c>.

--- a/Runtime/Core/Internal/TypedSlots.cs
+++ b/Runtime/Core/Internal/TypedSlots.cs
@@ -485,8 +485,10 @@ namespace DxMessaging.Core.Internal
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The typed handler holds an array of 6 <see cref="TypedGlobalSlot"/>
-    /// entries. The per-(<see cref="DispatchKind"/>,
+    /// The <see cref="TypedHandler{T}"/> specialization for <see cref="IMessage"/>
+    /// holds an array of 6 <see cref="TypedGlobalSlot"/> entries. Other
+    /// specializations share an empty array because they cannot accept global
+    /// registrations. The per-(<see cref="DispatchKind"/>,
     /// <see cref="DispatchVariant"/>) indexing scheme maps the six global
     /// flavours (3 kinds {<c>Untargeted</c>, <c>Targeted</c>,
     /// <c>Broadcast</c>} times 2 variants {<c>Default</c>, <c>Fast</c>}) to

--- a/Runtime/Core/MessageHandler.cs
+++ b/Runtime/Core/MessageHandler.cs
@@ -3175,13 +3175,16 @@ namespace DxMessaging.Core
         internal sealed class TypedHandler<T> : ITypedHandlerSlotSweeper
             where T : IMessage
         {
-            // Typed storage: 20 typed slots + 6 global slots. The legacy
-            // named fields were deleted so new handler variants must pick an
+            // Every message type owns 20 typed slots. Only the IMessage facade used by
+            // global accept-all registration can address the six global slots; ordinary
+            // typed handlers share the empty array instead of allocating unusable storage.
+            // The legacy named fields were deleted so new handler variants must pick an
             // explicit axis-indexed slot.
             internal readonly TypedSlot<T>[] _slots = new TypedSlot<T>[TypedSlotIndex.Length];
-            internal readonly TypedGlobalSlot[] _globalSlots = new TypedGlobalSlot[
-                TypedGlobalSlotIndex.Length
-            ];
+            internal readonly TypedGlobalSlot[] _globalSlots =
+                typeof(T) == typeof(IMessage)
+                    ? new TypedGlobalSlot[TypedGlobalSlotIndex.Length]
+                    : Array.Empty<TypedGlobalSlot>();
 
             // Constructor exists solely so the [Conditional("DEBUG")]
             // validator below runs at construction time. In Release builds
@@ -3408,10 +3411,12 @@ namespace DxMessaging.Core
                         $"_slots length is {_slots.Length} but TypedSlotIndex.Length is {TypedSlotIndex.Length}."
                     );
                 }
-                if (_globalSlots.Length != TypedGlobalSlotIndex.Length)
+                int expectedGlobalSlotCount =
+                    typeof(T) == typeof(IMessage) ? TypedGlobalSlotIndex.Length : 0;
+                if (_globalSlots.Length != expectedGlobalSlotCount)
                 {
                     throw new InvalidOperationException(
-                        $"_globalSlots length is {_globalSlots.Length} but TypedGlobalSlotIndex.Length is {TypedGlobalSlotIndex.Length}."
+                        $"_globalSlots length is {_globalSlots.Length} but the expected length for {typeof(T)} is {expectedGlobalSlotCount}."
                     );
                 }
                 // Lazy registration writers update the slot arrays; this assertion still

--- a/Tests/Editor/Contract/TypedSlotIndexCoverageTests.cs
+++ b/Tests/Editor/Contract/TypedSlotIndexCoverageTests.cs
@@ -148,9 +148,13 @@ namespace DxMessaging.Tests.Editor.Contract
         [Test]
         public void GlobalSlotIndexLengthMatchesArrayLengthOnFreshTypedHandler()
         {
-            object handler = MakeFreshTypedHandler();
+            object handler = MakeFreshTypedHandler(typeof(IMessage));
             Array slots = ReadArrayField(handler, "_globalSlots");
-            Assert.AreEqual(TypedGlobalSlotIndex.Length, slots.Length);
+            Assert.AreEqual(
+                TypedGlobalSlotIndex.Length,
+                slots.Length,
+                "TypedHandler<IMessage> must expose one slot for every global index."
+            );
         }
 
         [Test]
@@ -202,9 +206,39 @@ namespace DxMessaging.Tests.Editor.Contract
             }
 
             Array globalSlots = ReadArrayField(handler, "_globalSlots");
+            Assert.Zero(
+                globalSlots.Length,
+                "Ordinary TypedHandler<T> instances cannot use global registration slots."
+            );
+            Assert.AreSame(
+                Array.Empty<TypedGlobalSlot>(),
+                globalSlots,
+                "Ordinary TypedHandler<T> instances must share Array.Empty<TypedGlobalSlot>() "
+                    + "instead of allocating a distinct zero-length array."
+            );
             for (int i = 0; i < globalSlots.Length; ++i)
             {
                 Assert.IsNull(globalSlots.GetValue(i), "_globalSlots[" + i + "] must be null.");
+            }
+        }
+
+        [Test]
+        public void GlobalTypedHandlerRetainsEveryGlobalSlot()
+        {
+            object handler = MakeFreshTypedHandler(typeof(IMessage));
+            Array globalSlots = ReadArrayField(handler, "_globalSlots");
+
+            Assert.AreEqual(
+                TypedGlobalSlotIndex.Length,
+                globalSlots.Length,
+                "TypedHandler<IMessage> must retain every global registration slot."
+            );
+            for (int i = 0; i < globalSlots.Length; ++i)
+            {
+                Assert.IsNull(
+                    globalSlots.GetValue(i),
+                    "_globalSlots[" + i + "] must populate lazily on first registration."
+                );
             }
         }
 

--- a/Tests/Runtime/Benchmarks/HandlerCardinalityBenchmarkContractTests.cs
+++ b/Tests/Runtime/Benchmarks/HandlerCardinalityBenchmarkContractTests.cs
@@ -242,6 +242,8 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
                     HandlerStorageConstructionKind.HandlerCache,
                     HandlerStorageConstructionKind.PrioritySlot,
                     HandlerStorageConstructionKind.BusPriorityOwner,
+                    HandlerStorageConstructionKind.OrdinaryTypedHandler,
+                    HandlerStorageConstructionKind.GlobalTypedHandler,
                 },
                 (HandlerStorageConstructionKind[])
                     Enum.GetValues(typeof(HandlerStorageConstructionKind))

--- a/Tests/Runtime/Benchmarks/HandlerCardinalityBenchmarks.cs
+++ b/Tests/Runtime/Benchmarks/HandlerCardinalityBenchmarks.cs
@@ -342,13 +342,15 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
         HandlerCache,
         PrioritySlot,
         BusPriorityOwner,
+        OrdinaryTypedHandler,
+        GlobalTypedHandler,
     }
 
     /// <summary>
     /// Isolates the eager object count, bytes, and fixed-batch construction latency of
-    /// the handler-entry cache, typed priority slot, and bus priority owner. These rows run once
-    /// per benchmark execution,
-    /// independently of the cardinality matrix.
+    /// the handler-entry cache, typed priority slot, bus priority owner, ordinary typed handler,
+    /// and global typed handler. These rows run once per benchmark execution, independently of
+    /// the cardinality matrix.
     /// </summary>
     public sealed class HandlerStorageConstructionBenchmarks
     {
@@ -361,6 +363,8 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
         [TestCase(HandlerStorageConstructionKind.HandlerCache)]
         [TestCase(HandlerStorageConstructionKind.PrioritySlot)]
         [TestCase(HandlerStorageConstructionKind.BusPriorityOwner)]
+        [TestCase(HandlerStorageConstructionKind.OrdinaryTypedHandler)]
+        [TestCase(HandlerStorageConstructionKind.GlobalTypedHandler)]
         public void HandlerStorageConstructionBenchmark(HandlerStorageConstructionKind kind)
         {
             HandlerStorageConstructionBenchmarkResult result = RunScenario(kind);
@@ -382,7 +386,11 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
                 int constructed = ConstructBatch(kind, ConstructionSamples);
                 long endTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
                 s_constructionSink = null;
-                Assert.AreEqual(ConstructionSamples, constructed);
+                Assert.AreEqual(
+                    ConstructionSamples,
+                    constructed,
+                    $"Construction kind {kind} must construct the requested sample count."
+                );
                 double elapsedSeconds =
                     (endTimestamp - startTimestamp)
                     / (double)System.Diagnostics.Stopwatch.Frequency;
@@ -408,7 +416,8 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
                 Assert.AreEqual(
                     ConstructionSamples,
                     allocation.Diagnostics,
-                    "The selected allocation attempt must construct the reported sample count."
+                    $"Construction kind {kind} must construct the reported sample count in the "
+                        + "selected allocation attempt."
                 );
             }
 
@@ -447,6 +456,19 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
                         s_constructionSink = MessageBus.CreatePriorityStorageOwnerForBenchmark();
                     }
                     return count;
+                case HandlerStorageConstructionKind.OrdinaryTypedHandler:
+                    for (int index = 0; index < count; ++index)
+                    {
+                        s_constructionSink =
+                            new MessageHandler.TypedHandler<StorageConstructionMessage>();
+                    }
+                    return count;
+                case HandlerStorageConstructionKind.GlobalTypedHandler:
+                    for (int index = 0; index < count; ++index)
+                    {
+                        s_constructionSink = new MessageHandler.TypedHandler<IMessage>();
+                    }
+                    return count;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(kind), kind, null);
             }
@@ -454,18 +476,61 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
 
         private static void ValidateFreshConstruction(HandlerStorageConstructionKind kind)
         {
-            Assert.AreEqual(1, ConstructBatch(kind, 1));
+            Assert.AreEqual(
+                1,
+                ConstructBatch(kind, 1),
+                $"Construction kind {kind} must create one fresh storage owner."
+            );
             if (kind == HandlerStorageConstructionKind.BusPriorityOwner)
             {
                 Assert.IsTrue(
                     MessageBus.TryObservePriorityStorageOwnerForBenchmark(
                         s_constructionSink,
                         out MessageBus.PriorityStorageObservation observation
-                    )
+                    ),
+                    $"Construction kind {kind} must expose its fresh storage observation."
                 );
-                Assert.Zero(observation.Entries);
-                Assert.Zero(observation.MapCapacity);
-                Assert.Zero(observation.OrderCapacity);
+                Assert.Zero(
+                    observation.Entries,
+                    $"Construction kind {kind} must start with zero priority entries."
+                );
+                Assert.Zero(
+                    observation.MapCapacity,
+                    $"Construction kind {kind} must not eagerly allocate the priority map."
+                );
+                Assert.Zero(
+                    observation.OrderCapacity,
+                    $"Construction kind {kind} must not eagerly allocate priority order storage."
+                );
+            }
+            else if (kind == HandlerStorageConstructionKind.OrdinaryTypedHandler)
+            {
+                MessageHandler.TypedHandler<StorageConstructionMessage> handler =
+                    (MessageHandler.TypedHandler<StorageConstructionMessage>)s_constructionSink;
+                Assert.AreEqual(
+                    TypedSlotIndex.Length,
+                    handler._slots.Length,
+                    $"Construction kind {kind} must retain every ordinary typed slot."
+                );
+                Assert.Zero(
+                    handler._globalSlots.Length,
+                    $"Construction kind {kind} must omit global registration slots."
+                );
+            }
+            else if (kind == HandlerStorageConstructionKind.GlobalTypedHandler)
+            {
+                MessageHandler.TypedHandler<IMessage> handler =
+                    (MessageHandler.TypedHandler<IMessage>)s_constructionSink;
+                Assert.AreEqual(
+                    TypedSlotIndex.Length,
+                    handler._slots.Length,
+                    $"Construction kind {kind} must retain every ordinary typed slot."
+                );
+                Assert.AreEqual(
+                    TypedGlobalSlotIndex.Length,
+                    handler._globalSlots.Length,
+                    $"Construction kind {kind} must retain every global registration slot."
+                );
             }
             s_constructionSink = null;
         }

--- a/docs/architecture/performance.md
+++ b/docs/architecture/performance.md
@@ -29,12 +29,9 @@ for design details.
 - **Throughput.** Reported as emits per second. Higher is better. Registration
   scenarios report wall-clock time instead, where lower is better. The published
   throughput numbers come from the Standalone (IL2CPP) leg.
-- **Cold registration storage.** Registering a per-message-type handler or
-  post-processor does not create dispatch snapshot state for its routing slot.
-  That state materializes on the first matching emission, so a slot that is
-  registered but never emitted does not retain unused snapshot bookkeeping.
-  Registrations made after the first emission still invalidate the existing
-  snapshot for the next dispatch.
+- **Cold registration storage.** See
+  [Cold registration storage](#cold-registration-storage) for the state omitted
+  until a message type needs it.
 - **Allocations.** Reported as the COUNT of managed GC allocations (and a companion
   byte total) observed over one measurement batch (lower is better; `0` is best for
   hot-path dispatch). Both come from Unity's `GC.Alloc` profiler recorder, which is
@@ -58,6 +55,21 @@ for design details.
   technology per scenario column is rendered in bold (ties are all bolded;
   `N/A` never wins). The GC-allocations and GC-allocated-bytes matrices are not
   bolded: an allocation count or byte total is a property to read, not a race.
+
+## Cold registration storage
+
+> **Changed in v3.3.0**
+
+Registering a per-message-type handler or post-processor does not create dispatch
+snapshot state for its routing slot. That state materializes on the first matching
+emission, so a slot that is registered but never emitted does not retain unused
+snapshot bookkeeping. Registrations made after the first emission still invalidate
+the existing snapshot for the next dispatch.
+
+Ordinary per-message-type handlers also omit the six-slot global accept-all table.
+Only the `IMessage` facade used by `RegisterGlobalAcceptAll` owns that table. A local
+Mono construction A/B/A removed one allocation and 80 allocated bytes per ordinary
+typed handler while leaving global handler construction unchanged.
 
 ## Registration-order bulk teardown
 


### PR DESCRIPTION
## Summary

- share `Array.Empty<TypedGlobalSlot>()` across ordinary `TypedHandler<T>` instances
- retain the six-slot global table only on `TypedHandler<IMessage>`, the specialization used by `RegisterGlobalAcceptAll`
- add structural regression coverage and ordinary/global construction benchmark rows
- document the cold-registration storage change

## Why

Every ordinary per-message-type handler eagerly allocated a six-element global accept-all slot array even though only `TypedHandler<IMessage>` can address those slots. Projects that touch many message types therefore paid one unnecessary managed allocation per typed handler.

## Impact

Local Mono A/B/A construction probes for 1,000 ordinary typed handlers moved from 3,000 allocations / 312,000 bytes to 2,000 allocations / 232,000 bytes, returned to the control result, and repeated the candidate result. Global handler construction remained 3,000 allocations / 312,000 bytes in every row.

A fresh-domain 1,000-type cold registration comparison observed 756 fewer allocation calls and 69,358 fewer allocated bytes. Same-type marginal registration stayed exactly unchanged at 2,030 allocation calls. Timing samples are intentionally not used for a performance claim.

The dispatch path is unchanged; the type check runs only when a typed handler is constructed.

## Validation

- focused EditMode contracts: 36 passed, 0 failed
- focused PlayMode global/benchmark contracts: 62 passed, 0 failed
- Editor allocation assembly: 240 passed, 0 failed
- full Editor assembly: 691 passed, 0 failed
- full Runtime PlayMode assembly twice: 1,019 passed, 0 failed per run
- remediated typed-slot contracts: 17 passed, 0 failed
- construction benchmark fixture: 5 passed, 0 failed
- JavaScript tests: 410 passed
- documentation snippet tests: 583 passed
- `npm run validate:all`
- Prettier, Markdownlint, cspell, CSharpier, and `git diff --check`
- two-stage adversarial review ended with zero findings

The exact post-#391 main baseline completed green across CI, devcontainer, performance, and Unity workflows.

Refs #374.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dispatch behavior is unchanged; the `typeof(T) == typeof(IMessage)` branch runs only at handler construction, and global accept-all registration still uses the dedicated `TypedHandler<IMessage>` path.
> 
> **Overview**
> **Cold typed-handler storage** no longer pays for global accept-all tables on every message type. `TypedHandler<T>` still owns 20 typed slots, but `_globalSlots` is now a full six-element array only when `T` is `IMessage` (the facade used by `RegisterGlobalAcceptAll`). All other specializations share `Array.Empty<TypedGlobalSlot>()` instead of allocating unusable storage.
> 
> DEBUG validation, contract tests, and handler-storage construction benchmarks were extended to lock in the split between ordinary and global typed handlers. Performance docs now call out that ordinary handlers omit the global table and document the measured construction savings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 104791159678acb03c7e2eb8bc7e4a0ea8644b72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->