### PR TITLE
Improve Flow Graph object navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix Flow Graph object navigation and relationship-card readability. Live
+  component and route details can select and ping their exact receiver. Broadcast
+  and targeted route details also expose a source or target action when the
+  snapshot captured that exact live context object; destroyed references remain
+  inert
+  ([#345](https://github.com/Ambiguous-Interactive/DxMessaging/issues/345)).
 - Fix Message Monitor resizing so one persisted divider controls the complete
   log details area. Wrapped stack frames now keep their full line height without
   clipped text or extra vertical gaps

--- a/Editor/Theme/DxMessagingTheme.uss
+++ b/Editor/Theme/DxMessagingTheme.uss
@@ -253,6 +253,18 @@
     -unity-font-style: bold;
     margin-bottom: 6px;
 }
+.dxmessaging-flow-graph-details-relationship .dx-card__label {
+    color: var(--dx-text);
+    font-size: 11px;
+}
+.dxmessaging-flow-graph-details-relationship .dx-kv__v {
+    color: var(--dx-text);
+    font-size: 12px;
+}
+.dxmessaging-flow-graph-details-relationship .dx-detail__frame {
+    color: var(--dx-text-dim);
+    font-size: 11px;
+}
 .dx-kv { flex-direction: row; align-items: center; margin-bottom: 3px; }
 .dx-kv__k { width: 74px; color: var(--dx-text-muted); font-size: 11px; }
 .dx-kv__v { flex-grow: 1; flex-shrink: 1; white-space: normal; color: var(--dx-text-dim); font-size: 11px; }

--- a/Editor/Windows/DxMessagingEditorSourceLinks.cs
+++ b/Editor/Windows/DxMessagingEditorSourceLinks.cs
@@ -1210,14 +1210,21 @@ namespace DxMessaging.Editor.Windows
         /// </summary>
         internal static bool TryRevealContext(InstanceId? context)
         {
-            UnityEngine.Object contextObject = FindContextObject(context);
-            if (contextObject == null)
+            return TryRevealObject(FindContextObject(context));
+        }
+
+        /// <summary>
+        /// Selects and pings a captured Unity object when it is still alive.
+        /// </summary>
+        internal static bool TryRevealObject(UnityEngine.Object unityObject)
+        {
+            if (unityObject == null)
             {
                 return false;
             }
 
-            Selection.activeObject = contextObject;
-            EditorGUIUtility.PingObject(contextObject);
+            Selection.activeObject = unityObject;
+            EditorGUIUtility.PingObject(unityObject);
             return true;
         }
     }

--- a/Editor/Windows/DxMessagingFlowGraphWindow.cs
+++ b/Editor/Windows/DxMessagingFlowGraphWindow.cs
@@ -197,6 +197,10 @@ namespace DxMessaging.Editor.Windows
             "dxmessaging-flow-graph-details-overflow";
         internal const string DetailsCopyDiagnosticsButtonName =
             "dxmessaging-flow-graph-details-copy-diagnostics";
+        internal const string DetailsRevealReceiverButtonName =
+            "dxmessaging-flow-graph-details-reveal-receiver";
+        internal const string DetailsRevealContextButtonName =
+            "dxmessaging-flow-graph-details-reveal-context";
         internal const string GraphNodeMetricClassName = "dxmessaging-flow-graph-node-metric";
         internal const string WarningLabelName = "dxmessaging-flow-graph-warning";
         internal const string GlobalObserverMessageName = "ANY MESSAGE";
@@ -852,7 +856,8 @@ namespace DxMessaging.Editor.Windows
                             listenerCount,
                             registrationCount,
                             callCount,
-                            localMessageCount
+                            localMessageCount,
+                            component
                         )
                     );
 
@@ -918,7 +923,8 @@ namespace DxMessaging.Editor.Windows
                             listenerCount: 0,
                             registrationCount: 0,
                             callCount: 0,
-                            localMessageCount: 0
+                            localMessageCount: 0,
+                            receiverObject: component
                         )
                     );
                     warnings.Add($"{hierarchyPath}: diagnostics capture failed: {exception}");
@@ -6293,6 +6299,7 @@ namespace DxMessaging.Editor.Windows
                     )
                 );
             }
+            AddDetailsObjectActions(header, selectedItem, visibleSnapshot);
             details.Add(header);
 
             switch (selectedItem.Kind)
@@ -6627,6 +6634,90 @@ namespace DxMessaging.Editor.Windows
                 Populate();
             }
             return roster;
+        }
+
+        private static void AddDetailsObjectActions(
+            VisualElement header,
+            FlowGraphSelectedItem selectedItem,
+            FlowGraphVisibleSnapshot visibleSnapshot
+        )
+        {
+            if (selectedItem.Kind == FlowGraphSelectionKind.Component)
+            {
+                AddRevealObjectButton(
+                    header,
+                    DetailsRevealReceiverButtonName,
+                    "Select receiver",
+                    selectedItem.Component.ReceiverObject
+                );
+                return;
+            }
+
+            if (selectedItem.Kind != FlowGraphSelectionKind.Edge)
+            {
+                return;
+            }
+
+            UnityEngine.Object receiverObject = visibleSnapshot
+                .ComponentNodes.Where(component =>
+                    string.Equals(
+                        component.Id,
+                        selectedItem.Edge.TargetComponentId,
+                        StringComparison.Ordinal
+                    )
+                )
+                .Select(component => component.ReceiverObject)
+                .FirstOrDefault(candidate => candidate != null);
+            AddRevealObjectButton(
+                header,
+                DetailsRevealReceiverButtonName,
+                "Select receiver",
+                receiverObject
+            );
+
+            UnityEngine.Object contextObject = selectedItem.Edge.ContextObject;
+            if (contextObject == null || contextObject == receiverObject)
+            {
+                return;
+            }
+
+            string routeKind = DxMessagingEditorPalette.NormalizeRouteKind(
+                selectedItem.Edge.RegistrationTypeName
+            );
+            string contextLabel =
+                routeKind == DxMessagingEditorPalette.BroadcastKind ? "Select source"
+                : routeKind == DxMessagingEditorPalette.TargetedKind ? "Select target"
+                : "Select scope";
+            AddRevealObjectButton(
+                header,
+                DetailsRevealContextButtonName,
+                contextLabel,
+                contextObject
+            );
+        }
+
+        private static void AddRevealObjectButton(
+            VisualElement parent,
+            string name,
+            string text,
+            UnityEngine.Object unityObject
+        )
+        {
+            if (parent == null || unityObject == null)
+            {
+                return;
+            }
+
+            Button reveal = new() { name = name, text = text };
+            reveal.AddToClassList(DxMessagingEditorTheme.ButtonGhostClassName);
+            reveal.AddToClassList(DxMessagingEditorTheme.ToolButtonClassName);
+            DxMessagingEditorSourceLinks.MakeActivatable(
+                reveal,
+                "Select and ping this object in the Hierarchy.",
+                () => DxMessagingEditorSourceLinks.TryRevealObject(unityObject),
+                addLinkClass: false
+            );
+            parent.Add(reveal);
         }
 
         private static VisualElement CreateDetailsRouteRow(
@@ -8980,7 +9071,8 @@ namespace DxMessaging.Editor.Windows
                     RecentTracedDeliveryCount,
                     Context,
                     EmissionSites.OrderBy(site => site, StringComparer.Ordinal).ToArray(),
-                    ContextId?.Id ?? 0
+                    ContextId?.Id ?? 0,
+                    ContextId
                 );
             }
         }
@@ -9792,7 +9884,8 @@ namespace DxMessaging.Editor.Windows
             int listenerCount,
             int registrationCount,
             int callCount,
-            int localMessageCount
+            int localMessageCount,
+            UnityEngine.Object receiverObject = null
         )
         {
             Id = id ?? string.Empty;
@@ -9803,6 +9896,7 @@ namespace DxMessaging.Editor.Windows
             RegistrationCount = registrationCount;
             CallCount = callCount;
             LocalMessageCount = localMessageCount;
+            ReceiverObject = receiverObject;
         }
 
         internal string Id { get; }
@@ -9820,6 +9914,8 @@ namespace DxMessaging.Editor.Windows
         internal int CallCount { get; }
 
         internal int LocalMessageCount { get; }
+
+        internal UnityEngine.Object ReceiverObject { get; }
 
         internal bool Matches(string filterText)
         {
@@ -10014,7 +10110,8 @@ namespace DxMessaging.Editor.Windows
             int recentTracedDeliveryCount = 0,
             string context = "",
             IReadOnlyList<string> recentEmissionSites = null,
-            int contextId = 0
+            int contextId = 0,
+            InstanceId? contextIdentity = null
         )
         {
             MessageTypeName = messageTypeName ?? string.Empty;
@@ -10027,6 +10124,7 @@ namespace DxMessaging.Editor.Windows
             Context = context ?? string.Empty;
             RecentEmissionSites = recentEmissionSites ?? Array.Empty<string>();
             ContextId = contextId;
+            ContextIdentity = contextIdentity;
         }
 
         internal string MessageTypeName { get; }
@@ -10048,6 +10146,10 @@ namespace DxMessaging.Editor.Windows
         internal IReadOnlyList<string> RecentEmissionSites { get; }
 
         internal int ContextId { get; }
+
+        internal InstanceId? ContextIdentity { get; }
+
+        internal UnityEngine.Object ContextObject => ContextIdentity?.Object;
 
         internal bool Matches(string filterText)
         {

--- a/Samples~/Diagnostics Tooling Exerciser/README.md
+++ b/Samples~/Diagnostics Tooling Exerciser/README.md
@@ -70,6 +70,10 @@ After the default play-start burst:
   rows. Breadcrumbs backed by exact captured Unity-object identities and
   relationship endpoints select the matching graph item; **Route roster** reveals
   each exact receiver ID, registration subtype, context, and context ID on demand.
+  Selecting a live component or route exposes a direct receiver action. Broadcast
+  and targeted routes also expose source or target actions when the snapshot
+  captured that exact live context object. These actions select and ping the
+  object in the Hierarchy and Inspector.
   Diagnostics split route health from trace coverage; component and message
   selections show distinct busiest paths as directed relationship records,
   while route selections omit those redundant aggregates. The full text report

--- a/Tests/Editor/DxMessagingEditorThemeTests.cs
+++ b/Tests/Editor/DxMessagingEditorThemeTests.cs
@@ -210,6 +210,43 @@ namespace DxMessaging.Tests.Editor
             );
         }
 
+        [Test]
+        public void FlowGraphRelationshipCardsUseReadableTextTokensAndSizes()
+        {
+            string uss = StripBlockComments(
+                System.IO.File.ReadAllText(DxMessagingEditorTheme.ThemeUssPath)
+            );
+
+            string roleBody = FindRuleBody(
+                uss,
+                ".dxmessaging-flow-graph-details-relationship .dx-card__label"
+            );
+            string identityBody = FindRuleBody(
+                uss,
+                ".dxmessaging-flow-graph-details-relationship .dx-kv__v"
+            );
+            string metadataBody = FindRuleBody(
+                uss,
+                ".dxmessaging-flow-graph-details-relationship .dx-detail__frame"
+            );
+
+            Assert.That(
+                roleBody,
+                Does.Contain("color: var(--dx-text);").And.Contain("font-size: 11px;"),
+                "Relationship role labels should not inherit the tiny muted card-caption treatment."
+            );
+            Assert.That(
+                identityBody,
+                Does.Contain("color: var(--dx-text);").And.Contain("font-size: 12px;"),
+                "Relationship identities should be larger than generic diagnostic values."
+            );
+            Assert.That(
+                metadataBody,
+                Does.Contain("color: var(--dx-text-dim);").And.Contain("font-size: 11px;"),
+                "Relationship metadata should use readable secondary text instead of the faint token."
+            );
+        }
+
         /// <summary>
         /// Issue #344: "There is no 'pointer' intelligence for anything clickable." A hover
         /// background only tells a reader who already guessed the element was interactive, so
@@ -522,6 +559,27 @@ namespace DxMessaging.Tests.Editor
             }
 
             return stripped.ToString();
+        }
+
+        private static string FindRuleBody(string uss, string selector)
+        {
+            foreach (string block in uss.Split('}'))
+            {
+                int open = block.IndexOf('{');
+                if (open < 0)
+                {
+                    continue;
+                }
+
+                string blockSelector = block.Substring(0, open).Trim().Replace("\n", " ");
+                if (string.Equals(blockSelector, selector, StringComparison.Ordinal))
+                {
+                    return block.Substring(open + 1);
+                }
+            }
+
+            Assert.Fail($"The stylesheet declares no `{selector}` rule.");
+            return null;
         }
 
         private static string ReadEditorSourceText()

--- a/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
+++ b/Tests/Editor/DxMessagingFlowGraphWindowTests.cs
@@ -29,6 +29,7 @@ namespace DxMessaging.Tests.Editor
         private readonly List<Object> _createdObjects = new();
         private readonly List<string> _createdAssetPaths = new();
         private readonly List<EditorWindow> _createdWindows = new();
+        private Object _selectionBeforeTest;
         private const string MessageLanesName = "dxmessaging-flow-graph-message-lanes";
         private const string MessageLaneRowClassName = "dxmessaging-flow-graph-message-lane-row";
         private const string MessageLanesSummaryLabelName =
@@ -104,6 +105,12 @@ namespace DxMessaging.Tests.Editor
         private const string TraceIdLaneDetailsLabelName =
             "dxmessaging-flow-graph-trace-id-lane-details";
 
+        [SetUp]
+        public void SetUp()
+        {
+            _selectionBeforeTest = Selection.activeObject;
+        }
+
         [TearDown]
         public void TearDown()
         {
@@ -145,6 +152,7 @@ namespace DxMessaging.Tests.Editor
             _createdAssetPaths.Clear();
 
             EditorWindowTestUtility.CloseTrackedWindows(_createdWindows);
+            Selection.activeObject = _selectionBeforeTest;
 
             if (MessageHandler.MessageBus is MessageBus messageBus)
             {
@@ -4223,6 +4231,272 @@ namespace DxMessaging.Tests.Editor
                 routes[1].ClassListContains(DxMessagingFlowGraphWindow.SelectedRowClassName),
                 Is.False
             );
+        }
+
+        [Test]
+        public void SelectedComponentCanRevealItsLiveReceiverInTheEditor()
+        {
+            GameObject host = CreateTrackedObject("FlowGraphSelectableReceiver");
+            MessagingComponent receiver = host.AddComponent<MessagingComponent>();
+            FlowGraphComponentNode component = new(
+                "component:receiver",
+                "Root/FlowGraphSelectableReceiver",
+                nameof(MessagingComponent),
+                activeInHierarchy: true,
+                listenerCount: 1,
+                registrationCount: 0,
+                callCount: 0,
+                localMessageCount: 0,
+                receiverObject: receiver
+            );
+            FlowGraphSnapshot snapshot = new(
+                new[] { component },
+                new[] { new FlowGraphMessageNode("FlowGraphReceiverMessage", 1, 0) },
+                new[]
+                {
+                    new FlowGraphEdge(
+                        "FlowGraphReceiverMessage",
+                        component.Id,
+                        component.HierarchyPath,
+                        "Untargeted",
+                        registrationCount: 1,
+                        callCount: 0
+                    ),
+                },
+                Array.Empty<string>()
+            );
+            EditorWindow window = CreateTrackedEditorWindow();
+            EditorWindowTestUtility.ShowWindow(window);
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                window.rootVisualElement,
+                snapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateComponentSelectionKey(
+                        component
+                    )
+                )
+            );
+
+            Button reveal = window.rootVisualElement.Q<Button>(
+                DxMessagingFlowGraphWindow.DetailsRevealReceiverButtonName
+            );
+            Assert.That(
+                reveal,
+                Is.Not.Null,
+                "A selected live receiver should expose a direct Hierarchy/Inspector action."
+            );
+            using (ClickEvent click = ClickEvent.GetPooled())
+            {
+                click.target = reveal;
+                reveal.SendEvent(click);
+            }
+            Assert.That(
+                Selection.activeObject,
+                Is.SameAs(receiver),
+                "The receiver action should select the exact captured component, not only its display name."
+            );
+
+            Object.DestroyImmediate(host);
+            DxMessagingFlowGraphWindow.RefreshGraphContent(
+                window.rootVisualElement,
+                snapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateComponentSelectionKey(
+                        component
+                    )
+                )
+            );
+            Assert.That(
+                window.rootVisualElement.Q<Button>(
+                    DxMessagingFlowGraphWindow.DetailsRevealReceiverButtonName
+                ),
+                Is.Null,
+                "A captured receiver that has been destroyed must not keep a dead action."
+            );
+        }
+
+        [Test]
+        public void SelectedSyntheticComponentDoesNotOfferAReceiverAction()
+        {
+            FlowGraphComponentNode synthetic = new(
+                "component:synthetic",
+                "Root/Synthetic",
+                nameof(MessagingComponent),
+                activeInHierarchy: true,
+                listenerCount: 1,
+                registrationCount: 0,
+                callCount: 0,
+                localMessageCount: 0
+            );
+            VisualElement root = new();
+            FlowGraphEdge edge = new(
+                "FlowGraphSyntheticMessage",
+                synthetic.Id,
+                synthetic.HierarchyPath,
+                "Untargeted",
+                registrationCount: 1,
+                callCount: 0
+            );
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                root,
+                new FlowGraphSnapshot(
+                    new[] { synthetic },
+                    new[] { new FlowGraphMessageNode(edge.MessageTypeName, 1, 0) },
+                    new[] { edge },
+                    Array.Empty<string>()
+                ),
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateComponentSelectionKey(
+                        synthetic
+                    )
+                )
+            );
+
+            Assert.That(
+                root.Q<Button>(DxMessagingFlowGraphWindow.DetailsRevealReceiverButtonName),
+                Is.Null,
+                "A synthetic snapshot must not advertise an object action that cannot resolve."
+            );
+        }
+
+        [TestCase(RouteDetailCase.Broadcast, "Broadcast", "Select source")]
+        [TestCase(RouteDetailCase.Targeted, "Targeted", "Select target")]
+        [TestCase(RouteDetailCase.Untargeted, "Untargeted", null)]
+        [TestCase(RouteDetailCase.GlobalAcceptAll, "GlobalAcceptAll", null)]
+        public void CapturedRouteDetailsExposeOnlyExactLiveContextActions(
+            RouteDetailCase routeCase,
+            string expectedRegistrationType,
+            string expectedContextActionLabel
+        )
+        {
+            GameObject receiverHost = CreateTrackedObject("FlowGraphRouteReceiver");
+            MessagingComponent receiver = receiverHost.AddComponent<MessagingComponent>();
+            TestListener listener = receiverHost.AddComponent<TestListener>();
+            GameObject contextObject = null;
+            InstanceId contextIdentity = default;
+            MessageRegistrationToken token = receiver.Create(listener);
+            switch (routeCase)
+            {
+                case RouteDetailCase.Broadcast:
+                    contextObject = CreateTrackedObject("FlowGraphRouteSource");
+                    contextIdentity = contextObject;
+                    token.RegisterBroadcast<FlowGraphBroadcastMessage>(
+                        contextIdentity,
+                        listener.OnFlowGraphBroadcast
+                    );
+                    break;
+                case RouteDetailCase.Targeted:
+                    contextObject = CreateTrackedObject("FlowGraphRouteTarget");
+                    contextIdentity = contextObject;
+                    token.RegisterTargeted<FlowGraphTargetedMessage>(
+                        contextIdentity,
+                        listener.OnFlowGraphTargeted
+                    );
+                    break;
+                case RouteDetailCase.Untargeted:
+                    token.RegisterUntargeted<FlowGraphMessage>(listener.OnFlowGraphMessage);
+                    break;
+                case RouteDetailCase.GlobalAcceptAll:
+                    token.RegisterGlobalAcceptAll(
+                        listener.OnGlobalUntargeted,
+                        listener.OnGlobalTargeted,
+                        listener.OnGlobalBroadcast
+                    );
+                    break;
+                default:
+                    Assert.Fail("Unsupported route-detail test case: " + routeCase);
+                    break;
+            }
+            token.Enable();
+
+            FlowGraphSnapshot snapshot = DxMessagingFlowGraphWindow.CaptureSnapshot(
+                new[] { receiver }
+            );
+            FlowGraphComponentNode component = snapshot.ComponentNodes.Single();
+            FlowGraphEdge edge = snapshot.Edges.Single(candidate =>
+                candidate.RegistrationTypeName == expectedRegistrationType
+            );
+            string scenario =
+                routeCase + " / " + (expectedContextActionLabel ?? "no context action");
+            Assert.That(
+                component.ReceiverObject,
+                Is.SameAs(receiver),
+                "[" + scenario + "] Capture should retain the exact receiver object."
+            );
+            if (contextObject != null)
+            {
+                Assert.That(
+                    edge.ContextObject,
+                    Is.SameAs(contextObject),
+                    "[" + scenario + "] Capture should retain the exact live route context."
+                );
+            }
+            else
+            {
+                Assert.That(
+                    edge.ContextObject == null,
+                    Is.True,
+                    "[" + scenario + "] A context-free registration must keep ContextObject null."
+                );
+            }
+
+            EditorWindow window = CreateTrackedEditorWindow();
+            EditorWindowTestUtility.ShowWindow(window);
+
+            DxMessagingFlowGraphWindow.BuildGraphUi(
+                window.rootVisualElement,
+                snapshot,
+                new FlowGraphViewState(
+                    selectedItemKey: DxMessagingFlowGraphWindow.CreateEdgeSelectionKey(edge)
+                )
+            );
+
+            Button receiverAction = window.rootVisualElement.Q<Button>(
+                DxMessagingFlowGraphWindow.DetailsRevealReceiverButtonName
+            );
+            Button contextAction = window.rootVisualElement.Q<Button>(
+                DxMessagingFlowGraphWindow.DetailsRevealContextButtonName
+            );
+            Assert.That(
+                receiverAction,
+                Is.Not.Null,
+                "[" + scenario + "] Every captured route should expose its live receiver."
+            );
+            if (expectedContextActionLabel == null)
+            {
+                Assert.That(
+                    contextAction,
+                    Is.Null,
+                    "[" + scenario + "] A context-free route must not invent a context action."
+                );
+            }
+            else
+            {
+                Assert.That(
+                    contextAction,
+                    Is.Not.Null,
+                    "[" + scenario + "] A route with an exact live context should expose it."
+                );
+                Assert.That(
+                    contextAction.text,
+                    Is.EqualTo(expectedContextActionLabel),
+                    "[" + scenario + "] The context action label should match route semantics."
+                );
+                using (ClickEvent click = ClickEvent.GetPooled())
+                {
+                    click.target = contextAction;
+                    contextAction.SendEvent(click);
+                }
+                Assert.That(
+                    Selection.activeObject,
+                    Is.SameAs(contextObject),
+                    "[" + scenario + "] The captured route action should select its exact context."
+                );
+            }
+
+            receiver.EditorResetRuntimeState();
         }
 
         [Test]
@@ -10176,6 +10450,11 @@ namespace DxMessaging.Tests.Editor
             Assert.That(snapshot.ComponentNodes[0].CallCount, Is.EqualTo(1));
             Assert.That(snapshot.ComponentNodes[0].LocalMessageCount, Is.EqualTo(1));
             Assert.That(
+                snapshot.ComponentNodes[0].ReceiverObject,
+                Is.SameAs(messagingComponent),
+                "A live snapshot must retain the exact receiver for Hierarchy/Inspector navigation."
+            );
+            Assert.That(
                 snapshot.MessageNodes[0].MessageTypeName,
                 Does.Contain(nameof(FlowGraphMessage))
             );
@@ -10508,6 +10787,11 @@ namespace DxMessaging.Tests.Editor
                 edge.ContextId,
                 Is.EqualTo(contextId),
                 "Destroyed contexts must retain their exact registration identity."
+            );
+            Assert.That(
+                edge.ContextObject == null,
+                Is.True,
+                "Destroyed contexts must not expose a dead Unity object through ContextObject."
             );
 
             messagingComponent.EditorResetRuntimeState();
@@ -11702,6 +11986,14 @@ namespace DxMessaging.Tests.Editor
         private readonly struct FlowGraphMixedMessage : IBroadcastMessage, ITargetedMessage { }
 
         private readonly struct EvidenceOnlyFlowGraphMessage : IUntargetedMessage { }
+
+        public enum RouteDetailCase
+        {
+            Broadcast,
+            Targeted,
+            Untargeted,
+            GlobalAcceptAll,
+        }
 
         private static class SourceLinkAlpha
         {

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -195,6 +195,11 @@ when the filtered capture resolves exactly one; unresolved instance fallbacks
 remain plain text instead of presenting a dead action. Captured call sites separate a compact
 `Type.Method()` identity from the file and line, and keep the source action on
 the same row; stale asset paths remain readable without a dead button.
+Select a live component to use **Select receiver** and reveal its exact
+`MessagingComponent` in the Hierarchy and Inspector. A selected route also
+offers **Select receiver** plus **Select source** or **Select target** when its
+captured context object is still alive. Destroyed and synthetic snapshot
+objects do not render these actions.
 The graph does not invent a sender object because targeted emission APIs carry
 a target, not a sender.
 Global accept-all registrations appear as
@@ -213,7 +218,9 @@ activity metrics first; emission evidence and diagnostics start collapsed.
 Diagnostics split route health from trace coverage. For component and message
 selections, their distinct busiest route and trace path use bordered, directed
 relationship records with compact message and receiver identities instead of
-report sentences. Select either endpoint to move to that message or receiver.
+report sentences. Their role, identity, and activity text use primary and
+secondary text treatments instead of the smaller muted card-caption style.
+Select either endpoint to move to that message or receiver.
 Captured context breadcrumbs become links only when diagnostics retained the
 exact Unity-object-to-component identity and that component is visible in the
 filtered graph; ambiguous, destroyed, or filtered-out contexts remain text.


### PR DESCRIPTION
## Summary

- retain exact live receiver and route-context Unity objects in Flow Graph snapshots
- add receiver and source/target selection actions to component and route details
- improve relationship-card typography for readable role, identity, and activity text
- omit actions for synthetic, numeric-only, or destroyed object references
- document the behavior in the diagnostics guide, exerciser sample, and changelog

## Root cause

The Flow Graph retained display text and stable integer IDs but discarded the live receiver object when it built its snapshot. Route edges likewise exposed only the integer context ID after construction. The details pane therefore had no exact object to select or ping. Relationship cards also inherited the generic muted caption typography.

## User impact

A selected live component now offers **Select receiver**. A selected Broadcast or Targeted route offers **Select source** or **Select target** when diagnostics captured that exact live context object. All route kinds retain receiver navigation. Synthetic, numeric-only, and destroyed references remain inert instead of presenting dead actions.

## Validation

- Flow Graph EditMode fixture: 181 passed, 0 failed
- full Editor assembly: 742 passed, 0 failed, 1 skipped, 8 inconclusive
- documentation compilation: 583 passed, 0 failed
- JavaScript tests: 410 passed, 0 failed
- `npm run validate:all`
- `npm run format:check`
- `npm run lint:markdown`
- `npm run check:spelling`
- two-pass adversarial review, ending with zero findings
- shared Unity editor remained stopped, idle, main-stage, and scene-clean after verification

Refs #345.

The automated current Flow Graph screenshot remains blocked by #314's approved Personal/light EditorWindow capture environment, so this PR intentionally does not close #345.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only diagnostics UI and snapshot model changes; no runtime messaging or bus behavior. Risk is limited to Flow Graph details rendering and object-reference lifetime handling, which tests exercise.
> 
> **Overview**
> **Flow Graph** snapshots now keep live Unity references: each component node stores its **`MessagingComponent`**, and route edges carry **`InstanceId?`** so **`ContextObject`** resolves when the context is still alive.
> 
> The details header adds **Select receiver** for component and route selections. **Broadcast** and **Targeted** routes also get **Select source** / **Select target** when the captured context differs from the receiver; untargeted and global routes do not invent context actions. Buttons call **`TryRevealObject`** (select + ping); missing, synthetic, or destroyed objects omit the controls.
> 
> Relationship cards under **`.dxmessaging-flow-graph-details-relationship`** use larger primary/secondary text instead of muted caption styling. Docs, changelog, sample README, and EditMode tests cover the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36949f0f6ae84fc0e17eb1825f40283020aabcaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->