### PR TITLE
Isolate EditMode scene fixtures

### DIFF
--- a/Tests/Editor/Allocations/BenchmarkHarnessRobustnessTests.cs
+++ b/Tests/Editor/Allocations/BenchmarkHarnessRobustnessTests.cs
@@ -15,6 +15,7 @@ namespace DxMessaging.Tests.Editor.Allocations
     using DxMessaging.Tests.Runtime.Scripts.Components;
     using DxMessaging.Tests.Runtime.Scripts.Messages;
     using NUnit.Framework;
+    using UnityEditor;
     using UnityEngine;
     using UnityEngine.TestTools;
 
@@ -301,15 +302,17 @@ namespace DxMessaging.Tests.Editor.Allocations
                         parentReceiver = parent.AddComponent<SimpleMessageAwareComponent>();
                     }
 
-                    GameObject grandParent = new(
+                    GameObject grandParent = EditorUtility.CreateGameObjectWithHideFlags(
                         "BenchmarkReflexiveGrandParent",
+                        HideFlags.HideAndDontSave,
                         typeof(SimpleMessageAwareComponent)
                     );
                     _spawned.Add(grandParent);
                     parent.transform.SetParent(grandParent.transform);
 
-                    GameObject child = new(
+                    GameObject child = EditorUtility.CreateGameObjectWithHideFlags(
                         "BenchmarkReflexiveChild",
+                        HideFlags.HideAndDontSave,
                         typeof(SimpleMessageAwareComponent)
                     );
                     _spawned.Add(child);

--- a/Tests/Editor/Benchmarks/BenchmarkTestBase.cs
+++ b/Tests/Editor/Benchmarks/BenchmarkTestBase.cs
@@ -8,6 +8,7 @@ namespace DxMessaging.Tests.Editor.Benchmarks
     using DxMessaging.Tests.Runtime.Core;
     using DxMessaging.Tests.Runtime.Scripts.Components;
     using DxMessaging.Unity;
+    using UnityEditor;
     using UnityEngine;
     using Object = UnityEngine.Object;
 
@@ -62,8 +63,9 @@ namespace DxMessaging.Tests.Editor.Benchmarks
 
         protected GameObject CreateBenchmarkGameObject()
         {
-            GameObject target = new(
+            GameObject target = EditorUtility.CreateGameObjectWithHideFlags(
                 "Benchmark",
+                HideFlags.HideAndDontSave,
                 typeof(EmptyMessageAwareComponent),
                 typeof(SpriteRenderer),
                 typeof(Rigidbody2D),

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -18,13 +18,14 @@ namespace DxMessaging.Tests.Editor
     using UnityEditor;
     using UnityEditor.SceneManagement;
     using UnityEngine;
-    using UnityEngine.SceneManagement;
     using UnityEngine.UIElements;
     using Object = UnityEngine.Object;
 
     [TestFixture]
     public sealed class DxMessagingFlowGraphWindowTests
     {
+        private const string SceneSafetyFixturePath =
+            "Packages/com.wallstop-studios.dxmessaging/Tests/Editor/Fixtures/EditModeSceneSafety.unity";
         private readonly List<Object> _createdObjects = new();
         private readonly List<string> _createdAssetPaths = new();
         private readonly List<EditorWindow> _createdWindows = new();
@@ -10641,7 +10642,14 @@ namespace DxMessaging.Tests.Editor
         [Test]
         public void CaptureSnapshotBuildsEvidenceOnlyMessageNodesFromGlobalHistory()
         {
-            GameObject host = CreateTrackedObject("FlowGraphEvidenceOnlyHost");
+            // Investigation (2026-08-13): NewScene(Additive) cannot run while the shared
+            // editor has an unsaved untitled scene. Open this package-owned fixture instead.
+            using OwnedEditModeScene testScene = OwnedEditModeScene.OpenAuthored(
+                SceneSafetyFixturePath
+            );
+
+            testScene.Activate();
+            GameObject host = testScene.CreateGameObject("FlowGraphEvidenceOnlyHost");
             MessagingComponent messagingComponent = host.AddComponent<MessagingComponent>();
             MessageBus messageBus = MessageHandler.MessageBus as MessageBus;
             Assert.That(messageBus, Is.Not.Null);
@@ -10686,10 +10694,16 @@ namespace DxMessaging.Tests.Editor
         public void CaptureSnapshotDoesNotInferContextComponentFromDuplicateHierarchyText()
         {
             GameObject parent = CreateTrackedObject("FlowGraphDuplicateContextRoot");
-            GameObject receiver = new("Duplicate");
+            GameObject receiver = EditorUtility.CreateGameObjectWithHideFlags(
+                "Duplicate",
+                HideFlags.HideAndDontSave
+            );
             receiver.transform.SetParent(parent.transform);
             MessagingComponent messagingComponent = receiver.AddComponent<MessagingComponent>();
-            GameObject nonGraphContext = new("Duplicate");
+            GameObject nonGraphContext = EditorUtility.CreateGameObjectWithHideFlags(
+                "Duplicate",
+                HideFlags.HideAndDontSave
+            );
             nonGraphContext.transform.SetParent(parent.transform);
             MessageBus messageBus = MessageHandler.MessageBus as MessageBus;
             Assert.That(messageBus, Is.Not.Null);
@@ -10784,13 +10798,18 @@ namespace DxMessaging.Tests.Editor
             string sceneName = "FlowGraphSceneComponentHost-" + suffix;
             string prefabName = "FlowGraphPrefabComponentHost-" + suffix;
             string prefabPath = $"Assets/{prefabName}.prefab";
-            GameObject sceneHost = CreateTrackedObject(sceneName);
-            MessagingComponent sceneComponent = sceneHost.AddComponent<MessagingComponent>();
-            GameObject prefabHost = new(prefabName);
+            GameObject prefabHost = null;
             _createdAssetPaths.Add(prefabPath);
 
+            using OwnedEditModeScene testScene = OwnedEditModeScene.OpenAuthored(
+                SceneSafetyFixturePath
+            );
             try
             {
+                testScene.Activate();
+                GameObject sceneHost = testScene.CreateGameObject(sceneName);
+                MessagingComponent sceneComponent = sceneHost.AddComponent<MessagingComponent>();
+                prefabHost = testScene.CreateGameObject(prefabName);
                 prefabHost.AddComponent<MessagingComponent>();
                 GameObject prefabAsset = null;
                 EditorWindowTestUtility.IgnoreUnityInvalidGcHandleAsserts(() =>
@@ -10836,43 +10855,29 @@ namespace DxMessaging.Tests.Editor
             string suffix = Guid.NewGuid().ToString("N");
             string sceneName = "FlowGraphSceneHost-" + suffix;
             string previewName = "FlowGraphPreviewHost-" + suffix;
-            GameObject sceneHost = CreateTrackedObject(sceneName);
+            using OwnedEditModeScene testScene = OwnedEditModeScene.OpenAuthored(
+                SceneSafetyFixturePath
+            );
+            using OwnedEditModeScene previewScene = OwnedEditModeScene.CreatePreview();
+
+            testScene.Activate();
+            GameObject sceneHost = testScene.CreateGameObject(sceneName);
             sceneHost.AddComponent<MessagingComponent>();
-            Scene previewScene = EditorSceneManager.NewPreviewScene();
-            GameObject previewHost = new(previewName);
+            GameObject previewHost = previewScene.CreateGameObject(previewName);
+            MessagingComponent previewComponent = previewHost.AddComponent<MessagingComponent>();
+            Assert.That(previewComponent.gameObject.scene.IsValid(), Is.True);
+            Assert.That(EditorSceneManager.IsPreviewSceneObject(previewHost), Is.True);
 
-            try
-            {
-                SceneManager.MoveGameObjectToScene(previewHost, previewScene);
-                MessagingComponent previewComponent =
-                    previewHost.AddComponent<MessagingComponent>();
-                Assert.That(previewComponent.gameObject.scene.IsValid(), Is.True);
-                Assert.That(EditorSceneManager.IsPreviewSceneObject(previewHost), Is.True);
+            FlowGraphSnapshot snapshot = DxMessagingFlowGraphWindow.CaptureSnapshot();
 
-                FlowGraphSnapshot snapshot = DxMessagingFlowGraphWindow.CaptureSnapshot();
-
-                Assert.That(
-                    snapshot.ComponentNodes.Any(component => component.HierarchyPath == sceneName),
-                    Is.True
-                );
-                Assert.That(
-                    snapshot.ComponentNodes.Any(component =>
-                        component.HierarchyPath == previewName
-                    ),
-                    Is.False
-                );
-            }
-            finally
-            {
-                if (previewHost != null)
-                {
-                    Object.DestroyImmediate(previewHost);
-                }
-                if (previewScene.IsValid())
-                {
-                    EditorSceneManager.ClosePreviewScene(previewScene);
-                }
-            }
+            Assert.That(
+                snapshot.ComponentNodes.Any(component => component.HierarchyPath == sceneName),
+                Is.True
+            );
+            Assert.That(
+                snapshot.ComponentNodes.Any(component => component.HierarchyPath == previewName),
+                Is.False
+            );
         }
 
         private static int CountMessageBusRegistrations(IMessageBus messageBus)
@@ -11663,7 +11668,10 @@ namespace DxMessaging.Tests.Editor
 
         private GameObject CreateTrackedObject(string name)
         {
-            GameObject gameObject = new(name);
+            GameObject gameObject = EditorUtility.CreateGameObjectWithHideFlags(
+                name,
+                HideFlags.HideAndDontSave
+            );
             _createdObjects.Add(gameObject);
             return gameObject;
         }

--- a/Tests/Editor/DxMessagingMessageMonitorWindowTests.cs
+++ b/Tests/Editor/DxMessagingMessageMonitorWindowTests.cs
@@ -16,13 +16,14 @@ namespace DxMessaging.Tests.Editor
     using UnityEditor;
     using UnityEditor.SceneManagement;
     using UnityEngine;
-    using UnityEngine.SceneManagement;
     using UnityEngine.UIElements;
     using Object = UnityEngine.Object;
 
     [TestFixture]
     public sealed class DxMessagingMessageMonitorWindowTests
     {
+        private const string SceneSafetyFixturePath =
+            "Packages/com.wallstop-studios.dxmessaging/Tests/Editor/Fixtures/EditModeSceneSafety.unity";
         private readonly List<Object> _createdObjects = new();
         private readonly List<string> _createdAssetPaths = new();
         private readonly List<EditorWindow> _createdWindows = new();
@@ -3490,13 +3491,20 @@ namespace DxMessaging.Tests.Editor
             string sceneName = "SceneComponentHost-" + suffix;
             string prefabName = "PrefabComponentHost-" + suffix;
             string prefabPath = $"Assets/{prefabName}.prefab";
-            GameObject sceneHost = CreateTrackedObject(sceneName);
-            MessagingComponent sceneComponent = sceneHost.AddComponent<MessagingComponent>();
-            GameObject prefabHost = new(prefabName);
+            GameObject prefabHost = null;
             _createdAssetPaths.Add(prefabPath);
 
+            using OwnedEditModeScene testScene = OwnedEditModeScene.OpenAuthored(
+                SceneSafetyFixturePath
+            );
             try
             {
+                // Investigation (2026-08-13): NewScene(Additive) cannot run while the shared
+                // editor has an unsaved untitled scene. Open this package-owned fixture instead.
+                testScene.Activate();
+                GameObject sceneHost = testScene.CreateGameObject(sceneName);
+                MessagingComponent sceneComponent = sceneHost.AddComponent<MessagingComponent>();
+                prefabHost = testScene.CreateGameObject(prefabName);
                 prefabHost.AddComponent<MessagingComponent>();
                 GameObject prefabAsset = null;
                 EditorWindowTestUtility.IgnoreUnityInvalidGcHandleAsserts(() =>
@@ -3575,45 +3583,29 @@ namespace DxMessaging.Tests.Editor
             string suffix = Guid.NewGuid().ToString("N");
             string sceneName = "MonitorSceneHost-" + suffix;
             string previewName = "MonitorPreviewHost-" + suffix;
-            GameObject sceneHost = CreateTrackedObject(sceneName);
+            using OwnedEditModeScene testScene = OwnedEditModeScene.OpenAuthored(
+                SceneSafetyFixturePath
+            );
+            using OwnedEditModeScene previewScene = OwnedEditModeScene.CreatePreview();
+
+            testScene.Activate();
+            GameObject sceneHost = testScene.CreateGameObject(sceneName);
             sceneHost.AddComponent<MessagingComponent>();
-            Scene previewScene = EditorSceneManager.NewPreviewScene();
-            GameObject previewHost = new(previewName);
+            GameObject previewHost = previewScene.CreateGameObject(previewName);
+            MessagingComponent previewComponent = previewHost.AddComponent<MessagingComponent>();
+            Assert.That(previewComponent.gameObject.scene.IsValid(), Is.True);
+            Assert.That(EditorSceneManager.IsPreviewSceneObject(previewHost), Is.True);
 
-            try
-            {
-                SceneManager.MoveGameObjectToScene(previewHost, previewScene);
-                MessagingComponent previewComponent =
-                    previewHost.AddComponent<MessagingComponent>();
-                Assert.That(previewComponent.gameObject.scene.IsValid(), Is.True);
-                Assert.That(EditorSceneManager.IsPreviewSceneObject(previewHost), Is.True);
+            IReadOnlyList<ComponentMonitorEntry> components = Array.Empty<ComponentMonitorEntry>();
+            EditorWindowTestUtility.IgnoreUnityInvalidGcHandleAsserts(() =>
+                components = DxMessagingMessageMonitorWindow.CaptureComponentSnapshots()
+            );
 
-                IReadOnlyList<ComponentMonitorEntry> components =
-                    Array.Empty<ComponentMonitorEntry>();
-                EditorWindowTestUtility.IgnoreUnityInvalidGcHandleAsserts(() =>
-                    components = DxMessagingMessageMonitorWindow.CaptureComponentSnapshots()
-                );
-
-                Assert.That(
-                    components.Any(component => component.HierarchyPath == sceneName),
-                    Is.True
-                );
-                Assert.That(
-                    components.Any(component => component.HierarchyPath == previewName),
-                    Is.False
-                );
-            }
-            finally
-            {
-                if (previewHost != null)
-                {
-                    Object.DestroyImmediate(previewHost);
-                }
-                if (previewScene.IsValid())
-                {
-                    EditorSceneManager.ClosePreviewScene(previewScene);
-                }
-            }
+            Assert.That(components.Any(component => component.HierarchyPath == sceneName), Is.True);
+            Assert.That(
+                components.Any(component => component.HierarchyPath == previewName),
+                Is.False
+            );
         }
 
         [Test]
@@ -3836,7 +3828,10 @@ namespace DxMessaging.Tests.Editor
 
         private GameObject CreateTrackedObject(string name)
         {
-            GameObject gameObject = new(name);
+            GameObject gameObject = EditorUtility.CreateGameObjectWithHideFlags(
+                name,
+                HideFlags.HideAndDontSave
+            );
             _createdObjects.Add(gameObject);
             return gameObject;
         }

--- a/Tests/Editor/EditModeSceneSafetyContractTests.cs
+++ b/Tests/Editor/EditModeSceneSafetyContractTests.cs
@@ -457,7 +457,6 @@ namespace DxMessaging.Tests.Editor
                 );
             }
 
-            string before = source.Substring(0, constructionIndex);
             if (Regex.IsMatch(statement, @"\breturn\b"))
             {
                 if (IsInsideGameObjectReturningMethod(source, constructionIndex, gameObjectTypes))

--- a/Tests/Editor/EditModeSceneSafetyContractTests.cs
+++ b/Tests/Editor/EditModeSceneSafetyContractTests.cs
@@ -1,0 +1,1008 @@
+#if UNITY_EDITOR && UNITY_2021_3_OR_NEWER
+namespace DxMessaging.Tests.Editor
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using NUnit.Framework;
+    using UnityEngine;
+    using UnityEngine.SceneManagement;
+
+    [TestFixture]
+    [Category("Contract")]
+    public sealed class EditModeSceneSafetyContractTests
+    {
+        private const string PackageName = "com.wallstop-studios.dxmessaging";
+
+        private static readonly IReadOnlyDictionary<
+            string,
+            SceneResidentExemption
+        > SceneResidentExemptions = new Dictionary<string, SceneResidentExemption>(
+            StringComparer.Ordinal
+        );
+
+        [TestCase("GameObject host = new GameObject(\"classic\");", 1)]
+        [TestCase("GameObject host = new GameObject { name = \"initializer\" };", 1)]
+        [TestCase("UnityEngine.GameObject host = new UnityEngine.GameObject(\"qualified\");", 1)]
+        [TestCase("GameObject host = new(\"target typed\");", 1)]
+        [TestCase("GameObject host = (new(\"parenthesized\"));", 1)]
+        [TestCase("GameObject host;\nhost = new(\"deferred\");", 1)]
+        [TestCase("GameObject host;\nhost = (new(\"parenthesized deferred\"));", 1)]
+        [TestCase(
+            "void First() { GameObject receiver = new(\"unsafe\"); }\n"
+                + "void Second() { FlowGraphComponentNode receiver = new(); }",
+            1
+        )]
+        [TestCase("// GameObject host = new(\"comment\");", 0)]
+        [TestCase("string sample = \"GameObject host = new(\\\"text\\\");\";", 0)]
+        [TestCase(
+            "GameObject host = EditorUtility.CreateGameObjectWithHideFlags(\"safe\", HideFlags.HideAndDontSave);",
+            0
+        )]
+        [TestCase("GameObject Host { get; } = new(\"property\");", 1)]
+        [TestCase("GameObject CreateHost() => new(\"arrow\");", 1)]
+        [TestCase("GameObject CreateHost() { return new(\"return\"); }", 1)]
+        [TestCase("GameObject CreateHost() { return condition ? new(\"return\") : null; }", 1)]
+        [TestCase("GameObject Host { get { return new(\"getter\"); } }", 1)]
+        [TestCase("Func<GameObject> factory = () => new(\"lambda\");", 1)]
+        [TestCase("GameObject host = condition ? new(\"branch\") : null;", 1)]
+        [TestCase("GameObject[] hosts = { new(\"array\") };", 1)]
+        [TestCase("GameObject[] hosts = new GameObject[] { new(\"explicit array\") };", 1)]
+        [TestCase("GameObject host; this.host = new(\"member\");", 1)]
+        [TestCase("GameObject host; host ??= new(\"coalesce\");", 1)]
+        [TestCase("using GO = UnityEngine.GameObject; GO host = new GO(\"alias\");", 1)]
+        [TestCase("GameObject.CreatePrimitive(PrimitiveType.Cube);", 1)]
+        [TestCase("Object.Instantiate(prefab);", 1)]
+        [TestCase("Object.Instantiate<GameObject>(prefab);", 1)]
+        [TestCase("PrefabUtility.InstantiatePrefab(prefab);", 1)]
+        [TestCase("EditorUtility.CreateGameObjectWithHideFlags(\"unsafe\", HideFlags.None);", 1)]
+        [TestCase(
+            "EditorUtility.CreateGameObjectWithHideFlags(\"unsafe\", condition ? HideFlags.HideAndDontSave : HideFlags.None);",
+            1
+        )]
+        [TestCase("string value = $\"{new GameObject(\"unsafe\")}\";", 1)]
+        [TestCase(
+            "GameObject receiver; void Probe() { FlowGraphComponentNode receiver; receiver = new(); }",
+            0
+        )]
+        [TestCase("GameObject host = condition ? Make() : Wrap(new());", 0)]
+        public void ScannerFindsOnlyActiveSceneGameObjectConstruction(
+            string source,
+            int expectedCount
+        )
+        {
+            IReadOnlyList<EditModeGameObjectConstruction> actual =
+                EditModeGameObjectConstructionScanner.Find("Tests/Editor/Probe.cs", source);
+
+            Assert.That(
+                actual.Count,
+                Is.EqualTo(expectedCount),
+                $"Source '{source}' should report {expectedCount} unsafe construction(s), but "
+                    + $"reported {actual.Count}: {string.Join(" | ", actual.Select(item => item.Display))}."
+            );
+        }
+
+        [Test]
+        public void EditModeFixturesDoNotConstructGameObjectsInDeveloperScenes()
+        {
+            string packageRoot = GetPackageRoot();
+            string editorTestsRoot = Path.Combine(packageRoot, "Tests", "Editor");
+            List<string> offenders = new();
+            Dictionary<string, int> exemptionUses = SceneResidentExemptions.ToDictionary(
+                pair => pair.Key,
+                _ => 0,
+                StringComparer.Ordinal
+            );
+            int scannedFiles = 0;
+
+            foreach (
+                string file in Directory
+                    .EnumerateFiles(editorTestsRoot, "*.cs", SearchOption.AllDirectories)
+                    .OrderBy(path => path, StringComparer.Ordinal)
+            )
+            {
+                scannedFiles++;
+                string relativePath = NormalizeRelativePath(packageRoot, file);
+                string source = File.ReadAllText(file);
+                foreach (
+                    EditModeGameObjectConstruction construction in EditModeGameObjectConstructionScanner.Find(
+                        relativePath,
+                        source
+                    )
+                )
+                {
+                    if (
+                        !string.IsNullOrEmpty(construction.ExemptionId)
+                        && SceneResidentExemptions.TryGetValue(
+                            construction.ExemptionId,
+                            out SceneResidentExemption exemption
+                        )
+                        && exemption.Matches(construction)
+                    )
+                    {
+                        exemptionUses[construction.ExemptionId]++;
+                        continue;
+                    }
+
+                    offenders.Add(construction.Display);
+                }
+            }
+
+            Assert.That(
+                scannedFiles,
+                Is.GreaterThan(0),
+                $"Expected to scan EditMode fixtures under '{editorTestsRoot}', but found none."
+            );
+            Assert.That(
+                offenders,
+                Is.Empty,
+                "EditMode fixtures must not construct GameObjects in the developer's active scene. "
+                    + "Use EditorUtility.CreateGameObjectWithHideFlags(name, "
+                    + "HideFlags.HideAndDontSave, ...) for scene-less objects. A fixture that "
+                    + "genuinely tests scene residency must own and close an isolated scene and "
+                    + "carry an exact DXM-SCENE-RESIDENCY exemption. Offenders:\n"
+                    + string.Join("\n", offenders)
+            );
+
+            string[] invalidExemptions = exemptionUses
+                .Where(pair => pair.Value != 1)
+                .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+                .Select(pair =>
+                    $"{pair.Key}: used {pair.Value} times; reason: {SceneResidentExemptions[pair.Key].Reason}"
+                )
+                .ToArray();
+            Assert.That(
+                invalidExemptions,
+                Is.Empty,
+                "Every scene-residency exemption must name exactly one live construction. Remove stale "
+                    + "entries and split duplicate uses instead of leaving fixture files unchecked:\n"
+                    + string.Join("\n", invalidExemptions)
+            );
+        }
+
+        [Test]
+        public void OwnedSceneRefusesToClaimAnAlreadyLoadedPath()
+        {
+            string scenePath =
+                "Packages/com.wallstop-studios.dxmessaging/Tests/Editor/Fixtures/EditModeSceneSafety.unity";
+            using OwnedEditModeScene first = OwnedEditModeScene.OpenAuthored(scenePath);
+            int sceneCount = SceneManager.sceneCount;
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                using OwnedEditModeScene _ = OwnedEditModeScene.OpenAuthored(scenePath);
+            });
+
+            Assert.That(exception.Message, Does.Contain("already loaded"));
+            Assert.That(SceneManager.sceneCount, Is.EqualTo(sceneCount));
+            Assert.That(first.Scene.isLoaded, Is.True);
+        }
+
+        [Test]
+        public void OwnedSceneRestoresEditorStateWhenTheBodyThrows()
+        {
+            string scenePath =
+                "Packages/com.wallstop-studios.dxmessaging/Tests/Editor/Fixtures/EditModeSceneSafety.unity";
+            Scene originalActive = SceneManager.GetActiveScene();
+            int originalSceneCount = SceneManager.sceneCount;
+            bool originalDirty = originalActive.isDirty;
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                using OwnedEditModeScene owned = OwnedEditModeScene.OpenAuthored(scenePath);
+                owned.Activate();
+                _ = owned.CreateGameObject("Throwing fixture object");
+                throw new InvalidOperationException("Expected test-body failure.");
+            });
+
+            Assert.That(SceneManager.sceneCount, Is.EqualTo(originalSceneCount));
+            Assert.That(SceneManager.GetActiveScene().handle, Is.EqualTo(originalActive.handle));
+            Assert.That(originalActive.isDirty, Is.EqualTo(originalDirty));
+        }
+
+        [Test]
+        public void OwnedSceneCreationNeverDirtiesTheDeveloperScene()
+        {
+            string scenePath =
+                "Packages/com.wallstop-studios.dxmessaging/Tests/Editor/Fixtures/EditModeSceneSafety.unity";
+            Scene originalActive = SceneManager.GetActiveScene();
+            bool originalDirty = originalActive.isDirty;
+
+            using (OwnedEditModeScene authored = OwnedEditModeScene.OpenAuthored(scenePath))
+            {
+                GameObject authoredObject = authored.CreateGameObject("Authored object");
+                Assert.That(authoredObject.scene.handle, Is.EqualTo(authored.Scene.handle));
+                Assert.That(originalActive.isDirty, Is.EqualTo(originalDirty));
+            }
+
+            using (OwnedEditModeScene preview = OwnedEditModeScene.CreatePreview())
+            {
+                GameObject previewObject = preview.CreateGameObject("Preview object");
+                Assert.That(previewObject.scene.handle, Is.EqualTo(preview.Scene.handle));
+                Assert.That(originalActive.isDirty, Is.EqualTo(originalDirty));
+            }
+        }
+
+        private static string GetPackageRoot()
+        {
+            return Path.GetFullPath(
+                Path.Combine(Application.dataPath, "..", "Packages", PackageName)
+            );
+        }
+
+        private static string NormalizeRelativePath(string packageRoot, string file)
+        {
+            string relative = file.Substring(packageRoot.Length).TrimStart('/', '\\');
+            return relative.Replace('\\', '/');
+        }
+    }
+
+    internal readonly struct SceneResidentExemption
+    {
+        internal SceneResidentExemption(
+            string expectedRelativePath,
+            string expectedSourceFragment,
+            string reason
+        )
+        {
+            ExpectedRelativePath = expectedRelativePath;
+            ExpectedSourceFragment = expectedSourceFragment;
+            Reason = reason;
+        }
+
+        internal string ExpectedRelativePath { get; }
+        internal string ExpectedSourceFragment { get; }
+        internal string Reason { get; }
+
+        internal bool Matches(EditModeGameObjectConstruction construction)
+        {
+            return string.Equals(
+                    construction.RelativePath,
+                    ExpectedRelativePath,
+                    StringComparison.Ordinal
+                )
+                && construction.SourceLine.IndexOf(ExpectedSourceFragment, StringComparison.Ordinal)
+                    >= 0;
+        }
+    }
+
+    internal static class EditModeGameObjectConstructionScanner
+    {
+        private const string ExemptionPrefix = "// DXM-SCENE-RESIDENCY:";
+
+        private static readonly Regex AliasDeclaration = new(
+            @"\busing\s+(?<alias>[A-Za-z_]\w*)\s*=\s*(?:global::)?UnityEngine\.GameObject\s*;",
+            RegexOptions.Compiled
+        );
+
+        private static readonly Regex ExplicitConstruction = new(
+            @"\bnew\s+(?<type>(?:(?:global::)?UnityEngine\.)?GameObject|[A-Za-z_]\w*)\s*(?:\(|\{)",
+            RegexOptions.Compiled
+        );
+
+        private static readonly Regex ImplicitConstruction = new(
+            @"\bnew\s*\(",
+            RegexOptions.Compiled
+        );
+
+        private static readonly Regex AssignedTarget = new(
+            @"(?:(?:this|base)\.)?(?<name>[A-Za-z_]\w*)\s*(?:=|\?\?=)\s*\(*\s*$",
+            RegexOptions.Compiled
+        );
+
+        private static readonly Regex DangerousFactory = new(
+            @"\b(?:GameObject\.CreatePrimitive|(?:Object|UnityEngine\.Object)\.Instantiate(?:\s*<[^>]+>)?|PrefabUtility\.InstantiatePrefab)\s*\(",
+            RegexOptions.Compiled
+        );
+
+        private static readonly Regex HideFlagFactory = new(
+            @"\bEditorUtility\.CreateGameObjectWithHideFlags\s*\(",
+            RegexOptions.Compiled
+        );
+
+        internal static IReadOnlyList<EditModeGameObjectConstruction> Find(
+            string relativePath,
+            string source
+        )
+        {
+            if (relativePath == null)
+            {
+                throw new ArgumentNullException(nameof(relativePath));
+            }
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            LexedSource lexed = Lex(source);
+            string sanitized = lexed.Sanitized;
+            HashSet<string> gameObjectTypes = new(StringComparer.Ordinal)
+            {
+                "GameObject",
+                "UnityEngine.GameObject",
+                "global::UnityEngine.GameObject",
+            };
+            foreach (Match alias in AliasDeclaration.Matches(sanitized))
+            {
+                gameObjectTypes.Add(alias.Groups["alias"].Value);
+            }
+
+            List<int> constructionIndexes = new();
+            foreach (Match construction in ExplicitConstruction.Matches(sanitized))
+            {
+                if (gameObjectTypes.Contains(construction.Groups["type"].Value))
+                {
+                    constructionIndexes.Add(construction.Index);
+                }
+            }
+
+            foreach (Match construction in ImplicitConstruction.Matches(sanitized))
+            {
+                if (IsGameObjectTarget(sanitized, construction.Index, gameObjectTypes))
+                {
+                    constructionIndexes.Add(construction.Index);
+                }
+            }
+
+            constructionIndexes.AddRange(
+                DangerousFactory.Matches(sanitized).Cast<Match>().Select(match => match.Index)
+            );
+            foreach (Match factory in HideFlagFactory.Matches(sanitized))
+            {
+                int close = FindMatchingParenthesis(sanitized, factory.Index + factory.Length - 1);
+                string invocation = sanitized.Substring(
+                    factory.Index,
+                    Math.Max(0, close - factory.Index + 1)
+                );
+                int open = invocation.IndexOf('(');
+                IReadOnlyList<string> arguments =
+                    open >= 0 && invocation.Length > open + 1
+                        ? SplitTopLevelArguments(
+                            invocation.Substring(open + 1, invocation.Length - open - 2)
+                        )
+                        : Array.Empty<string>();
+                if (
+                    close < 0
+                    || arguments.Count < 2
+                    || !string.Equals(
+                        arguments[1].Trim(),
+                        "HideFlags.HideAndDontSave",
+                        StringComparison.Ordinal
+                    )
+                )
+                {
+                    constructionIndexes.Add(factory.Index);
+                }
+            }
+
+            string[] sourceLines = source.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+            List<EditModeGameObjectConstruction> results = new();
+            foreach (int index in constructionIndexes.Distinct().OrderBy(value => value))
+            {
+                int lineNumber = 1;
+                for (int cursor = 0; cursor < index; cursor++)
+                {
+                    if (sanitized[cursor] == '\n')
+                    {
+                        lineNumber++;
+                    }
+                }
+
+                string sourceLine = sourceLines[lineNumber - 1].Trim();
+                string exemptionId = ParseExemptionId(lexed.LineComments, lineNumber);
+                results.Add(
+                    new EditModeGameObjectConstruction(
+                        relativePath,
+                        lineNumber,
+                        sourceLine,
+                        exemptionId
+                    )
+                );
+            }
+
+            return results;
+        }
+
+        private static bool IsGameObjectTarget(
+            string source,
+            int constructionIndex,
+            ISet<string> gameObjectTypes
+        )
+        {
+            int statementStart = source.LastIndexOf(';', Math.Max(0, constructionIndex - 1));
+            string statement = source.Substring(
+                statementStart + 1,
+                constructionIndex - statementStart - 1
+            );
+            if (
+                ContainsGameObjectDeclaration(statement, gameObjectTypes)
+                && (
+                    IsTopLevelTargetExpression(statement)
+                    || IsParenthesizedTargetExpression(statement)
+                    || IsExplicitGameObjectArrayInitializer(statement, gameObjectTypes)
+                    || Regex.IsMatch(
+                        statement,
+                        @"\b(?:(?:global::)?UnityEngine\.)?GameObject\s*\[\]\s+[A-Za-z_]\w*\s*=\s*{[^}]*$"
+                    )
+                )
+            )
+            {
+                return true;
+            }
+
+            int windowStart = Math.Max(0, constructionIndex - 500);
+            string window = source.Substring(windowStart, constructionIndex - windowStart);
+            if (
+                gameObjectTypes.Any(type =>
+                    Regex.IsMatch(
+                        window,
+                        $@"(?:^|[^\w.]){Regex.Escape(type)}\s+[A-Za-z_]\w*\s*{{[^{{}}]*}}\s*=\s*$"
+                    )
+                )
+            )
+            {
+                return true;
+            }
+
+            Match assigned = AssignedTarget.Match(statement);
+            if (assigned.Success)
+            {
+                return ResolvesToGameObject(
+                    source,
+                    assigned.Groups["name"].Value,
+                    constructionIndex,
+                    gameObjectTypes
+                );
+            }
+
+            string before = source.Substring(0, constructionIndex);
+            if (Regex.IsMatch(statement, @"\breturn\b"))
+            {
+                if (IsInsideGameObjectReturningMethod(source, constructionIndex, gameObjectTypes))
+                {
+                    return true;
+                }
+            }
+
+            if (
+                Regex.IsMatch(
+                    statement,
+                    @"\bFunc\s*<\s*(?:(?:global::)?UnityEngine\.)?GameObject\s*>[^;]*=>[^;]*$"
+                )
+            )
+            {
+                return true;
+            }
+
+            if (Regex.IsMatch(statement, @"\bget\s*{[^{}]*\breturn\b"))
+            {
+                return IsInsideGameObjectProperty(source, constructionIndex, gameObjectTypes);
+            }
+
+            return IsInsideExpressionBodiedGameObjectMethod(
+                source,
+                constructionIndex,
+                gameObjectTypes
+            );
+        }
+
+        private static bool ContainsGameObjectDeclaration(string text, ISet<string> gameObjectTypes)
+        {
+            foreach (string type in gameObjectTypes)
+            {
+                string escaped = Regex.Escape(type);
+                if (
+                    Regex.IsMatch(
+                        text,
+                        $@"(?:^|[^\w.]){escaped}\s*(?:\[\])?\s*\??\s+[A-Za-z_]\w*[^;]*="
+                    )
+                )
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static bool IsParenthesizedTargetExpression(string statement)
+        {
+            int assignment = statement.IndexOf('=');
+            if (assignment < 0)
+            {
+                return false;
+            }
+
+            string targetPrefix = statement.Substring(assignment + 1);
+            return Regex.IsMatch(targetPrefix, @"^\s*\(*\s*$");
+        }
+
+        private static bool IsExplicitGameObjectArrayInitializer(
+            string statement,
+            IEnumerable<string> gameObjectTypes
+        )
+        {
+            int assignment = statement.IndexOf('=');
+            if (assignment < 0)
+            {
+                return false;
+            }
+
+            string targetPrefix = statement.Substring(assignment + 1);
+            return gameObjectTypes.Any(type =>
+                Regex.IsMatch(
+                    targetPrefix,
+                    $@"^\s*new\s+{Regex.Escape(type)}\s*\[\s*\]\s*\{{[^{{}}]*$"
+                )
+            );
+        }
+
+        private static bool ResolvesToGameObject(
+            string source,
+            string name,
+            int constructionIndex,
+            ISet<string> gameObjectTypes
+        )
+        {
+            Regex declaration = new(
+                $@"(?<type>[A-Za-z_][\w.:<>?\[\]]*)\s+{Regex.Escape(name)}\s*(?:[;=,\){{])"
+            );
+            Match nearest = declaration
+                .Matches(source.Substring(0, constructionIndex))
+                .Cast<Match>()
+                .Where(match => constructionIndex < FindEnclosingScopeEnd(source, match.Index))
+                .LastOrDefault();
+            return nearest != null
+                && gameObjectTypes.Contains(nearest.Groups["type"].Value.TrimEnd('?'));
+        }
+
+        private static bool IsInsideGameObjectReturningMethod(
+            string source,
+            int constructionIndex,
+            ISet<string> gameObjectTypes
+        )
+        {
+            foreach (string type in gameObjectTypes)
+            {
+                Regex method = new(
+                    $@"(?:^|[^\w.]){Regex.Escape(type)}\s+[A-Za-z_]\w*\s*\([^;{{}}]*\)\s*{{"
+                );
+                foreach (Match match in method.Matches(source))
+                {
+                    int openBrace = source.IndexOf('{', match.Index);
+                    if (
+                        openBrace >= 0
+                        && openBrace < constructionIndex
+                        && constructionIndex < FindMatchingBrace(source, openBrace)
+                    )
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        private static bool IsInsideExpressionBodiedGameObjectMethod(
+            string source,
+            int constructionIndex,
+            ISet<string> gameObjectTypes
+        )
+        {
+            int arrow = source.LastIndexOf("=>", constructionIndex, StringComparison.Ordinal);
+            int semicolon = source.LastIndexOf(';', Math.Max(0, constructionIndex - 1));
+            if (arrow < 0 || arrow < semicolon)
+            {
+                return false;
+            }
+
+            string signature = source.Substring(semicolon + 1, arrow - semicolon - 1);
+            return gameObjectTypes.Any(type =>
+                Regex.IsMatch(
+                    signature,
+                    $@"(?:^|[^\w.]){Regex.Escape(type)}\s+[A-Za-z_]\w*\s*\([^)]*\)\s*$"
+                )
+            );
+        }
+
+        private static int FindEnclosingScopeEnd(string source, int declarationIndex)
+        {
+            Stack<int> openBraces = new();
+            for (int index = 0; index < declarationIndex; index++)
+            {
+                if (source[index] == '{')
+                {
+                    openBraces.Push(index);
+                }
+                else if (source[index] == '}' && openBraces.Count > 0)
+                {
+                    openBraces.Pop();
+                }
+            }
+            return openBraces.Count == 0
+                ? source.Length
+                : FindMatchingBrace(source, openBraces.Peek());
+        }
+
+        private static int FindMatchingBrace(string source, int openBrace)
+        {
+            int depth = 0;
+            for (int index = openBrace; index < source.Length; index++)
+            {
+                if (source[index] == '{')
+                {
+                    depth++;
+                }
+                else if (source[index] == '}' && --depth == 0)
+                {
+                    return index;
+                }
+            }
+            return source.Length;
+        }
+
+        private static int FindMatchingParenthesis(string source, int openParenthesis)
+        {
+            int depth = 0;
+            for (int index = openParenthesis; index < source.Length; index++)
+            {
+                if (source[index] == '(')
+                {
+                    depth++;
+                }
+                else if (source[index] == ')' && --depth == 0)
+                {
+                    return index;
+                }
+            }
+            return -1;
+        }
+
+        private static bool IsTopLevelTargetExpression(string statement)
+        {
+            int assignment = statement.IndexOf('=');
+            if (assignment < 0)
+            {
+                return false;
+            }
+
+            int depth = 0;
+            for (int index = assignment + 1; index < statement.Length; index++)
+            {
+                char current = statement[index];
+                if (current == '(' || current == '[' || current == '{')
+                {
+                    depth++;
+                }
+                else if (current == ')' || current == ']' || current == '}')
+                {
+                    depth--;
+                }
+            }
+            return depth == 0;
+        }
+
+        private static bool IsInsideGameObjectProperty(
+            string source,
+            int constructionIndex,
+            ISet<string> gameObjectTypes
+        )
+        {
+            foreach (string type in gameObjectTypes)
+            {
+                Regex property = new($@"(?:^|[^\w.]){Regex.Escape(type)}\s+[A-Za-z_]\w*\s*{{");
+                foreach (Match match in property.Matches(source))
+                {
+                    int openBrace = source.IndexOf('{', match.Index);
+                    if (
+                        openBrace >= 0
+                        && openBrace < constructionIndex
+                        && constructionIndex < FindMatchingBrace(source, openBrace)
+                    )
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        private static IReadOnlyList<string> SplitTopLevelArguments(string arguments)
+        {
+            List<string> result = new();
+            int start = 0;
+            int depth = 0;
+            for (int index = 0; index < arguments.Length; index++)
+            {
+                char current = arguments[index];
+                if (current == '(' || current == '[' || current == '{' || current == '<')
+                {
+                    depth++;
+                }
+                else if (current == ')' || current == ']' || current == '}' || current == '>')
+                {
+                    depth--;
+                }
+                else if (current == ',' && depth == 0)
+                {
+                    result.Add(arguments.Substring(start, index - start));
+                    start = index + 1;
+                }
+            }
+            result.Add(arguments.Substring(start));
+            return result;
+        }
+
+        private static string ParseExemptionId(
+            IReadOnlyDictionary<int, string> lineComments,
+            int lineNumber
+        )
+        {
+            if (!lineComments.TryGetValue(lineNumber, out string comment))
+            {
+                return string.Empty;
+            }
+
+            string trimmed = comment.Trim();
+            if (!trimmed.StartsWith(ExemptionPrefix, StringComparison.Ordinal))
+            {
+                return string.Empty;
+            }
+
+            string id = trimmed.Substring(ExemptionPrefix.Length).Trim();
+            return Regex.IsMatch(id, @"^[a-z0-9]+(?:-[a-z0-9]+)*$") ? id : string.Empty;
+        }
+
+        private static LexedSource Lex(string source)
+        {
+            char[] sanitized = source.ToCharArray();
+            Dictionary<int, string> lineComments = new();
+            Stack<LexerFrame> frames = new();
+            frames.Push(new LexerFrame(LexerState.Code, 0));
+            int lineNumber = 1;
+
+            for (int index = 0; index < source.Length; index++)
+            {
+                char current = source[index];
+                char next = index + 1 < source.Length ? source[index + 1] : '\0';
+                LexerFrame frame = frames.Peek();
+                bool isCode = frame.State == LexerState.Code;
+
+                if (isCode && frame.InterpolationDepth > 0 && current == '}')
+                {
+                    sanitized[index] = ' ';
+                    frame.InterpolationDepth--;
+                    frames.Pop();
+                    if (frame.InterpolationDepth > 0)
+                    {
+                        frames.Push(frame);
+                    }
+                    continue;
+                }
+
+                if (isCode && current == '/' && next == '/')
+                {
+                    int end = source.IndexOf('\n', index);
+                    if (end < 0)
+                    {
+                        end = source.Length;
+                    }
+                    lineComments[lineNumber] = source.Substring(index, end - index);
+                    frames.Push(new LexerFrame(LexerState.LineComment, 0));
+                }
+                else if (isCode && current == '/' && next == '*')
+                {
+                    frames.Push(new LexerFrame(LexerState.BlockComment, 0));
+                }
+                else if (isCode && current == '\'')
+                {
+                    sanitized[index] = ' ';
+                    frames.Push(new LexerFrame(LexerState.Character, 0));
+                    continue;
+                }
+                else if (isCode && current == '$' && next == '"')
+                {
+                    sanitized[index] = ' ';
+                    sanitized[index + 1] = ' ';
+                    index++;
+                    frames.Push(new LexerFrame(LexerState.InterpolatedString, 0));
+                    continue;
+                }
+                else if (
+                    isCode
+                    && (
+                        (
+                            current == '$'
+                            && next == '@'
+                            && index + 2 < source.Length
+                            && source[index + 2] == '"'
+                        )
+                        || (
+                            current == '@'
+                            && next == '$'
+                            && index + 2 < source.Length
+                            && source[index + 2] == '"'
+                        )
+                    )
+                )
+                {
+                    sanitized[index] = ' ';
+                    sanitized[index + 1] = ' ';
+                    sanitized[index + 2] = ' ';
+                    index += 2;
+                    frames.Push(new LexerFrame(LexerState.InterpolatedVerbatimString, 0));
+                    continue;
+                }
+                else if (isCode && current == '@' && next == '"')
+                {
+                    sanitized[index] = ' ';
+                    sanitized[index + 1] = ' ';
+                    index++;
+                    frames.Push(new LexerFrame(LexerState.VerbatimString, 0));
+                    continue;
+                }
+                else if (isCode && current == '"')
+                {
+                    sanitized[index] = ' ';
+                    frames.Push(new LexerFrame(LexerState.String, 0));
+                    continue;
+                }
+                else if (isCode && frame.InterpolationDepth > 0 && current == '{')
+                {
+                    frame.InterpolationDepth++;
+                    frames.Pop();
+                    frames.Push(frame);
+                }
+
+                if (frames.Peek().State != LexerState.Code)
+                {
+                    sanitized[index] = current == '\r' || current == '\n' ? current : ' ';
+                }
+
+                LexerState state = frames.Peek().State;
+                if (state == LexerState.LineComment && (current == '\r' || current == '\n'))
+                {
+                    frames.Pop();
+                }
+                else if (state == LexerState.BlockComment && current == '*' && next == '/')
+                {
+                    sanitized[index + 1] = ' ';
+                    index++;
+                    frames.Pop();
+                }
+                else if (
+                    (state == LexerState.String || state == LexerState.Character)
+                    && current == '\\'
+                    && next != '\0'
+                )
+                {
+                    sanitized[index + 1] = ' ';
+                    index++;
+                }
+                else if (
+                    (state == LexerState.String && current == '"')
+                    || (state == LexerState.Character && current == '\'')
+                )
+                {
+                    frames.Pop();
+                }
+                else if (
+                    (
+                        state == LexerState.VerbatimString
+                        || state == LexerState.InterpolatedVerbatimString
+                    )
+                    && current == '"'
+                )
+                {
+                    if (next == '"')
+                    {
+                        sanitized[index + 1] = ' ';
+                        index++;
+                    }
+                    else
+                    {
+                        frames.Pop();
+                    }
+                }
+                else if (state == LexerState.InterpolatedString && current == '\\' && next != '\0')
+                {
+                    sanitized[index + 1] = ' ';
+                    index++;
+                }
+                else if (state == LexerState.InterpolatedString && current == '"')
+                {
+                    frames.Pop();
+                }
+                else if (
+                    (
+                        state == LexerState.InterpolatedString
+                        || state == LexerState.InterpolatedVerbatimString
+                    )
+                    && current == '{'
+                )
+                {
+                    if (next == '{')
+                    {
+                        sanitized[index + 1] = ' ';
+                        index++;
+                    }
+                    else
+                    {
+                        frames.Push(new LexerFrame(LexerState.Code, 1));
+                    }
+                }
+
+                if (current == '\n')
+                {
+                    lineNumber++;
+                }
+            }
+
+            return new LexedSource(new string(sanitized), lineComments);
+        }
+
+        private enum LexerState
+        {
+            Code,
+            LineComment,
+            BlockComment,
+            String,
+            VerbatimString,
+            InterpolatedString,
+            InterpolatedVerbatimString,
+            Character,
+        }
+
+        private struct LexerFrame
+        {
+            internal LexerFrame(LexerState state, int interpolationDepth)
+            {
+                State = state;
+                InterpolationDepth = interpolationDepth;
+            }
+
+            internal LexerState State;
+            internal int InterpolationDepth;
+        }
+
+        private readonly struct LexedSource
+        {
+            internal LexedSource(string sanitized, IReadOnlyDictionary<int, string> lineComments)
+            {
+                Sanitized = sanitized;
+                LineComments = lineComments;
+            }
+
+            internal string Sanitized { get; }
+            internal IReadOnlyDictionary<int, string> LineComments { get; }
+        }
+    }
+
+    internal readonly struct EditModeGameObjectConstruction
+    {
+        internal EditModeGameObjectConstruction(
+            string relativePath,
+            int lineNumber,
+            string sourceLine,
+            string exemptionId
+        )
+        {
+            RelativePath = relativePath;
+            LineNumber = lineNumber;
+            SourceLine = sourceLine;
+            ExemptionId = exemptionId;
+        }
+
+        internal string RelativePath { get; }
+
+        internal int LineNumber { get; }
+
+        internal string SourceLine { get; }
+
+        internal string ExemptionId { get; }
+
+        internal string Display => $"{RelativePath}:{LineNumber}: {SourceLine}";
+    }
+}
+#endif

--- a/Tests/Editor/EditModeSceneSafetyContractTests.cs.meta
+++ b/Tests/Editor/EditModeSceneSafetyContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1dfe270988162d8051788375a8017053
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/EditorSurfaceCaptureTests.cs
+++ b/Tests/Editor/EditorSurfaceCaptureTests.cs
@@ -317,7 +317,10 @@ namespace DxMessaging.Tests.Editor
 
         private VisualElement CreateInspectorWarningPanel()
         {
-            GameObject host = new(nameof(CreateInspectorWarningPanel));
+            GameObject host = EditorUtility.CreateGameObjectWithHideFlags(
+                nameof(CreateInspectorWarningPanel),
+                HideFlags.HideAndDontSave
+            );
             _createdObjects.Add(host);
             MessageAwareComponent component =
                 host.AddComponent<EmptyMessageAwareComponentForCaptureTest>();

--- a/Tests/Editor/Fixtures.meta
+++ b/Tests/Editor/Fixtures.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 38cc7e3da7e04f819e7a4b0e850fc645
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/Fixtures/EditModeSceneSafety.unity
+++ b/Tests/Editor/Fixtures/EditModeSceneSafety.unity
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1001}
+  m_Layer: 0
+  m_Name: DxMessaging EditMode Scene Fixture
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Tests/Editor/Fixtures/EditModeSceneSafety.unity.meta
+++ b/Tests/Editor/Fixtures/EditModeSceneSafety.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 22569661488c4f20b8a086f1af8fa42c
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/MessageAwareComponentFallbackEditorTests.cs
+++ b/Tests/Editor/MessageAwareComponentFallbackEditorTests.cs
@@ -1601,7 +1601,10 @@ namespace DxMessaging.Tests.Editor
 
         private GameObject CreateTrackedObject(string name)
         {
-            GameObject gameObject = new(name);
+            GameObject gameObject = EditorUtility.CreateGameObjectWithHideFlags(
+                name,
+                HideFlags.HideAndDontSave
+            );
             _createdObjects.Add(gameObject);
             return gameObject;
         }

--- a/Tests/Editor/MessageAwareComponentSubscriptionsViewTests.cs
+++ b/Tests/Editor/MessageAwareComponentSubscriptionsViewTests.cs
@@ -10,6 +10,7 @@ namespace DxMessaging.Tests.Editor
     using DxMessaging.Editor.CustomEditors;
     using DxMessaging.Unity;
     using NUnit.Framework;
+    using UnityEditor;
     using UnityEngine;
     using UnityEngine.UIElements;
     using Object = UnityEngine.Object;
@@ -838,7 +839,10 @@ namespace DxMessaging.Tests.Editor
             out MessagingComponent messagingComponent
         )
         {
-            GameObject host = new(nameof(MessageAwareComponentSubscriptionsViewTests));
+            GameObject host = EditorUtility.CreateGameObjectWithHideFlags(
+                nameof(MessageAwareComponentSubscriptionsViewTests),
+                HideFlags.HideAndDontSave
+            );
             _createdObjects.Add(host);
             messagingComponent = host.AddComponent<MessagingComponent>();
             return host.AddComponent<SubscriptionsTestComponent>();

--- a/Tests/Editor/MessagingComponentEditorHarnessTests.cs
+++ b/Tests/Editor/MessagingComponentEditorHarnessTests.cs
@@ -194,7 +194,10 @@ namespace DxMessaging.Tests.Editor
 
         private GameObject CreateTrackedObject(string name)
         {
-            GameObject gameObject = new(name);
+            GameObject gameObject = EditorUtility.CreateGameObjectWithHideFlags(
+                name,
+                HideFlags.HideAndDontSave
+            );
             _createdObjects.Add(gameObject);
             return gameObject;
         }

--- a/Tests/Editor/MessagingComponentSerializationTests.cs
+++ b/Tests/Editor/MessagingComponentSerializationTests.cs
@@ -2,6 +2,7 @@
 namespace DxMessaging.Tests.Editor
 {
     using System.Collections.Generic;
+    using DxMessaging.Core;
     using DxMessaging.Core.MessageBus;
     using DxMessaging.Unity;
     using NUnit.Framework;
@@ -46,11 +47,9 @@ namespace DxMessaging.Tests.Editor
         [Test]
         public void SerializedProviderHandleSurvivesJsonRoundtrip()
         {
-            MessageBus messageBus = new();
-            TestScriptableMessageBusProvider provider = Track(
-                ScriptableObject.CreateInstance<TestScriptableMessageBusProvider>()
+            CurrentGlobalMessageBusProvider provider = Track(
+                ScriptableObject.CreateInstance<CurrentGlobalMessageBusProvider>()
             );
-            provider.Configure(messageBus);
             string assetPath = AssetDatabase.GenerateUniqueAssetPath(
                 "Assets/__TempTestProvider.asset"
             );
@@ -59,7 +58,12 @@ namespace DxMessaging.Tests.Editor
             AssetDatabase.SaveAssets();
             AssetDatabase.ImportAsset(assetPath);
 
-            GameObject owner = Track(new GameObject("OriginalComponentOwner"));
+            GameObject owner = Track(
+                EditorUtility.CreateGameObjectWithHideFlags(
+                    "OriginalComponentOwner",
+                    HideFlags.HideAndDontSave
+                )
+            );
             MessagingComponent original = owner.AddComponent<MessagingComponent>();
             original.Configure(
                 new MessageBusProviderHandle(provider),
@@ -80,7 +84,12 @@ namespace DxMessaging.Tests.Editor
                 "JSON serialization should produce content."
             );
 
-            GameObject cloneOwner = Track(new GameObject("ClonedComponentOwner"));
+            GameObject cloneOwner = Track(
+                EditorUtility.CreateGameObjectWithHideFlags(
+                    "ClonedComponentOwner",
+                    HideFlags.HideAndDontSave
+                )
+            );
             MessagingComponent clone = cloneOwner.AddComponent<MessagingComponent>();
             EditorJsonUtility.FromJsonOverwrite(serializedJson, clone);
 
@@ -99,9 +108,9 @@ namespace DxMessaging.Tests.Editor
 
             IMessageBus resolvedBus = clone.SerializedProviderHandle.ResolveBus();
             Assert.AreSame(
-                messageBus,
+                MessageHandler.MessageBus,
                 resolvedBus,
-                "Resolved bus should match the original provider configuration."
+                "The deserialized provider should retain its production resolution behavior."
             );
         }
 
@@ -114,21 +123,6 @@ namespace DxMessaging.Tests.Editor
             }
 
             return unityObject;
-        }
-
-        private sealed class TestScriptableMessageBusProvider : ScriptableMessageBusProvider
-        {
-            private IMessageBus _bus;
-
-            internal void Configure(IMessageBus bus)
-            {
-                _bus = bus;
-            }
-
-            public override IMessageBus Resolve()
-            {
-                return _bus;
-            }
         }
     }
 }

--- a/Tests/Editor/OwnedEditModeScene.cs
+++ b/Tests/Editor/OwnedEditModeScene.cs
@@ -155,7 +155,12 @@ namespace DxMessaging.Tests.Editor
                 {
                     if (_isPreviewScene)
                     {
-                        EditorSceneManager.ClosePreviewScene(_scene);
+                        if (!EditorSceneManager.ClosePreviewScene(_scene))
+                        {
+                            throw new InvalidOperationException(
+                                "Unity refused to close the fixture-owned preview scene."
+                            );
+                        }
                     }
                     else if (_scene.isLoaded)
                     {

--- a/Tests/Editor/OwnedEditModeScene.cs
+++ b/Tests/Editor/OwnedEditModeScene.cs
@@ -1,0 +1,204 @@
+#if UNITY_EDITOR && UNITY_2021_3_OR_NEWER
+namespace DxMessaging.Tests.Editor
+{
+    using System;
+    using System.Collections.Generic;
+    using UnityEditor;
+    using UnityEditor.SceneManagement;
+    using UnityEngine;
+    using UnityEngine.SceneManagement;
+
+    internal sealed class OwnedEditModeScene : IDisposable
+    {
+        private readonly Scene _originalActiveScene;
+        private readonly bool _isPreviewScene;
+        private Scene _scene;
+        private bool _disposed;
+
+        private OwnedEditModeScene(Scene scene, bool isPreviewScene, Scene originalActiveScene)
+        {
+            _scene = scene;
+            _isPreviewScene = isPreviewScene;
+            _originalActiveScene = originalActiveScene;
+        }
+
+        internal Scene Scene
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _scene;
+            }
+        }
+
+        internal static OwnedEditModeScene OpenAuthored(string scenePath)
+        {
+            if (string.IsNullOrWhiteSpace(scenePath))
+            {
+                throw new ArgumentException(
+                    "An authored scene path is required.",
+                    nameof(scenePath)
+                );
+            }
+
+            for (int index = 0; index < SceneManager.sceneCount; index++)
+            {
+                Scene loaded = SceneManager.GetSceneAt(index);
+                if (
+                    loaded.isLoaded
+                    && string.Equals(loaded.path, scenePath, StringComparison.OrdinalIgnoreCase)
+                )
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot claim authored scene '{scenePath}' because it was already loaded."
+                    );
+                }
+            }
+
+            Scene originalActiveScene = SceneManager.GetActiveScene();
+            Scene opened = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
+            return new OwnedEditModeScene(
+                opened,
+                isPreviewScene: false,
+                originalActiveScene: originalActiveScene
+            );
+        }
+
+        internal static OwnedEditModeScene CreatePreview()
+        {
+            return new OwnedEditModeScene(
+                EditorSceneManager.NewPreviewScene(),
+                isPreviewScene: true,
+                originalActiveScene: SceneManager.GetActiveScene()
+            );
+        }
+
+        internal void Activate()
+        {
+            ThrowIfDisposed();
+            if (_isPreviewScene)
+            {
+                throw new InvalidOperationException(
+                    "A preview scene cannot become the active scene."
+                );
+            }
+
+            if (!SceneManager.SetActiveScene(_scene))
+            {
+                throw new InvalidOperationException(
+                    $"Unity refused to activate fixture-owned scene '{_scene.path}'."
+                );
+            }
+        }
+
+        internal GameObject CreateGameObject(string name, params Type[] componentTypes)
+        {
+            ThrowIfDisposed();
+            GameObject gameObject = EditorUtility.CreateGameObjectWithHideFlags(
+                name,
+                HideFlags.HideAndDontSave
+            );
+            SceneManager.MoveGameObjectToScene(gameObject, _scene);
+            gameObject.hideFlags = HideFlags.None;
+
+            if (componentTypes != null)
+            {
+                foreach (Type componentType in componentTypes)
+                {
+                    if (componentType == null)
+                    {
+                        throw new ArgumentException(
+                            "Scene-resident component types cannot contain null.",
+                            nameof(componentTypes)
+                        );
+                    }
+                    gameObject.AddComponent(componentType);
+                }
+            }
+
+            return gameObject;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+
+            List<Exception> failures = new();
+            try
+            {
+                if (
+                    _originalActiveScene.IsValid()
+                    && _originalActiveScene.isLoaded
+                    && SceneManager.GetActiveScene().handle != _originalActiveScene.handle
+                )
+                {
+                    if (!SceneManager.SetActiveScene(_originalActiveScene))
+                    {
+                        throw new InvalidOperationException(
+                            $"Unity refused to restore active scene '{_originalActiveScene.path}'."
+                        );
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                failures.Add(exception);
+            }
+
+            try
+            {
+                if (_scene.IsValid())
+                {
+                    if (_isPreviewScene)
+                    {
+                        EditorSceneManager.ClosePreviewScene(_scene);
+                    }
+                    else if (_scene.isLoaded)
+                    {
+                        if (!EditorSceneManager.CloseScene(_scene, removeScene: true))
+                        {
+                            throw new InvalidOperationException(
+                                $"Unity refused to close fixture-owned scene '{_scene.path}'."
+                            );
+                        }
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                failures.Add(exception);
+            }
+            finally
+            {
+                if (!_scene.IsValid() || !_scene.isLoaded)
+                {
+                    _scene = default;
+                }
+            }
+
+            if (failures.Count == 1)
+            {
+                _disposed = false;
+                throw failures[0];
+            }
+            if (failures.Count > 1)
+            {
+                _disposed = false;
+                throw new AggregateException("Fixture-owned scene cleanup failed.", failures);
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(OwnedEditModeScene));
+            }
+        }
+    }
+}
+#endif

--- a/Tests/Editor/OwnedEditModeScene.cs.meta
+++ b/Tests/Editor/OwnedEditModeScene.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8505df02166c4b43aa8f11e9970606e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/SampleQualityContractTests.cs
+++ b/Tests/Editor/SampleQualityContractTests.cs
@@ -11,7 +11,6 @@ namespace DxMessaging.Tests.Editor
     using DxMessaging.Core.MessageBus;
     using NUnit.Framework;
     using UnityEditor;
-    using UnityEditor.SceneManagement;
     using UnityEngine;
     using UnityEngine.SceneManagement;
     using Object = UnityEngine.Object;
@@ -77,22 +76,21 @@ namespace DxMessaging.Tests.Editor
                 return;
             }
 
-            Scene originalScene = SceneManager.GetActiveScene();
-            Scene isolatedScene = EditorSceneManager.OpenScene(
-                $"{importedSamplesRoot}/Mini Combat/MiniCombat.unity",
-                OpenSceneMode.Additive
+            using OwnedEditModeScene isolatedScene = OwnedEditModeScene.OpenAuthored(
+                $"{importedSamplesRoot}/Mini Combat/MiniCombat.unity"
             );
             GameObject? host = null;
 
             try
             {
                 Assert.That(
-                    SceneManager.SetActiveScene(isolatedScene),
+                    isolatedScene.Scene.IsValid(),
                     Is.True,
-                    "The fallback test must own an isolated active scene."
+                    "The fallback test must open an isolated scene."
                 );
-                Type bootType = FindSceneComponent(isolatedScene, "Boot").GetType();
-                host = new GameObject("Mini Combat fallback owner");
+                isolatedScene.Activate();
+                Type bootType = FindSceneComponent(isolatedScene.Scene, "Boot").GetType();
+                host = isolatedScene.CreateGameObject("Mini Combat fallback owner");
                 Component boot = host.AddComponent(bootType);
                 FieldInfo playerField =
                     bootType.GetField("player", BindingFlags.Instance | BindingFlags.NonPublic)
@@ -139,16 +137,6 @@ namespace DxMessaging.Tests.Editor
                 {
                     Object.DestroyImmediate(host);
                 }
-
-                if (originalScene.IsValid() && originalScene.isLoaded)
-                {
-                    _ = SceneManager.SetActiveScene(originalScene);
-                }
-
-                if (isolatedScene.IsValid() && isolatedScene.isLoaded)
-                {
-                    _ = EditorSceneManager.CloseScene(isolatedScene, removeScene: true);
-                }
             }
         }
 
@@ -161,10 +149,8 @@ namespace DxMessaging.Tests.Editor
                 return;
             }
 
-            Scene originalScene = SceneManager.GetActiveScene();
-            Scene isolatedScene = EditorSceneManager.OpenScene(
-                $"{importedSamplesRoot}/Mini Combat/MiniCombat.unity",
-                OpenSceneMode.Additive
+            using OwnedEditModeScene isolatedScene = OwnedEditModeScene.OpenAuthored(
+                $"{importedSamplesRoot}/Mini Combat/MiniCombat.unity"
             );
             GameObject? host = null;
             GameObject? assignedPlayer = null;
@@ -174,16 +160,17 @@ namespace DxMessaging.Tests.Editor
             try
             {
                 Assert.That(
-                    SceneManager.SetActiveScene(isolatedScene),
+                    isolatedScene.Scene.IsValid(),
                     Is.True,
-                    "The mixed-ownership test must own an isolated active scene."
+                    "The mixed-ownership test must open an isolated scene."
                 );
-                Type bootType = FindSceneComponent(isolatedScene, "Boot").GetType();
-                Type playerType = FindSceneComponent(isolatedScene, "Player").GetType();
-                Type overlayType = FindSceneComponent(isolatedScene, "UIOverlay").GetType();
-                host = new GameObject("Mini Combat mixed owner");
-                assignedPlayer = new GameObject("Scene-owned Player");
-                assignedOverlay = new GameObject("Scene-owned UI Overlay");
+                isolatedScene.Activate();
+                Type bootType = FindSceneComponent(isolatedScene.Scene, "Boot").GetType();
+                Type playerType = FindSceneComponent(isolatedScene.Scene, "Player").GetType();
+                Type overlayType = FindSceneComponent(isolatedScene.Scene, "UIOverlay").GetType();
+                host = isolatedScene.CreateGameObject("Mini Combat mixed owner");
+                assignedPlayer = isolatedScene.CreateGameObject("Scene-owned Player");
+                assignedOverlay = isolatedScene.CreateGameObject("Scene-owned UI Overlay");
                 Component player = assignedPlayer.AddComponent(playerType);
                 Component overlay = assignedOverlay.AddComponent(overlayType);
                 Component boot = host.AddComponent(bootType);
@@ -228,7 +215,6 @@ namespace DxMessaging.Tests.Editor
                 DestroyImmediateIfAlive(host);
                 DestroyImmediateIfAlive(assignedPlayer);
                 DestroyImmediateIfAlive(assignedOverlay);
-                RestoreAndCloseScene(originalScene, isolatedScene);
             }
         }
 
@@ -265,10 +251,8 @@ namespace DxMessaging.Tests.Editor
                 ?? throw new AssertionException(
                     "The diagnostics sample requires the default concrete global MessageBus."
                 );
-            Scene originalScene = SceneManager.GetActiveScene();
-            Scene isolatedScene = EditorSceneManager.OpenScene(
-                $"{importedSamplesRoot}/Diagnostics Tooling Exerciser/DiagnosticsToolingExerciser.unity",
-                OpenSceneMode.Additive
+            using OwnedEditModeScene isolatedScene = OwnedEditModeScene.OpenAuthored(
+                $"{importedSamplesRoot}/Diagnostics Tooling Exerciser/DiagnosticsToolingExerciser.unity"
             );
             GameObject? firstHost = null;
             GameObject? secondHost = null;
@@ -277,15 +261,19 @@ namespace DxMessaging.Tests.Editor
             try
             {
                 Assert.That(
-                    SceneManager.SetActiveScene(isolatedScene),
+                    isolatedScene.Scene.IsValid(),
                     Is.True,
-                    "The diagnostics ownership test must own an isolated active scene."
+                    "The diagnostics ownership test must open an isolated scene."
                 );
-                exerciserType = FindSceneComponent(isolatedScene, "DiagnosticsToolingExerciser")
+                isolatedScene.Activate();
+                exerciserType = FindSceneComponent(
+                        isolatedScene.Scene,
+                        "DiagnosticsToolingExerciser"
+                    )
                     .GetType();
                 messageBus.DiagnosticsMode = originalMode;
-                firstHost = new GameObject("Diagnostics owner 1");
-                secondHost = new GameObject("Diagnostics owner 2");
+                firstHost = isolatedScene.CreateGameObject("Diagnostics owner 1");
+                secondHost = isolatedScene.CreateGameObject("Diagnostics owner 2");
                 Component first = firstHost.AddComponent(exerciserType);
                 Component second = secondHost.AddComponent(exerciserType);
 
@@ -334,24 +322,13 @@ namespace DxMessaging.Tests.Editor
                 }
 
                 messageBus.DiagnosticsMode = originalMode;
-                if (originalScene.IsValid() && originalScene.isLoaded)
-                {
-                    _ = SceneManager.SetActiveScene(originalScene);
-                }
-
-                if (isolatedScene.IsValid() && isolatedScene.isLoaded)
-                {
-                    _ = EditorSceneManager.CloseScene(isolatedScene, removeScene: true);
-                }
             }
         }
 
         private static void AssertMiniCombatMessageFlow(string importedSamplesRoot)
         {
-            Scene originalScene = SceneManager.GetActiveScene();
-            Scene sampleScene = EditorSceneManager.OpenScene(
-                $"{importedSamplesRoot}/Mini Combat/MiniCombat.unity",
-                OpenSceneMode.Additive
+            using OwnedEditModeScene sampleScene = OwnedEditModeScene.OpenAuthored(
+                $"{importedSamplesRoot}/Mini Combat/MiniCombat.unity"
             );
             Component? player = null;
             Component? overlay = null;
@@ -359,13 +336,14 @@ namespace DxMessaging.Tests.Editor
             try
             {
                 Assert.That(
-                    SceneManager.SetActiveScene(sampleScene),
+                    sampleScene.Scene.IsValid(),
                     Is.True,
-                    "The Mini Combat smoke test must activate its imported scene."
+                    "The Mini Combat smoke test must open its imported scene."
                 );
-                Component boot = FindSceneComponent(sampleScene, "Boot");
-                player = FindSceneComponent(sampleScene, "Player");
-                overlay = FindSceneComponent(sampleScene, "UIOverlay");
+                sampleScene.Activate();
+                Component boot = FindSceneComponent(sampleScene.Scene, "Boot");
+                player = FindSceneComponent(sampleScene.Scene, "Player");
+                overlay = FindSceneComponent(sampleScene.Scene, "UIOverlay");
 
                 InvokeRequired(player, "Awake");
                 InvokeRequired(overlay, "Awake");
@@ -395,29 +373,27 @@ namespace DxMessaging.Tests.Editor
             {
                 ReleaseMessageAwareComponent(player);
                 ReleaseMessageAwareComponent(overlay);
-                RestoreAndCloseScene(originalScene, sampleScene);
             }
         }
 
         private static void AssertUiButtonsMessageFlow(string importedSamplesRoot)
         {
-            Scene originalScene = SceneManager.GetActiveScene();
-            Scene sampleScene = EditorSceneManager.OpenScene(
-                $"{importedSamplesRoot}/UI Buttons + Inspector/UIButtonsInspector.unity",
-                OpenSceneMode.Additive
+            using OwnedEditModeScene sampleScene = OwnedEditModeScene.OpenAuthored(
+                $"{importedSamplesRoot}/UI Buttons + Inspector/UIButtonsInspector.unity"
             );
             Component? observer = null;
 
             try
             {
                 Assert.That(
-                    SceneManager.SetActiveScene(sampleScene),
+                    sampleScene.Scene.IsValid(),
                     Is.True,
-                    "The UI Buttons smoke test must activate its imported scene."
+                    "The UI Buttons smoke test must open its imported scene."
                 );
-                observer = FindSceneComponent(sampleScene, "MessagingObserver");
+                sampleScene.Activate();
+                observer = FindSceneComponent(sampleScene.Scene, "MessagingObserver");
                 Type observerType = observer.GetType();
-                Component emitter = FindSceneComponent(sampleScene, "UIButtonEmitter");
+                Component emitter = FindSceneComponent(sampleScene.Scene, "UIButtonEmitter");
                 GetRequiredField(observerType, "logTypedClicks").SetValue(observer, false);
 
                 InvokeRequired(observer, "Awake");
@@ -448,7 +424,6 @@ namespace DxMessaging.Tests.Editor
             finally
             {
                 ReleaseMessageAwareComponent(observer);
-                RestoreAndCloseScene(originalScene, sampleScene);
             }
         }
 
@@ -638,10 +613,9 @@ namespace DxMessaging.Tests.Editor
                 $"The CI sample fixture must copy {scenePath}."
             );
 
-            Scene scene = default;
-            try
+            using (OwnedEditModeScene ownedScene = OwnedEditModeScene.OpenAuthored(scenePath))
             {
-                scene = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
+                Scene scene = ownedScene.Scene;
                 Assert.That(scene.IsValid(), Is.True, $"Unity must open {scenePath}.");
                 Assert.That(scene.isLoaded, Is.True, $"Unity must load {scenePath}.");
 
@@ -657,13 +631,6 @@ namespace DxMessaging.Tests.Editor
                             $"{scenePath} contains a missing script on '{child.name}'."
                         );
                     }
-                }
-            }
-            finally
-            {
-                if (scene.IsValid() && scene.isLoaded)
-                {
-                    _ = EditorSceneManager.CloseScene(scene, removeScene: true);
                 }
             }
         }
@@ -743,19 +710,6 @@ namespace DxMessaging.Tests.Editor
             if (gameObject != null)
             {
                 Object.DestroyImmediate(gameObject);
-            }
-        }
-
-        private static void RestoreAndCloseScene(Scene originalScene, Scene ownedScene)
-        {
-            if (originalScene.IsValid() && originalScene.isLoaded)
-            {
-                _ = SceneManager.SetActiveScene(originalScene);
-            }
-
-            if (ownedScene.IsValid() && ownedScene.isLoaded)
-            {
-                _ = EditorSceneManager.CloseScene(ownedScene, removeScene: true);
             }
         }
 


### PR DESCRIPTION
Closes #370.

## What changed

- Add an `OwnedEditModeScene` scope for package-authored additive scenes and preview scenes.
- Refuse already-loaded authored scenes, restore the original active scene, verify cleanup results, and keep failed cleanup retryable.
- Create non-scene test objects with `HideAndDontSave` and move owned objects into their fixture scene before clearing the flag.
- Convert affected Flow Graph, Message Monitor, editor harness, serialization, sample-quality, and benchmark fixtures.
- Add a package-authored scene fixture plus a source contract that rejects classic, target-typed, deferred, member, return, property, lambda, array, alias, initializer, interpolation, and unsafe factory construction.
- Keep the contract exemption map empty because every current fixture now uses a scene-less factory or an owned scene.

## Why

EditMode fixtures could create `GameObject` instances in a developer's active scene. Destroying those objects during teardown does not clear the scene dirty flag, which can leave save prompts or persistent shared-editor pollution. Direct refreshes could also mutate unrelated editor state.

## Validation

- Scene-safety contract: 36 passed, 0 failed.
- Affected editor fixtures: 299 passed, 0 failed, 8 inconclusive sample-import cases.
- Complete editor assembly, final head: 735 passed, 0 failed, 1 skipped, 8 inconclusive.
- Allocation editor assembly: 115 passed, 0 failed.
- JavaScript tests: 410 passed, 0 failed.
- `validate:all`, Prettier, CSharpier, pre-commit, `git diff --check`, package meta validation, and `npm pack --json --dry-run --ignore-scripts` passed.
- Package-filtered Unity console: 0 warnings and 0 errors. Pre-existing Hot Reload and malformed host-asset metadata warnings remained visible and were not cleared.
- Shared editor finished stopped, unpaused, idle, on the main stage, with a clean untitled scene, one root object, no prefab stage, and the original seven windows.

Three adversarial review tracks completed with no remaining critical, high, or medium findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to editor test infrastructure and contracts; production messaging/runtime code is untouched.
> 
> **Overview**
> EditMode tests no longer create **GameObjects** in the developer’s active scene, which avoids dirtying untitled scenes and leaving shared-editor pollution after teardown.
> 
> Adds **`OwnedEditModeScene`** to open/own package-authored additive scenes and preview scenes, restore the prior active scene on dispose, reject double-loading the same path, and create scene-resident objects via **`HideAndDontSave`** then move them into the owned scene. Flow Graph, Message Monitor, benchmarks, editor harnesses, sample-quality contracts, and related fixtures are migrated to this scope or to **`EditorUtility.CreateGameObjectWithHideFlags(..., HideFlags.HideAndDontSave)`** for scene-less helpers.
> 
> Introduces **`EditModeSceneSafety.unity`** plus **`EditModeSceneSafetyContractTests`**, which scans all editor test sources for unsafe `GameObject` construction patterns and validates owned-scene lifecycle behavior. **`MessagingComponentSerializationTests`** now round-trips against **`CurrentGlobalMessageBusProvider`** instead of a bespoke test provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cbeecf6a24a9664501603b406214935436d9b5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->