### PR TITLE
Fix Message Monitor detail resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix Message Monitor resizing so one persisted divider controls the complete
+  log details area. Wrapped stack frames now keep their full line height without
+  clipped text or extra vertical gaps
+  ([#344](https://github.com/Ambiguous-Interactive/DxMessaging/issues/344)).
 - Fix nested runtime-settings overrides restoring ended settings when their
   tokens are disposed out of order. Static reset now invalidates older override
   tokens so they cannot replace newer configuration

--- a/Editor/DxMessagingEditorTheme.cs
+++ b/Editor/DxMessagingEditorTheme.cs
@@ -76,6 +76,7 @@ namespace DxMessaging.Editor
         internal const string DetailTitleClassName = "dx-detail__title";
         internal const string DetailFrameClassName = "dx-detail__frame";
         internal const string DetailLinkClassName = "dx-detail__link";
+        internal const string DetailStackLinkClassName = "dx-detail__stack-link";
         internal const string DetailActiveClassName = "dx-detail__active";
 
         /// <summary>
@@ -86,7 +87,7 @@ namespace DxMessaging.Editor
         internal const string ClickableClassName = "dx-clickable";
 
         /// <summary>
-        /// The grab strip <see cref="CreateResizeHandle"/> renders under a resizable panel.
+        /// The grab strip <see cref="CreateResizeHandle"/> renders next to a resizable panel.
         /// </summary>
         internal const string ResizerClassName = "dx-resizer";
         internal const string KeyValueClassName = "dx-kv";
@@ -294,13 +295,23 @@ namespace DxMessaging.Editor
         /// <param name="onHeightChanged">
         /// Raised with each dragged height so the caller can remember it across those rebuilds.
         /// </param>
+        /// <param name="growsUpward">
+        /// Whether dragging upward increases the target height. Use this when the handle sits
+        /// above its target, such as the divider between a log and its lower details pane.
+        /// </param>
+        /// <param name="allowTargetShrink">
+        /// Whether layout may shrink the resized target below its requested height when its
+        /// parent has less room. Keep this enabled for a persisted pane in a resizable window.
+        /// </param>
         internal static VisualElement CreateResizeHandle(
             VisualElement target,
             float minHeight,
             float maxHeight,
             string name = null,
             float initialHeight = 0f,
-            Action<float> onHeightChanged = null
+            Action<float> onHeightChanged = null,
+            bool growsUpward = false,
+            bool allowTargetShrink = false
         )
         {
             VisualElement handle = new();
@@ -317,7 +328,7 @@ namespace DxMessaging.Editor
 
             if (initialHeight > 0f)
             {
-                ApplyResizedHeight(target, initialHeight, minHeight, maxHeight);
+                ApplyResizedHeight(target, initialHeight, minHeight, maxHeight, allowTargetShrink);
             }
 
             float pointerStartY = 0f;
@@ -332,14 +343,16 @@ namespace DxMessaging.Editor
                 }
 
                 pointerStartY = evt.position.y;
-                // Prefer the inline style once one exists, because a shrinkable target resolves
-                // to whatever space it was given and successive drags would otherwise each start
-                // from a different origin than the last one ended at. UI Toolkit reports
+                // A window-level target may resolve below its remembered inline height when the
+                // window is short. Start that drag from what the reader can see or a small drag
+                // would have to erase hundreds of hidden pixels before anything moved. Fixed-size
+                // targets keep using their inline height so successive drags start where the last
+                // one ended. UI Toolkit reports
                 // `Undefined` when a pixel value IS set and `Null` when none is -- measured, and
                 // the opposite of what the names suggest -- so before the first drag this falls
                 // back to the resolved height rather than reading a `value` of 0 and jumping.
                 startHeight =
-                    target.style.height.keyword == StyleKeyword.Undefined
+                    !allowTargetShrink && target.style.height.keyword == StyleKeyword.Undefined
                         ? target.style.height.value.value
                         : target.resolvedStyle.height;
                 handle.CapturePointer(evt.pointerId);
@@ -352,9 +365,10 @@ namespace DxMessaging.Editor
                     return;
                 }
 
-                float requested = startHeight + (evt.position.y - pointerStartY);
+                float pointerDelta = evt.position.y - pointerStartY;
+                float requested = startHeight + (growsUpward ? -pointerDelta : pointerDelta);
                 onHeightChanged?.Invoke(
-                    ApplyResizedHeight(target, requested, minHeight, maxHeight)
+                    ApplyResizedHeight(target, requested, minHeight, maxHeight, allowTargetShrink)
                 );
                 evt.StopPropagation();
             });
@@ -374,13 +388,15 @@ namespace DxMessaging.Editor
         /// the height actually used. The cap has to move with it -- a `max-height` left below the
         /// dragged height silently wins -- and so does `flex-shrink`: these panels are built
         /// shrinkable so they give space back when the window is short, which also means a plain
-        /// height is only a starting size that Yoga takes straight back.
+        /// height is only a starting size that Yoga takes straight back unless the caller
+        /// explicitly keeps shrink enabled for a window-level pane.
         /// </summary>
         internal static float ApplyResizedHeight(
             VisualElement target,
             float requestedHeight,
             float minHeight,
-            float maxHeight
+            float maxHeight,
+            bool allowTargetShrink = false
         )
         {
             if (target == null)
@@ -391,7 +407,7 @@ namespace DxMessaging.Editor
             float clamped = Mathf.Clamp(requestedHeight, minHeight, maxHeight);
             target.style.height = clamped;
             target.style.maxHeight = maxHeight;
-            target.style.flexShrink = 0f;
+            target.style.flexShrink = allowTargetShrink ? 1f : 0f;
             return clamped;
         }
 

--- a/Editor/Theme/DxMessagingTheme.uss
+++ b/Editor/Theme/DxMessagingTheme.uss
@@ -53,6 +53,14 @@
     color: var(--dx-text);
 }
 .dx-tool-btn:hover { background-color: var(--dx-tool-btn-hover); }
+.dx-detail__stack-link {
+    height: 18px;
+    min-height: 18px;
+    padding-left: 4px;
+    padding-right: 4px;
+    margin-top: 0;
+    margin-bottom: 0;
+}
 
 /* record toggle */
 .dx-record {
@@ -260,7 +268,7 @@
     border-radius: var(--dx-r-chip);
 }
 
-/* Grab strip under a resizable panel. Fixed height and no growth, so it never takes
+/* Grab strip next to a resizable panel. Fixed height and no growth, so it never takes
    space from the panel it resizes. */
 .dx-resizer {
     height: 5px;

--- a/Editor/Windows/DxMessagingMessageMonitorLiveView.cs
+++ b/Editor/Windows/DxMessagingMessageMonitorLiveView.cs
@@ -132,6 +132,12 @@ namespace DxMessaging.Editor.Windows
 
         /// <summary>Raised by the Snapshot button to leave live mode.</summary>
         internal Action OnExitLiveMode { get; set; }
+
+        /// <summary>Remembered height of the shared log/details divider, or 0 for its default.</summary>
+        internal float InitialDetailsPaneHeight { get; set; }
+
+        /// <summary>Raised while the reader drags the shared log/details divider.</summary>
+        internal Action<float> OnDetailsPaneHeightChanged { get; set; }
     }
 
     /// <summary>
@@ -215,7 +221,9 @@ namespace DxMessaging.Editor.Windows
         /// </summary>
         private const int ChipLabelWidth = 0;
 
-        private const int DetailStackTraceMaxHeight = 120;
+        private const int DetailsMaxHeightPercent = 45;
+
+        private const int MessageListMinHeight = 56;
 
         // The body renders into four fixed slots so a poll can update each independently. Named
         // only so the UI Toolkit debugger reads clearly; nothing queries them.
@@ -244,6 +252,8 @@ namespace DxMessaging.Editor.Windows
             internal VisualElement ListSlot { get; set; }
 
             internal VisualElement DetailSlot { get; set; }
+
+            internal VisualElement DetailsResizer { get; set; }
 
             internal VisualElement FooterSlot { get; set; }
 
@@ -301,6 +311,8 @@ namespace DxMessaging.Editor.Windows
             internal void DropDetail()
             {
                 DetailSlot.Clear();
+                DetailSlot.style.display = DisplayStyle.None;
+                DetailsResizer.style.display = DisplayStyle.None;
                 _detailFirstTraceId = 0;
                 _detailLastTraceId = 0;
                 _detailCount = 0;
@@ -332,6 +344,8 @@ namespace DxMessaging.Editor.Windows
 
             VisualElement body = new() { name = BodyName };
             body.style.flexGrow = 1;
+            body.style.flexShrink = 1;
+            body.style.minHeight = 0;
             root.Add(body);
             RenderBody(body, recorder, viewState, diagnosticsEnabled, callbacks);
             return root;
@@ -367,9 +381,10 @@ namespace DxMessaging.Editor.Windows
                 throw new ArgumentNullException(nameof(recorder));
             }
 
-            LiveBodyState state = EnsureBodyState(body);
+            callbacks ??= new MessageMonitorLiveViewCallbacks();
+            LiveBodyState state = EnsureBodyState(body, callbacks);
             state.ViewState = viewState;
-            state.Callbacks = callbacks ?? new MessageMonitorLiveViewCallbacks();
+            state.Callbacks = callbacks;
 
             List<MessageMonitorLiveEntry> rows = FilterRows(recorder.Entries, viewState);
             if (rows.Count == 0)
@@ -905,6 +920,8 @@ namespace DxMessaging.Editor.Windows
 
             state.DetailSlot.Clear();
             state.DetailSlot.Add(CreateDetail(row));
+            state.DetailSlot.style.display = DisplayStyle.Flex;
+            state.DetailsResizer.style.display = DisplayStyle.Flex;
             state.RememberDetail(row);
         }
 
@@ -912,7 +929,10 @@ namespace DxMessaging.Editor.Windows
         /// Builds the body's four slots on first render and hands back the state they are tracked
         /// in. A body that already carries state keeps every element it has.
         /// </summary>
-        private static LiveBodyState EnsureBodyState(VisualElement body)
+        private static LiveBodyState EnsureBodyState(
+            VisualElement body,
+            MessageMonitorLiveViewCallbacks callbacks
+        )
         {
             if (body.userData is LiveBodyState existing)
             {
@@ -920,14 +940,32 @@ namespace DxMessaging.Editor.Windows
             }
 
             body.Clear();
-            LiveBodyState state = new();
+            LiveBodyState state = new() { Callbacks = callbacks };
             body.Add(CreateListHeader());
 
             state.ListSlot = new VisualElement { name = ListSlotName };
             state.ListSlot.style.flexGrow = 1;
+            state.ListSlot.style.flexShrink = 1;
+            state.ListSlot.style.minHeight = MessageListMinHeight;
             body.Add(state.ListSlot);
 
             state.DetailSlot = new VisualElement { name = DetailSlotName };
+            state.DetailSlot.style.flexShrink = 1;
+            if (callbacks.InitialDetailsPaneHeight <= 0f)
+            {
+                state.DetailSlot.style.maxHeight = Length.Percent(DetailsMaxHeightPercent);
+            }
+            state.DetailsResizer = DxMessagingEditorTheme.CreateResizeHandle(
+                state.DetailSlot,
+                DxMessagingMessageMonitorWindow.DetailsPaneMinHeight,
+                DxMessagingMessageMonitorWindow.DetailsPaneResizeMaxHeight,
+                DxMessagingMessageMonitorWindow.DetailsPaneResizerName,
+                callbacks.InitialDetailsPaneHeight,
+                height => state.Callbacks.OnDetailsPaneHeightChanged?.Invoke(height),
+                growsUpward: true,
+                allowTargetShrink: true
+            );
+            body.Add(state.DetailsResizer);
             body.Add(state.DetailSlot);
 
             state.FooterSlot = new VisualElement { name = FooterSlotName };
@@ -956,6 +994,10 @@ namespace DxMessaging.Editor.Windows
         {
             VisualElement detail = new() { name = DetailName };
             detail.AddToClassList(DxMessagingEditorTheme.DetailClassName);
+            detail.style.flexGrow = 1;
+            detail.style.flexShrink = 1;
+            detail.style.minHeight = 0;
+            detail.style.overflow = Overflow.Hidden;
             DxMessagingEditorTheme.ApplyCompleteBorder(
                 detail,
                 DxMessagingEditorPalette.BorderPanel
@@ -963,6 +1005,7 @@ namespace DxMessaging.Editor.Windows
 
             VisualElement head = new();
             head.AddToClassList(DxMessagingEditorTheme.DetailHeadClassName);
+            head.style.flexShrink = 0;
             string routeKind = DxMessagingEditorPalette.NormalizeRouteKind(row.Entry.RouteKind);
             Label badge = new(string.IsNullOrEmpty(routeKind) ? "Other" : routeKind);
             DxMessagingEditorTheme.AddRouteKindTypeBadgeClasses(badge, routeKind);
@@ -999,16 +1042,19 @@ namespace DxMessaging.Editor.Windows
             card.Add(CreateKeyValue("Count", row.Count.ToString(CultureInfo.InvariantCulture)));
             card.Add(CreateKeyValue("Dispatch", CreateTraceRangeText(row)));
             card.Add(CreateKeyValue("Observed", CreateObservedRangeText(row)));
-            detail.Add(card);
-
-            detail.Add(
+            ScrollView detailBody = new(ScrollViewMode.Vertical);
+            detailBody.style.flexGrow = 1;
+            detailBody.style.flexShrink = 1;
+            detailBody.style.minHeight = 0;
+            detailBody.Add(card);
+            detailBody.Add(
                 DxMessagingMessageMonitorWindow.CreateStackTraceSection(
                     row.Entry,
                     DetailStackFoldoutName,
-                    DetailStackFirstFrameLabelName,
-                    DetailStackTraceMaxHeight
+                    DetailStackFirstFrameLabelName
                 )
             );
+            detail.Add(detailBody);
 
             return detail;
         }

--- a/Editor/Windows/DxMessagingMessageMonitorWindow.cs
+++ b/Editor/Windows/DxMessagingMessageMonitorWindow.cs
@@ -64,7 +64,7 @@ namespace DxMessaging.Editor.Windows
         internal const string DetailsContextRowName = "dxmessaging-monitor-details-context-row";
         internal const string DetailsStackFrameRowClassName =
             "dxmessaging-monitor-details-stack-frame";
-        internal const string DetailsStackResizerName = "dxmessaging-monitor-details-stack-resizer";
+        internal const string DetailsPaneResizerName = "dxmessaging-monitor-details-resizer";
         internal const string ComponentResizerName = "dxmessaging-monitor-component-resizer";
         internal const string BreakdownFoldoutName = "dxmessaging-monitor-breakdown";
         internal const string VisibleMessageTypeLanesName =
@@ -117,6 +117,9 @@ namespace DxMessaging.Editor.Windows
         internal const string SnapshotModeHintText =
             "Buffered bus history as of the last Refresh. One row per emission, newest first, nothing merged.";
 
+        internal const string DetailsPaneHeightPreferenceKey =
+            "WallstopStudios.DxMessaging.MessageMonitor.DetailsPaneHeight";
+
         /// <summary>
         /// How the log and the detail pane divide a window that can be dragged down to its 320 px
         /// minimum.
@@ -134,6 +137,10 @@ namespace DxMessaging.Editor.Windows
 
         private const int DetailsMaxHeightPercent = 45;
 
+        internal const int DetailsPaneMinHeight = 80;
+
+        internal const int DetailsPaneResizeMaxHeight = 900;
+
         /// <summary>
         /// Floor for a disclosure section, sized to its own toggle header. A <see cref="Foldout"/>
         /// that shrinks has to keep at least the row a reader clicks to open it: without this floor
@@ -141,8 +148,6 @@ namespace DxMessaging.Editor.Windows
         /// of the window. Compression below the floor goes to the scrolling lists inside instead.
         /// </summary>
         private const int FoldoutHeaderMinHeight = 22;
-
-        private const int DetailsStackTraceMaxHeight = 140;
 
         private const int LanePillScrollMaxHeight = 96;
 
@@ -152,10 +157,6 @@ namespace DxMessaging.Editor.Windows
         /// #344's resize request is that the shipped caps were chosen for a window the reader
         /// does not have.
         /// </summary>
-        internal const int StackTraceMinHeight = 40;
-
-        internal const int StackTraceResizeMaxHeight = 640;
-
         internal const int ComponentPanelMinHeight = 60;
 
         internal const int ComponentPanelResizeMaxHeight = 720;
@@ -168,6 +169,9 @@ namespace DxMessaging.Editor.Windows
 
         [SerializeField]
         private bool _liveMode;
+
+        [SerializeField]
+        private float _detailsPaneHeight;
 
         private MessageMonitorViewState _viewState = MessageMonitorViewState.Default;
         private MessageMonitorLiveRecorder _liveRecorder;
@@ -198,6 +202,10 @@ namespace DxMessaging.Editor.Windows
 
         private void OnEnable()
         {
+            if (_detailsPaneHeight <= 0f)
+            {
+                _detailsPaneHeight = EditorPrefs.GetFloat(DetailsPaneHeightPreferenceKey, 0f);
+            }
             EditorApplication.playModeStateChanged += HandlePlayModeStateChanged;
             DxMessagingEditorSourceLinks.MessageSourceIndexChanged -=
                 HandleMessageSourceIndexChanged;
@@ -211,6 +219,10 @@ namespace DxMessaging.Editor.Windows
             DxMessagingEditorSourceLinks.MessageSourceIndexChanged -=
                 HandleMessageSourceIndexChanged;
             StopLivePump();
+            if (_detailsPaneHeight > 0f)
+            {
+                EditorPrefs.SetFloat(DetailsPaneHeightPreferenceKey, _detailsPaneHeight);
+            }
         }
 
         /// <summary>
@@ -322,7 +334,9 @@ namespace DxMessaging.Editor.Windows
                 Refresh,
                 exportText => EditorGUIUtility.systemCopyBuffer = exportText,
                 components,
-                EnterLiveMode
+                EnterLiveMode,
+                _detailsPaneHeight,
+                RememberDetailsPaneHeight
             );
         }
 
@@ -374,6 +388,8 @@ namespace DxMessaging.Editor.Windows
                             RenderLiveBody();
                         },
                         OnExitLiveMode = ExitLiveMode,
+                        InitialDetailsPaneHeight = _detailsPaneHeight,
+                        OnDetailsPaneHeightChanged = RememberDetailsPaneHeight,
                     }
                 )
             );
@@ -408,8 +424,15 @@ namespace DxMessaging.Editor.Windows
                         _liveViewState = state;
                         RenderLiveBody();
                     },
+                    InitialDetailsPaneHeight = _detailsPaneHeight,
+                    OnDetailsPaneHeightChanged = RememberDetailsPaneHeight,
                 }
             );
+        }
+
+        private void RememberDetailsPaneHeight(float height)
+        {
+            _detailsPaneHeight = height;
         }
 
         private void StartLivePump()
@@ -545,7 +568,9 @@ namespace DxMessaging.Editor.Windows
             Action onRefresh = null,
             Action<string> onCopyExport = null,
             IReadOnlyList<ComponentMonitorEntry> componentEntries = null,
-            Action onEnterLiveMode = null
+            Action onEnterLiveMode = null,
+            float initialDetailsPaneHeight = 0f,
+            Action<float> onDetailsPaneHeightChanged = null
         )
         {
             if (root == null)
@@ -565,6 +590,8 @@ namespace DxMessaging.Editor.Windows
                 State = viewState,
                 OnViewStateChanged = onViewStateChanged,
                 OnCopyExport = onCopyExport,
+                DetailsPaneHeight = initialDetailsPaneHeight,
+                OnDetailsPaneHeightChanged = onDetailsPaneHeightChanged,
             };
 
             // The surface keeps a handle to its own state so a background source index that
@@ -648,7 +675,9 @@ namespace DxMessaging.Editor.Windows
             /// </summary>
             internal float ComponentPanelHeight { get; set; }
 
-            internal float StackTraceHeight { get; set; }
+            internal float DetailsPaneHeight { get; set; }
+
+            internal Action<float> OnDetailsPaneHeightChanged { get; set; }
 
             internal Action<MessageMonitorViewState> OnViewStateChanged { get; set; }
 
@@ -745,7 +774,7 @@ namespace DxMessaging.Editor.Windows
             }
 
             ui.DetailsSlot.Clear();
-            ui.DetailsSlot.Add(CreateDetailsPane(rows[selectedEntryIndex], ui));
+            ui.DetailsSlot.Add(CreateDetailsPane(rows[selectedEntryIndex]));
         }
 
         /// <summary>
@@ -1003,12 +1032,32 @@ namespace DxMessaging.Editor.Windows
             ui.List = list;
 
             VisualElement detailsSlot = new();
-            // Capped AND shrinkable, with no floor of its own. The cap keeps the pane from taking
-            // the window on a tall window; the shrink keeps it inside one whose chrome is taller
-            // than expected, which is how 2021.3 differs from 6000.x for the same window size.
+            // The detail pane is the one resizable lower area. Its handle sits above it, so an
+            // upward drag grows the pane and gives the scrolling log less room. It remains
+            // shrinkable at short window heights so the existing no-overflow contract wins over
+            // a remembered size from a taller layout.
             detailsSlot.style.flexShrink = 1;
-            detailsSlot.style.maxHeight = Length.Percent(DetailsMaxHeightPercent);
-            detailsSlot.Add(CreateDetailsPane(filteredEntries[selectedEntryIndex], ui));
+            if (ui.DetailsPaneHeight <= 0f)
+            {
+                detailsSlot.style.maxHeight = Length.Percent(DetailsMaxHeightPercent);
+            }
+            messageSection.Add(
+                DxMessagingEditorTheme.CreateResizeHandle(
+                    detailsSlot,
+                    DetailsPaneMinHeight,
+                    DetailsPaneResizeMaxHeight,
+                    DetailsPaneResizerName,
+                    ui.DetailsPaneHeight,
+                    height =>
+                    {
+                        ui.DetailsPaneHeight = height;
+                        ui.OnDetailsPaneHeightChanged?.Invoke(height);
+                    },
+                    growsUpward: true,
+                    allowTargetShrink: true
+                )
+            );
+            detailsSlot.Add(CreateDetailsPane(filteredEntries[selectedEntryIndex]));
             messageSection.Add(detailsSlot);
             ui.DetailsSlot = detailsSlot;
         }
@@ -2266,15 +2315,13 @@ namespace DxMessaging.Editor.Windows
         /// route kind and message type, the emission's fields, and the stack trace behind a
         /// disclosure that starts closed.
         /// </summary>
-        private static VisualElement CreateDetailsPane(
-            MessageMonitorEntry entry,
-            MonitorUi ui = null
-        )
+        private static VisualElement CreateDetailsPane(MessageMonitorEntry entry)
         {
             VisualElement details = new() { name = DetailsPaneName };
             details.AddToClassList(DxMessagingEditorTheme.DetailClassName);
             // The pane gives space back when the window is short, and its body scrolls rather than
             // spilling out of the bottom, so a 320 px window still shows the log above it.
+            details.style.flexGrow = 1;
             details.style.flexShrink = 1;
             details.style.minHeight = 0;
             details.style.overflow = Overflow.Hidden;
@@ -2323,16 +2370,7 @@ namespace DxMessaging.Editor.Windows
                 CreateStackTraceSection(
                     entry,
                     DetailsStackFoldoutName,
-                    DetailsStackFirstFrameLabelName,
-                    DetailsStackTraceMaxHeight,
-                    ui?.StackTraceHeight ?? 0f,
-                    height =>
-                    {
-                        if (ui != null)
-                        {
-                            ui.StackTraceHeight = height;
-                        }
-                    }
+                    DetailsStackFirstFrameLabelName
                 )
             );
 
@@ -2413,10 +2451,7 @@ namespace DxMessaging.Editor.Windows
         internal static VisualElement CreateStackTraceSection(
             MessageMonitorEntry entry,
             string foldoutName,
-            string labelName,
-            float maxHeight,
-            float initialHeight = 0f,
-            Action<float> onHeightChanged = null
+            string labelName
         )
         {
             IReadOnlyList<string> frames = DxMessagingEditorSourceLinks.ReadCallSiteFrames(
@@ -2443,15 +2478,14 @@ namespace DxMessaging.Editor.Windows
                     + "by default because a stack per row is what buries the log. Unity's own "
                     + "stack-capture frames are left out.",
             };
-            ScrollView stackScroll = new(ScrollViewMode.Vertical);
-            stackScroll.style.maxHeight = maxHeight;
+            VisualElement stackFrames = new();
 
             if (!captured)
             {
                 Label empty = new(emptyBody) { name = labelName };
                 empty.style.whiteSpace = WhiteSpace.Normal;
-                stackScroll.Add(empty);
-                stackFoldout.Add(stackScroll);
+                stackFrames.Add(empty);
+                stackFoldout.Add(stackFrames);
                 return stackFoldout;
             }
 
@@ -2461,7 +2495,8 @@ namespace DxMessaging.Editor.Windows
                 VisualElement frameRow = new();
                 frameRow.AddToClassList(DetailsStackFrameRowClassName);
                 frameRow.style.flexDirection = FlexDirection.Row;
-                frameRow.style.flexShrink = 1;
+                frameRow.style.alignItems = Align.FlexStart;
+                frameRow.style.flexShrink = 0;
 
                 Label frameLabel = new(frame) { tooltip = frame };
                 // The first surviving frame is the emitting call site, so it reads as the answer
@@ -2474,6 +2509,10 @@ namespace DxMessaging.Editor.Windows
                 }
                 frameLabel.AddToClassList(DxMessagingEditorTheme.KeyValueValueClassName);
                 frameLabel.style.whiteSpace = WhiteSpace.Normal;
+                frameLabel.style.flexGrow = 1;
+                frameLabel.style.flexShrink = 1;
+                frameLabel.style.marginTop = 0;
+                frameLabel.style.marginBottom = 0;
                 frameRow.Add(frameLabel);
 
                 if (
@@ -2484,28 +2523,18 @@ namespace DxMessaging.Editor.Windows
                     && AssetDatabase.LoadMainAssetAtPath(frameLocation.AssetPath) != null
                 )
                 {
-                    frameRow.Add(
-                        DxMessagingEditorSourceLinks.CreateSourceLinkButton(
-                            "Open",
-                            frameLocation,
-                            includeLocationInText: false
-                        )
+                    Button open = DxMessagingEditorSourceLinks.CreateSourceLinkButton(
+                        "Open",
+                        frameLocation,
+                        includeLocationInText: false
                     );
+                    open.AddToClassList(DxMessagingEditorTheme.DetailStackLinkClassName);
+                    frameRow.Add(open);
                 }
-                stackScroll.Add(frameRow);
+                stackFrames.Add(frameRow);
             }
 
-            stackFoldout.Add(stackScroll);
-            stackFoldout.Add(
-                DxMessagingEditorTheme.CreateResizeHandle(
-                    stackScroll,
-                    StackTraceMinHeight,
-                    StackTraceResizeMaxHeight,
-                    DetailsStackResizerName,
-                    initialHeight,
-                    onHeightChanged
-                )
-            );
+            stackFoldout.Add(stackFrames);
             return stackFoldout;
         }
 

--- a/Tests/Editor/DxMessagingMessageMonitorLiveViewTests.cs
+++ b/Tests/Editor/DxMessagingMessageMonitorLiveViewTests.cs
@@ -864,7 +864,7 @@ namespace DxMessaging.Tests.Editor
             VisualElement detail = root.Q<VisualElement>(
                 DxMessagingMessageMonitorLiveView.DetailName
             );
-            Assert.IsNotNull(detail);
+            Assert.IsNotNull(detail, "The selected live row must render its details pane.");
 
             RenderBody(body, recorder);
 
@@ -993,6 +993,322 @@ namespace DxMessaging.Tests.Editor
         }
 
         [Test]
+        public void LiveModeUsesTheSharedLogDetailsDividerAndRememberedHeight()
+        {
+            const float RememberedHeight = 240f;
+            float resizedHeight = 0f;
+            EditorWindow window = CreateTrackedEditorWindow();
+            window.position = new Rect(0f, 0f, 600f, 700f);
+            window.rootVisualElement.style.width = 600f;
+            window.rootVisualElement.style.height = 700f;
+            VisualElement root = DxMessagingMessageMonitorLiveView.Create(
+                Recorder(
+                    Enumerable
+                        .Range(1, 20)
+                        .Select(index => Entry(index, $"PlayerSpawned{index}"))
+                        .ToArray()
+                ),
+                MessageMonitorLiveViewState.Default,
+                diagnosticsEnabled: true,
+                callbacks: new MessageMonitorLiveViewCallbacks
+                {
+                    InitialDetailsPaneHeight = RememberedHeight,
+                    OnDetailsPaneHeightChanged = height => resizedHeight = height,
+                }
+            );
+            window.rootVisualElement.Add(root);
+
+            VisualElement divider = root.Q<VisualElement>(
+                DxMessagingMessageMonitorWindow.DetailsPaneResizerName
+            );
+            Assert.IsNotNull(divider, "Live mode must use the same log/details divider.");
+            VisualElement detail = root.Q<VisualElement>(
+                DxMessagingMessageMonitorLiveView.DetailName
+            );
+            Assert.IsNotNull(detail, "The selected live row must render its details pane.");
+            Assert.AreEqual(
+                RememberedHeight,
+                detail.parent.style.height.value.value,
+                "The height remembered by the window must carry across the mode switch."
+            );
+            Assert.IsNull(
+                root.Q<VisualElement>("dxmessaging-monitor-details-stack-resizer"),
+                "Live mode must not restore the nested stack-trace resizer."
+            );
+
+            EditorSurfaceCapture.InvokeInheritedPanelMethod(
+                root.panel,
+                "ValidateLayout",
+                System.Array.Empty<object>()
+            );
+            // The first pass realizes the virtualized rows and changes the list's content basis;
+            // the second measures the settled split that the reader sees.
+            EditorSurfaceCapture.InvokeInheritedPanelMethod(
+                root.panel,
+                "ValidateLayout",
+                System.Array.Empty<object>()
+            );
+            float initialDetailsHeight = detail.parent.resolvedStyle.height;
+            ListView list = root.Q<ListView>();
+            Assert.IsNotNull(list, "A populated live view must render its scrolling log.");
+            float initialListHeight = list.resolvedStyle.height;
+
+            DragResizeHandle(divider, deltaY: -80f);
+            EditorSurfaceCapture.InvokeInheritedPanelMethod(
+                root.panel,
+                "ValidateLayout",
+                System.Array.Empty<object>()
+            );
+            EditorSurfaceCapture.InvokeInheritedPanelMethod(
+                root.panel,
+                "ValidateLayout",
+                System.Array.Empty<object>()
+            );
+
+            Assert.Greater(
+                detail.parent.resolvedStyle.height,
+                initialDetailsHeight,
+                "Dragging the live divider upward must grow the visible details pane."
+            );
+            Assert.Less(
+                list.resolvedStyle.height,
+                initialListHeight,
+                "The live log must give the space moved into the details pane."
+            );
+            Assert.Greater(
+                resizedHeight,
+                RememberedHeight,
+                "A real live-mode drag must report its new height to the host window."
+            );
+        }
+
+        [Test]
+        public void LiveModeKeepsWrappedStackFramesInsideItsScrollingDetailsPane()
+        {
+            string longFrame =
+                "WallstopStudios.Sample.Deep.Namespace.ExerciserWithALongTypeName:"
+                + "EmitOneOfEachWithALongMethodName (at Packages/"
+                + "com.wallstop-studios.dxmessaging/Editor/Windows/"
+                + "DxMessagingMessageMonitorWindow.cs:185)";
+            EditorWindow window = CreateTrackedEditorWindow();
+            window.position = new Rect(0f, 0f, 420f, 380f);
+            window.rootVisualElement.style.width = 420f;
+            window.rootVisualElement.style.height = 380f;
+            VisualElement root = DxMessagingMessageMonitorLiveView.Create(
+                Recorder(
+                    Entry(
+                        1,
+                        "PlayerSpawned",
+                        stackTrace: longFrame + "\n" + longFrame.Replace(":185)", ":138)")
+                    )
+                ),
+                MessageMonitorLiveViewState.Default,
+                diagnosticsEnabled: true
+            );
+            window.rootVisualElement.Add(root);
+
+            VisualElement detail = root.Q<VisualElement>(
+                DxMessagingMessageMonitorLiveView.DetailName
+            );
+            Assert.IsNotNull(detail, "The live selection must render its details pane.");
+            ScrollView detailScroll = detail.Q<ScrollView>();
+            Assert.IsNotNull(
+                detailScroll,
+                "The whole live details body must scroll, including an expanded stack trace."
+            );
+            Foldout stack = root.Q<Foldout>(
+                DxMessagingMessageMonitorLiveView.DetailStackFoldoutName
+            );
+            Assert.IsNotNull(stack, "A captured live trace must expose its stack disclosure.");
+            stack.value = true;
+            EditorSurfaceCapture.InvokeInheritedPanelMethod(
+                root.panel,
+                "ValidateLayout",
+                System.Array.Empty<object>()
+            );
+
+            List<VisualElement> rows = stack
+                .Query<VisualElement>(
+                    className: DxMessagingMessageMonitorWindow.DetailsStackFrameRowClassName
+                )
+                .ToList();
+            Assert.AreEqual(2, rows.Count, "Both live caller frames must remain visible.");
+            foreach (VisualElement row in rows)
+            {
+                Label label = row.Q<Label>();
+                Assert.IsNotNull(label, "Every live stack row must render its frame text.");
+                Assert.AreEqual(
+                    WhiteSpace.Normal,
+                    label.resolvedStyle.whiteSpace,
+                    "A long live frame must keep wrapping enabled."
+                );
+                Assert.Greater(
+                    label.worldBound.height,
+                    label.resolvedStyle.fontSize * 1.5f,
+                    "The deliberately long live frame must wrap onto multiple lines."
+                );
+                Assert.GreaterOrEqual(
+                    row.worldBound.height,
+                    label.worldBound.height - 0.5f,
+                    "The live frame row must contain the full wrapped label."
+                );
+                Button open = row.Q<Button>();
+                Assert.IsNotNull(
+                    open,
+                    "A real package source path must render its live Open link in the regression."
+                );
+                Assert.LessOrEqual(
+                    open.resolvedStyle.height,
+                    18.5f,
+                    "A toolbar-height live Open button must not add blank lines between frames."
+                );
+            }
+
+            float gap = rows[1].worldBound.yMin - rows[0].worldBound.yMax;
+            Assert.That(
+                gap,
+                Is.InRange(0f, 4f),
+                $"Live stack rows should read continuously; measured gap was {gap}px."
+            );
+        }
+
+        [Test]
+        public void LiveModeConstrainsRememberedTallDetailsInsideTheMinimumWindow()
+        {
+            EditorWindow window = CreateTrackedEditorWindow();
+            window.position = new Rect(0f, 0f, 420f, 320f);
+            window.rootVisualElement.style.width = 420f;
+            window.rootVisualElement.style.height = 320f;
+            float resizedHeight = 0f;
+            VisualElement root = DxMessagingMessageMonitorLiveView.Create(
+                Recorder(Entry(1, "PlayerSpawned")),
+                MessageMonitorLiveViewState.Default,
+                diagnosticsEnabled: true,
+                new MessageMonitorLiveViewCallbacks
+                {
+                    InitialDetailsPaneHeight =
+                        DxMessagingMessageMonitorWindow.DetailsPaneResizeMaxHeight,
+                    OnDetailsPaneHeightChanged = height => resizedHeight = height,
+                }
+            );
+            window.rootVisualElement.Add(root);
+            EditorSurfaceCapture.InvokeInheritedPanelMethod(
+                root.panel,
+                "ValidateLayout",
+                System.Array.Empty<object>()
+            );
+            EditorSurfaceCapture.InvokeInheritedPanelMethod(
+                root.panel,
+                "ValidateLayout",
+                System.Array.Empty<object>()
+            );
+
+            VisualElement detail = root.Q<VisualElement>(
+                DxMessagingMessageMonitorLiveView.DetailName
+            );
+            VisualElement divider = root.Q<VisualElement>(
+                DxMessagingMessageMonitorWindow.DetailsPaneResizerName
+            );
+            VisualElement header = root.Q<VisualElement>(
+                DxMessagingMessageMonitorLiveView.ListHeaderName
+            );
+            ListView list = root.Q<ListView>();
+            VisualElement footer = root.Q<VisualElement>(
+                DxMessagingMessageMonitorLiveView.FooterName
+            );
+            Assert.IsNotNull(detail, "The minimum live window must retain selected details.");
+            Assert.IsNotNull(divider, "The minimum live window must retain its divider.");
+            Assert.IsNotNull(header, "The minimum live window must retain its list header.");
+            Assert.IsNotNull(list, "The minimum live window must retain its scrolling log.");
+            Assert.IsNotNull(footer, "The minimum live window must retain its footer.");
+
+            foreach (VisualElement element in new[] { header, list, divider, detail, footer })
+            {
+                Assert.GreaterOrEqual(
+                    element.worldBound.yMin,
+                    root.worldBound.yMin - 0.5f,
+                    $"{element.name} must start inside the minimum live window."
+                );
+                Assert.LessOrEqual(
+                    element.worldBound.yMax,
+                    root.worldBound.yMax + 0.5f,
+                    $"{element.name} must end inside the minimum live window."
+                );
+            }
+
+            float visibleHeight = detail.parent.resolvedStyle.height;
+            Assert.Less(
+                visibleHeight,
+                DxMessagingMessageMonitorWindow.DetailsPaneResizeMaxHeight,
+                "The live hierarchy must constrain a 900px preference in its minimum window."
+            );
+            DragResizeHandle(divider, deltaY: -20f);
+            Assert.AreEqual(
+                visibleHeight + 20f,
+                resizedHeight,
+                1f,
+                "The first live drag must start from the constrained visible height."
+            );
+        }
+
+        [Test]
+        public void LiveModeHidesTheDetailsDividerWhenThereIsNoSelectedRow()
+        {
+            MessageMonitorLiveRecorder recorder = Recorder(Entry(1, "PlayerSpawned"));
+            VisualElement root = CreateView(
+                recorder,
+                callbacks: new MessageMonitorLiveViewCallbacks { InitialDetailsPaneHeight = 240f }
+            );
+            VisualElement body = root.Q<VisualElement>(DxMessagingMessageMonitorLiveView.BodyName);
+            VisualElement detailSlot = root.Q<VisualElement>(
+                DxMessagingMessageMonitorLiveView.DetailName
+            ).parent;
+
+            VisualElement divider = root.Q<VisualElement>(
+                DxMessagingMessageMonitorWindow.DetailsPaneResizerName
+            );
+            Assert.IsNotNull(divider, "The persistent body keeps its divider for later rows.");
+            Assert.AreEqual(
+                DisplayStyle.Flex,
+                detailSlot.style.display.value,
+                "A selected row must begin with its live details slot visible."
+            );
+
+            RenderBody(
+                body,
+                recorder,
+                new MessageMonitorLiveViewState(
+                    filterText: "does-not-match",
+                    showUntargeted: true,
+                    showTargeted: true,
+                    showBroadcast: true
+                )
+            );
+            Assert.AreEqual(
+                DisplayStyle.None,
+                divider.style.display.value,
+                "An empty log must not show a divider that has no details pane to resize."
+            );
+            Assert.AreEqual(
+                DisplayStyle.None,
+                detailSlot.style.display.value,
+                "A filter-empty log must not reserve the remembered detail height as blank space."
+            );
+
+            RenderBody(body, recorder);
+            Assert.AreEqual(
+                DisplayStyle.Flex,
+                divider.style.display.value,
+                "The live divider must return when filtered rows become visible again."
+            );
+            Assert.AreEqual(
+                DisplayStyle.Flex,
+                detailSlot.style.display.value,
+                "The existing detail slot must return when rows become visible again."
+            );
+        }
+
+        [Test]
         public void TheLiveButtonIsDisabledWhenNoHostCanSwitchModes()
         {
             EditorWindow window = CreateTrackedEditorWindow();
@@ -1032,6 +1348,9 @@ namespace DxMessaging.Tests.Editor
             MessageBus messageBus = MessageHandler.MessageBus as MessageBus;
             Assert.IsNotNull(messageBus);
             bool previousDiagnosticsMode = messageBus.DiagnosticsMode;
+            string preferenceKey = DxMessagingMessageMonitorWindow.DetailsPaneHeightPreferenceKey;
+            bool hadPreviousHeight = EditorPrefs.HasKey(preferenceKey);
+            float previousHeight = EditorPrefs.GetFloat(preferenceKey, 0f);
             DxMessagingMessageMonitorWindow window =
                 ScriptableObject.CreateInstance<DxMessagingMessageMonitorWindow>();
             _createdWindows.Add(window);
@@ -1043,6 +1362,7 @@ namespace DxMessaging.Tests.Editor
                 LiveModeProbeMessage message = default;
                 messageBus.UntargetedBroadcast(ref message);
 
+                window.position = new Rect(0f, 0f, 700f, 700f);
                 EditorWindowTestUtility.ShowWindow(window);
                 VisualElement root = window.rootVisualElement;
 
@@ -1050,14 +1370,40 @@ namespace DxMessaging.Tests.Editor
                     root.Q<VisualElement>(DxMessagingMessageMonitorLiveView.RootName),
                     "The window opens in snapshot mode."
                 );
+                EditorSurfaceCapture.InvokeInheritedPanelMethod(
+                    root.panel,
+                    "ValidateLayout",
+                    System.Array.Empty<object>()
+                );
+                VisualElement snapshotDivider = root.Q<VisualElement>(
+                    DxMessagingMessageMonitorWindow.DetailsPaneResizerName
+                );
+                Assert.IsNotNull(
+                    snapshotDivider,
+                    "Snapshot mode must expose the shared divider before switching modes."
+                );
+                DragResizeHandle(snapshotDivider, deltaY: -60f);
+                float draggedHeight = root.Q<VisualElement>(
+                    DxMessagingMessageMonitorWindow.DetailsPaneName
+                ).parent.style.height.value.value;
 
                 SendClick(root.Q<Button>(DxMessagingMessageMonitorWindow.LiveButtonName));
 
-                Assert.IsNotNull(root.Q<VisualElement>(DxMessagingMessageMonitorLiveView.RootName));
+                Assert.IsNotNull(
+                    root.Q<VisualElement>(DxMessagingMessageMonitorLiveView.RootName),
+                    "The Live button must replace the snapshot surface with the live view."
+                );
                 Assert.AreEqual(
                     nameof(LiveModeProbeMessage),
                     root.Q<Label>(DxMessagingMessageMonitorLiveView.DetailTitleLabelName)?.text,
                     "Entering live mode drains what the bus was already holding."
+                );
+                Assert.AreEqual(
+                    draggedHeight,
+                    root.Q<VisualElement>(
+                        DxMessagingMessageMonitorLiveView.DetailName
+                    ).parent.style.height.value.value,
+                    "A height dragged in snapshot mode must render after switching to live mode."
                 );
 
                 SendClick(root.Q<Button>(DxMessagingMessageMonitorLiveView.SnapshotButtonName));
@@ -1066,12 +1412,35 @@ namespace DxMessaging.Tests.Editor
                     root.Q<VisualElement>(DxMessagingMessageMonitorLiveView.RootName),
                     "The Snapshot button swaps back."
                 );
-                Assert.IsNotNull(root.Q<Button>(DxMessagingMessageMonitorWindow.LiveButtonName));
+                Assert.IsNotNull(
+                    root.Q<Button>(DxMessagingMessageMonitorWindow.LiveButtonName),
+                    "Switching back must restore the snapshot Live button."
+                );
+                Assert.AreEqual(
+                    draggedHeight,
+                    root.Q<VisualElement>(
+                        DxMessagingMessageMonitorWindow.DetailsPaneName
+                    ).parent.style.height.value.value,
+                    "The shared height must still render after switching back to snapshot mode."
+                );
             }
             finally
             {
                 messageBus.DiagnosticsMode = previousDiagnosticsMode;
                 messageBus._emissionBuffer.Clear();
+                // Close first because production OnDisable persists the dragged value. Restore
+                // the developer's preference afterwards so this fixture is order-independent and
+                // leaves the shared editor exactly as it found it.
+                EditorWindowTestUtility.CloseWindow(window);
+                _createdWindows.Remove(window);
+                if (hadPreviousHeight)
+                {
+                    EditorPrefs.SetFloat(preferenceKey, previousHeight);
+                }
+                else
+                {
+                    EditorPrefs.DeleteKey(preferenceKey);
+                }
             }
         }
 
@@ -1117,6 +1486,53 @@ namespace DxMessaging.Tests.Editor
                 diagnosticsEnabled: true,
                 callbacks
             );
+        }
+
+        private static void DragResizeHandle(VisualElement handle, float deltaY)
+        {
+            Vector2 start = new(handle.worldBound.center.x, handle.worldBound.center.y);
+            using (
+                PointerDownEvent down = PointerDownEvent.GetPooled(
+                    new Event
+                    {
+                        type = EventType.MouseDown,
+                        mousePosition = start,
+                        button = 0,
+                    }
+                )
+            )
+            {
+                down.target = handle;
+                handle.SendEvent(down);
+            }
+            using (
+                PointerMoveEvent move = PointerMoveEvent.GetPooled(
+                    new Event
+                    {
+                        type = EventType.MouseDrag,
+                        mousePosition = new Vector2(start.x, start.y + deltaY),
+                        button = 0,
+                    }
+                )
+            )
+            {
+                move.target = handle;
+                handle.SendEvent(move);
+            }
+            using (
+                PointerUpEvent up = PointerUpEvent.GetPooled(
+                    new Event
+                    {
+                        type = EventType.MouseUp,
+                        mousePosition = new Vector2(start.x, start.y + deltaY),
+                        button = 0,
+                    }
+                )
+            )
+            {
+                up.target = handle;
+                handle.SendEvent(up);
+            }
         }
 
         private static MessageMonitorLiveRecorder Recorder(params MessageMonitorEntry[] entries)

--- a/Tests/Editor/DxMessagingMessageMonitorLiveViewTests.cs
+++ b/Tests/Editor/DxMessagingMessageMonitorLiveViewTests.cs
@@ -1244,10 +1244,14 @@ namespace DxMessaging.Tests.Editor
             );
             DragResizeHandle(divider, deltaY: -20f);
             Assert.AreEqual(
-                visibleHeight + 20f,
+                Mathf.Clamp(
+                    visibleHeight + 20f,
+                    DxMessagingMessageMonitorWindow.DetailsPaneMinHeight,
+                    DxMessagingMessageMonitorWindow.DetailsPaneResizeMaxHeight
+                ),
                 resizedHeight,
                 1f,
-                "The first live drag must start from the constrained visible height."
+                "The first live drag must start from the visible height, then honor the pane bounds."
             );
         }
 

--- a/Tests/Editor/DxMessagingMessageMonitorWindowTests.cs
+++ b/Tests/Editor/DxMessagingMessageMonitorWindowTests.cs
@@ -1017,8 +1017,15 @@ namespace DxMessaging.Tests.Editor
 
                 Assert.That(
                     rememberedHeight,
-                    Is.EqualTo(visibleHeight + 20f).Within(1f),
-                    "The first new drag must start from the visible height, not the hidden 900px request."
+                    Is.EqualTo(
+                            Mathf.Clamp(
+                                visibleHeight + 20f,
+                                DxMessagingMessageMonitorWindow.DetailsPaneMinHeight,
+                                DxMessagingMessageMonitorWindow.DetailsPaneResizeMaxHeight
+                            )
+                        )
+                        .Within(1f),
+                    "The first new drag must start from the visible height, then honor the pane bounds."
                 );
             }
             finally

--- a/Tests/Editor/DxMessagingMessageMonitorWindowTests.cs
+++ b/Tests/Editor/DxMessagingMessageMonitorWindowTests.cs
@@ -506,6 +506,180 @@ namespace DxMessaging.Tests.Editor
             );
         }
 
+        [Test]
+        public void ExpandedStackFramesKeepTheirFullWrappedHeightWithoutVerticalGaps()
+        {
+            string longFrame =
+                "WallstopStudios.Sample.Deep.Namespace.ExerciserWithALongTypeName:"
+                + "EmitOneOfEachWithALongMethodName (at Packages/"
+                + "com.wallstop-studios.dxmessaging/Editor/Windows/"
+                + "DxMessagingMessageMonitorWindow.cs:185)";
+            MessageMonitorEntry entry = new(
+                nameof(OlderMessage),
+                "Context: Player",
+                longFrame + "\n" + longFrame.Replace(":185)", ":138)")
+            );
+            EditorWindow window = CreateTrackedEditorWindow();
+
+            try
+            {
+                window.position = new Rect(0f, 0f, 480f, 520f);
+                EditorWindowTestUtility.ShowWindow(window);
+                VisualElement root = window.rootVisualElement;
+                root.style.width = 480f;
+                root.style.height = 520f;
+                DxMessagingMessageMonitorWindow.BuildMonitorUi(
+                    root,
+                    new MessageMonitorSnapshot(
+                        diagnosticsEnabled: true,
+                        capacity: 8,
+                        entries: new[] { entry }
+                    )
+                );
+
+                Foldout stack = root.Q<Foldout>(
+                    DxMessagingMessageMonitorWindow.DetailsStackFoldoutName
+                );
+                Assert.That(stack, Is.Not.Null, "A captured trace must expose its disclosure.");
+                stack.value = true;
+                EditorSurfaceCapture.InvokeInheritedPanelMethod(
+                    root.panel,
+                    "ValidateLayout",
+                    Array.Empty<object>()
+                );
+
+                List<VisualElement> rows = stack
+                    .Query<VisualElement>(
+                        className: DxMessagingMessageMonitorWindow.DetailsStackFrameRowClassName
+                    )
+                    .ToList();
+                Assert.That(rows.Count, Is.EqualTo(2), "Both caller frames must be visible.");
+                for (int index = 0; index < rows.Count; ++index)
+                {
+                    VisualElement row = rows[index];
+                    Label label = row.Q<Label>();
+                    Assert.That(label, Is.Not.Null, "Every stack row must render its frame text.");
+                    Assert.That(
+                        label.resolvedStyle.whiteSpace,
+                        Is.EqualTo(WhiteSpace.Normal),
+                        "A long frame must wrap instead of collapsing to one clipped line."
+                    );
+                    Assert.That(
+                        label.worldBound.height,
+                        Is.GreaterThan(label.resolvedStyle.fontSize * 1.5f),
+                        "The deliberately long frame must occupy more than one rendered line."
+                    );
+                    Assert.That(
+                        row.resolvedStyle.flexShrink,
+                        Is.EqualTo(0f),
+                        "A frame row must not be compressed below its wrapped label."
+                    );
+                    Assert.That(
+                        row.worldBound.height,
+                        Is.GreaterThanOrEqualTo(label.worldBound.height - 0.5f),
+                        "The full wrapped frame must fit inside its row instead of being clipped."
+                    );
+                    Button open = row.Q<Button>();
+                    Assert.That(
+                        open,
+                        Is.Not.Null,
+                        "A real package source path must render its Open link in the regression."
+                    );
+                    Assert.That(
+                        open.resolvedStyle.height,
+                        Is.LessThanOrEqualTo(18.5f),
+                        "A toolbar-height Open button must not add blank lines between frames."
+                    );
+                }
+
+                float gap = rows[1].worldBound.yMin - rows[0].worldBound.yMax;
+                Assert.That(
+                    gap,
+                    Is.InRange(0f, 4f),
+                    $"Stack rows should read continuously; measured vertical gap was {gap}px."
+                );
+            }
+            finally
+            {
+                EditorWindowTestUtility.CloseWindow(window);
+            }
+        }
+
+        [Test]
+        public void ResolvableOneLineStackFramesKeepCompactTextSpacing()
+        {
+            const string SourcePath = "Packages/com.wallstop-studios.dxmessaging/package.json";
+            MessageMonitorEntry entry = new(
+                nameof(OlderMessage),
+                "Context: Player",
+                $"Sample.First:Emit () (at {SourcePath}:185)\n"
+                    + $"Sample.Second:Call () (at {SourcePath}:138)"
+            );
+            EditorWindow window = CreateTrackedEditorWindow();
+
+            try
+            {
+                window.position = new Rect(0f, 0f, 900f, 420f);
+                EditorWindowTestUtility.ShowWindow(window);
+                VisualElement root = window.rootVisualElement;
+                root.style.width = 900f;
+                root.style.height = 420f;
+                DxMessagingMessageMonitorWindow.BuildMonitorUi(
+                    root,
+                    new MessageMonitorSnapshot(
+                        diagnosticsEnabled: true,
+                        capacity: 8,
+                        entries: new[] { entry }
+                    )
+                );
+
+                Foldout stack = root.Q<Foldout>(
+                    DxMessagingMessageMonitorWindow.DetailsStackFoldoutName
+                );
+                Assert.That(stack, Is.Not.Null, "A captured trace must expose its disclosure.");
+                stack.value = true;
+                EditorSurfaceCapture.InvokeInheritedPanelMethod(
+                    root.panel,
+                    "ValidateLayout",
+                    Array.Empty<object>()
+                );
+
+                List<VisualElement> rows = stack
+                    .Query<VisualElement>(
+                        className: DxMessagingMessageMonitorWindow.DetailsStackFrameRowClassName
+                    )
+                    .ToList();
+                Assert.That(rows.Count, Is.EqualTo(2), "Both one-line frames must be visible.");
+                Label first = rows[0].Q<Label>();
+                Label second = rows[1].Q<Label>();
+                Assert.That(first, Is.Not.Null, "The first frame must render its text.");
+                Assert.That(second, Is.Not.Null, "The second frame must render its text.");
+                Assert.That(
+                    first.worldBound.height,
+                    Is.LessThanOrEqualTo(first.resolvedStyle.fontSize * 1.5f),
+                    "The first compact-frame precondition must remain one rendered line."
+                );
+                Assert.That(
+                    second.worldBound.height,
+                    Is.LessThanOrEqualTo(second.resolvedStyle.fontSize * 1.5f),
+                    "The second compact-frame precondition must remain one rendered line."
+                );
+                Assert.That(rows[0].Q<Button>(), Is.Not.Null, "The first frame must render Open.");
+                Assert.That(rows[1].Q<Button>(), Is.Not.Null, "The second frame must render Open.");
+
+                float labelGap = second.worldBound.yMin - first.worldBound.yMax;
+                Assert.That(
+                    labelGap,
+                    Is.InRange(0f, 5f),
+                    $"Compact Open buttons must not add blank lines; measured gap was {labelGap}px."
+                );
+            }
+            finally
+            {
+                EditorWindowTestUtility.CloseWindow(window);
+            }
+        }
+
         /// <summary>
         /// Issue #344's second round: "We need to ideally be able to link/click the contexts."
         /// A context whose object is still alive selects and pings it; one whose object is gone
@@ -595,12 +769,12 @@ namespace DxMessaging.Tests.Editor
         }
 
         /// <summary>
-        /// Issue #344's second round: "The Component Diagnostics and other areas are not
-        /// resizable." Each capped panel now carries a drag handle, and a drag past the shipped
-        /// cap actually takes effect -- a `max-height` left in place would silently win.
+        /// Issue #344's final resize feedback asks for the entire lower log/details area to move,
+        /// rather than a nested stack-trace viewport. The outer divider and Component Diagnostics
+        /// each keep their useful drag handle.
         /// </summary>
         [Test]
-        public void CappedPanelsCarryAResizeHandleThatCanGrowThemPastTheirShippedCap()
+        public void LogDetailsDividerResizesTheWholeLowerPaneAndSurvivesARebuild()
         {
             // Pointer capture needs a real panel, so this drives the shown window.
             EditorWindow window = CreateTrackedEditorWindow();
@@ -640,15 +814,28 @@ namespace DxMessaging.Tests.Editor
                     Is.Not.Null,
                     "Component Diagnostics is the panel #344 named; it must be resizable."
                 );
-                VisualElement stackResizer = root.Q<VisualElement>(
-                    DxMessagingMessageMonitorWindow.DetailsStackResizerName
+                VisualElement detailsResizer = root.Q<VisualElement>(
+                    DxMessagingMessageMonitorWindow.DetailsPaneResizerName
                 );
-                Assert.That(stackResizer, Is.Not.Null, "The stack trace is capped too.");
+                Assert.That(
+                    detailsResizer,
+                    Is.Not.Null,
+                    "The divider must resize the entire details pane below the log."
+                );
+                Assert.That(
+                    root.Query<VisualElement>("dxmessaging-monitor-details-stack-resizer").First(),
+                    Is.Null,
+                    "The old nested stack-trace resizer made the middle of the pane move instead."
+                );
 
                 ScrollView componentScroll = root.Q<ScrollView>(
                     DxMessagingMessageMonitorWindow.ComponentScrollViewName
                 );
-                Assert.That(componentScroll, Is.Not.Null);
+                Assert.That(
+                    componentScroll,
+                    Is.Not.Null,
+                    "Component Diagnostics must expose its scrolling resize target."
+                );
                 Assert.That(
                     componentScroll.style.maxHeight.value.value,
                     Is.EqualTo(180f),
@@ -685,29 +872,214 @@ namespace DxMessaging.Tests.Editor
                         + "drag would not survive layout."
                 );
 
-                // The dragged height has to survive the rebuild every filter keystroke causes, for
-                // the same reason the disclosures remember whether they were open.
-                float dragged = componentScroll.style.height.value.value;
+                VisualElement detailsPane = root.Q<VisualElement>(
+                    DxMessagingMessageMonitorWindow.DetailsPaneName
+                );
+                Assert.That(
+                    detailsPane,
+                    Is.Not.Null,
+                    "The selected snapshot row must render its details pane."
+                );
+                VisualElement detailsSlot = detailsPane.parent;
+                float initialDetailsHeight = detailsSlot.resolvedStyle.height;
+                DragResizeHandle(detailsResizer, deltaY: -140f);
+                float draggedDetailsHeight = detailsSlot.style.height.value.value;
+                Assert.That(
+                    draggedDetailsHeight,
+                    Is.GreaterThan(initialDetailsHeight),
+                    "Dragging the divider upward must grow the whole details area."
+                );
+                EditorSurfaceCapture.InvokeInheritedPanelMethod(
+                    root.panel,
+                    "ValidateLayout",
+                    Array.Empty<object>()
+                );
+                Assert.That(
+                    detailsPane.worldBound.height,
+                    Is.EqualTo(detailsSlot.worldBound.height).Within(1f),
+                    "The bordered details pane must fill the complete area moved by the divider."
+                );
+
+                // Both dragged heights have to survive the rebuild every filter keystroke causes.
+                float draggedComponentHeight = componentScroll.style.height.value.value;
                 TextField filter = root.Q<TextField>(
                     DxMessagingMessageMonitorWindow.FilterFieldName
                 );
-                Assert.That(filter, Is.Not.Null);
+                Assert.That(filter, Is.Not.Null, "Snapshot mode must render its filter field.");
                 filter.value = "Sample";
 
                 ScrollView rebuiltScroll = root.Q<ScrollView>(
                     DxMessagingMessageMonitorWindow.ComponentScrollViewName
                 );
-                Assert.That(rebuiltScroll, Is.Not.Null);
+                Assert.That(
+                    rebuiltScroll,
+                    Is.Not.Null,
+                    "Filtering must rebuild Component Diagnostics with its scroll target."
+                );
                 Assert.That(
                     rebuiltScroll.style.height.value.value,
-                    Is.EqualTo(dragged),
+                    Is.EqualTo(draggedComponentHeight),
                     "A filter keystroke rebuilds this section; the height a reader dragged must come "
                         + "back with it."
+                );
+                VisualElement rebuiltDetailsPane = root.Q<VisualElement>(
+                    DxMessagingMessageMonitorWindow.DetailsPaneName
+                );
+                Assert.That(
+                    rebuiltDetailsPane,
+                    Is.Not.Null,
+                    "Filtering must rebuild the selected snapshot details pane."
+                );
+                Assert.That(
+                    rebuiltDetailsPane.parent.style.height.value.value,
+                    Is.EqualTo(draggedDetailsHeight),
+                    "The shared log/details divider must keep the reader's height after filtering."
                 );
             }
             finally
             {
                 EditorWindowTestUtility.CloseWindow(window);
+            }
+        }
+
+        [Test]
+        public void RememberedTallDetailsPaneStartsItsNextDragFromTheVisibleShortWindowHeight()
+        {
+            EditorWindow window = CreateTrackedEditorWindow();
+            try
+            {
+                window.position = new Rect(0f, 0f, 420f, 320f);
+                EditorWindowTestUtility.ShowWindow(window);
+                VisualElement root = window.rootVisualElement;
+                root.style.width = 420f;
+                root.style.height = 320f;
+                float rememberedHeight = 0f;
+
+                DxMessagingMessageMonitorWindow.BuildMonitorUi(
+                    root,
+                    new MessageMonitorSnapshot(
+                        diagnosticsEnabled: true,
+                        capacity: 8,
+                        entries: new[]
+                        {
+                            new MessageMonitorEntry(
+                                nameof(OlderMessage),
+                                "Context: Player",
+                                CapturedStackTrace
+                            ),
+                        }
+                    ),
+                    MessageMonitorViewState.Default,
+                    initialDetailsPaneHeight: DxMessagingMessageMonitorWindow.DetailsPaneResizeMaxHeight,
+                    onDetailsPaneHeightChanged: height => rememberedHeight = height
+                );
+                EditorSurfaceCapture.InvokeInheritedPanelMethod(
+                    root.panel,
+                    "ValidateLayout",
+                    Array.Empty<object>()
+                );
+
+                VisualElement detailsPane = root.Q<VisualElement>(
+                    DxMessagingMessageMonitorWindow.DetailsPaneName
+                );
+                Assert.That(
+                    detailsPane,
+                    Is.Not.Null,
+                    "A remembered height must still render the snapshot details pane."
+                );
+                VisualElement detailsSlot = detailsPane.parent;
+                VisualElement divider = root.Q<VisualElement>(
+                    DxMessagingMessageMonitorWindow.DetailsPaneResizerName
+                );
+                Assert.That(
+                    divider,
+                    Is.Not.Null,
+                    "A remembered height must still render the snapshot divider."
+                );
+                float visibleHeight = detailsSlot.resolvedStyle.height;
+                Assert.That(
+                    visibleHeight,
+                    Is.LessThan(DxMessagingMessageMonitorWindow.DetailsPaneResizeMaxHeight),
+                    "The short window must constrain the remembered tall-pane request."
+                );
+                Assert.That(
+                    divider.worldBound.yMin,
+                    Is.GreaterThanOrEqualTo(root.worldBound.yMin - 0.5f),
+                    "The constrained snapshot divider must stay inside the short window."
+                );
+                Assert.That(
+                    detailsSlot.worldBound.yMax,
+                    Is.LessThanOrEqualTo(root.worldBound.yMax + 0.5f),
+                    "The constrained snapshot details pane must stay inside the short window."
+                );
+
+                DragResizeHandle(divider, deltaY: -20f);
+
+                Assert.That(
+                    rememberedHeight,
+                    Is.EqualTo(visibleHeight + 20f).Within(1f),
+                    "The first new drag must start from the visible height, not the hidden 900px request."
+                );
+            }
+            finally
+            {
+                EditorWindowTestUtility.CloseWindow(window);
+            }
+        }
+
+        [Test]
+        public void WindowRestoresTheSharedDetailsPaneHeightAfterCloseAndReopen()
+        {
+            const float RememberedHeight = 237f;
+            string preferenceKey = DxMessagingMessageMonitorWindow.DetailsPaneHeightPreferenceKey;
+            bool hadPreviousValue = EditorPrefs.HasKey(preferenceKey);
+            float previousValue = EditorPrefs.GetFloat(preferenceKey, 0f);
+            FieldInfo heightField = typeof(DxMessagingMessageMonitorWindow).GetField(
+                "_detailsPaneHeight",
+                BindingFlags.Instance | BindingFlags.NonPublic
+            );
+            MethodInfo rememberHeight = typeof(DxMessagingMessageMonitorWindow).GetMethod(
+                "RememberDetailsPaneHeight",
+                BindingFlags.Instance | BindingFlags.NonPublic
+            );
+            Assert.That(heightField, Is.Not.Null, "The window must retain the divider position.");
+            Assert.That(rememberHeight, Is.Not.Null, "The resize callback must update the window.");
+
+            DxMessagingMessageMonitorWindow first = null;
+            DxMessagingMessageMonitorWindow reopened = null;
+            try
+            {
+                EditorPrefs.DeleteKey(preferenceKey);
+                first = ScriptableObject.CreateInstance<DxMessagingMessageMonitorWindow>();
+                rememberHeight.Invoke(first, new object[] { RememberedHeight });
+                EditorWindowTestUtility.CloseWindow(first);
+                first = null;
+
+                reopened = ScriptableObject.CreateInstance<DxMessagingMessageMonitorWindow>();
+                Assert.That(
+                    (float)heightField.GetValue(reopened),
+                    Is.EqualTo(RememberedHeight),
+                    "OnDisable must persist the dragged height and OnEnable must restore it."
+                );
+            }
+            finally
+            {
+                if (first != null)
+                {
+                    EditorWindowTestUtility.CloseWindow(first);
+                }
+                if (reopened != null)
+                {
+                    EditorWindowTestUtility.CloseWindow(reopened);
+                }
+                if (hadPreviousValue)
+                {
+                    EditorPrefs.SetFloat(preferenceKey, previousValue);
+                }
+                else
+                {
+                    EditorPrefs.DeleteKey(preferenceKey);
+                }
             }
         }
 

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -117,10 +117,17 @@ The detail pane links out to what a row stands for:
   frame names a file and line. Unity's own stack-capture frames are left out, and
   the first row is the emitting call site.
 
-Anything that answers a click shows the pointer cursor, and the capped panels --
-Component Diagnostics and the stack trace -- carry a drag handle along their bottom
-edge for readers with more room than the default height assumes. A dragged height
-survives filtering and reselection.
+Anything that answers a click shows the pointer cursor. Drag the divider between
+the log and detail pane to resize the complete lower area; the window remembers
+that height across filtering, mode changes, reloads, and reopen. Component
+Diagnostics keeps its own drag handle because it is a separate disclosure. Stack
+frames use their full wrapped line height and scroll with the rest of the detail
+pane.
+
+> **Changed in v3.3.0**
+>
+> The log and complete detail pane now share one remembered divider. Stack frames
+> keep their full wrapped height inside the detail pane's scroll area.
 
 Three taxonomy chips, one per route kind, name their kind and are drawn in the
 color that marks it in every row, so the chips are both the color legend and the


### PR DESCRIPTION
## Summary

- replace the nested stack-trace resizer with one shared divider for the complete log/details area in snapshot and live modes
- persist the divider height across filtering, mode changes, domain reloads, and window reopen while keeping short-window drags responsive
- keep wrapped and source-linked stack frames unclipped with compact vertical spacing
- collapse empty live details instead of reserving remembered-height blank space
- document the changed behavior and add focused layout, lifecycle, persistence, and mode-transfer regressions

## Root cause

The previous controls resized inner sections instead of the complete details pane. Persisted requested heights could differ from the height visible after flex layout, and stack-frame source buttons inherited toolbar dimensions that inflated row spacing.

## Validation

- Unity MCP serialized exact-tree Editor assembly: 699 passed, 0 failed, 1 skipped, 8 inconclusive
- JavaScript tests: 410 passed
- documentation snippet tests: 583 passed
- `npm run validate:all`
- CSharpier, Prettier, Markdownlint, cspell, and `git diff --check`
- three independent final adversarial reviews: zero actionable findings

Closes #344

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only UI Toolkit layout and preferences; no runtime messaging or security impact. Risk is limited to Message Monitor UX regressions, mitigated by broad layout and persistence tests.
> 
> **Overview**
> Fixes Message Monitor resizing (#344) by replacing the nested stack-trace resizer with **one shared divider** between the log and the full details pane in snapshot and live modes.
> 
> **Resize behavior:** `CreateResizeHandle` gains `growsUpward` and `allowTargetShrink` so the handle above the pane grows it on upward drags and can start drags from the **visible** height when the window is shorter than a remembered size. Divider height is stored in `EditorPrefs` and survives filtering, live/snapshot switches, and window reopen; live mode hides the divider and detail slot when there is nothing to show instead of leaving blank space.
> 
> **Stack trace UI:** Stack frames scroll with the rest of the detail body (no inner capped scroll + resizer). Wrapped frames keep full line height; **Open** links use a compact style so toolbar-sized buttons do not add vertical gaps.
> 
> Docs and Editor tests cover divider persistence, mode transfer, short-window layout, and stack wrapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe184c5d31093f28ec7af78f2bdda8cb87d7b5af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->