### PR TITLE
Harden runtime contracts and isolate perf measurements

### DIFF
--- a/.llm/skills/test-coverage-design/references/lifecycle-edge-coverage.md
+++ b/.llm/skills/test-coverage-design/references/lifecycle-edge-coverage.md
@@ -25,28 +25,29 @@ deregistration, interceptor / post-processor pipeline) is expected to keep
 this scenario list green. New dispatch behavior must add scenarios when the
 mechanism it introduces is not already covered.
 
-| Scenario                                            | Pinned by                                      | Notes                                                                |
-| --------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------------- |
-| `SceneUnloadMidDispatchDrainsInFlightEmission`      | `LifecycleEdgeCasesTests`                      | Handler triggers `SceneManager.UnloadSceneAsync` from inside body.   |
-| `SceneTransitionWithDontDestroyOnLoad`              | `LifecycleEdgeCasesTests`                      | DDOL host survives an additive scene unload and keeps receiving.     |
-| `RegisterDuringSceneLoadCallback`                   | `LifecycleEdgeCasesTests`                      | `SceneManager.sceneLoaded` callback registers a handler.             |
-| `PrefabPoolingEnableDisableCycles`                  | `LifecycleEdgeCasesTests` (with `LeakWatcher`) | 100-cycle SetActive churn; bus must not leak registrations.          |
-| `TokenDisableMidDispatch`                           | `LifecycleEdgeCasesTests`                      | Snapshot semantics: B still runs after A disables the token.         |
-| `TokenReEnableMidDispatch`                          | `LifecycleEdgeCasesTests`                      | Re-enable mid-dispatch does not retroactively join current emission. |
-| `EmitOnEmptyBusIsSilentNoOp`                        | `LifecycleEdgeCasesTests`                      | Emit with zero handlers must not throw or perturb counters.          |
-| `EmitImmediatelyAfterResetIsSilentNoOp`             | `LifecycleEdgeCasesTests`                      | Reset-generation guard: pre-reset handlers must NOT fire.            |
-| `OnApplicationQuitDrainsCleanly`                    | `LifecycleEdgeCasesTests` (with `LeakWatcher`) | Quit must not throw and must not leak registrations.                 |
-| `HostDestroyMidDispatchDoesNotCrash`                | `LifecycleEdgeCasesTests`                      | `Object.Destroy(host)` from a handler must not crash dispatch.       |
-| `CrossKindReentrancyChainCompletes`                 | `ReentrantEmissionExtendedTests`               | All 6 (outer, inner) cross-kind permutations.                        |
-| `DeepRecursion10Levels`                             | `ReentrantEmissionExtendedTests`               | Bounded self-recursion plus `IMessageBus.EmissionId` invariant.      |
-| `ReentrantUnsubscribeThenResubscribeSelf`           | `ReentrantEmissionExtendedTests`               | Snapshot semantics for self-modifying handlers.                      |
-| `NestedHandlerThrowsDuringReentrantEmit`            | `ReentrantEmissionExtendedTests`               | Inner throw aborts outer trailing handlers consistently.             |
-| `ReentrantInterceptorVeto`                          | `ReentrantEmissionExtendedTests`               | Inner vetoed re-emit; outer trailing handler still runs.             |
-| `InterceptorMutationDuringReemitObservesFreshState` | `ReentrantEmissionExtendedTests`               | Interceptor sees fresh state on re-emit, no carry-over.              |
+| Scenario                                                      | Pinned by                                      | Notes                                                                |
+| ------------------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------------- |
+| `SceneUnloadMidDispatchDrainsInFlightEmission`                | `LifecycleEdgeCasesTests`                      | Handler triggers `SceneManager.UnloadSceneAsync` from inside body.   |
+| `SceneTransitionWithDontDestroyOnLoad`                        | `LifecycleEdgeCasesTests`                      | DDOL host survives an additive scene unload and keeps receiving.     |
+| `RegisterDuringSceneLoadCallback`                             | `LifecycleEdgeCasesTests`                      | `SceneManager.sceneLoaded` callback registers a handler.             |
+| `PrefabPoolingEnableDisableCycles`                            | `LifecycleEdgeCasesTests` (with `LeakWatcher`) | 100-cycle SetActive churn; bus must not leak registrations.          |
+| `TokenDisableMidDispatch`                                     | `LifecycleEdgeCasesTests`                      | Snapshot semantics: B still runs after A disables the token.         |
+| `TokenReEnableMidDispatch`                                    | `LifecycleEdgeCasesTests`                      | Re-enable mid-dispatch does not retroactively join current emission. |
+| `EmitOnEmptyBusIsSilentNoOp`                                  | `LifecycleEdgeCasesTests`                      | Emit with zero handlers must not throw or perturb counters.          |
+| `EmitImmediatelyAfterResetIsSilentNoOp`                       | `LifecycleEdgeCasesTests`                      | Reset-generation guard: pre-reset handlers must NOT fire.            |
+| `ResetFromInterceptorStopsSnapshotAndAllowsFreshRegistration` | `MutationInterceptorTests`                     | Reset stops copied interceptors and the handler phase.               |
+| `OnApplicationQuitDrainsCleanly`                              | `LifecycleEdgeCasesTests` (with `LeakWatcher`) | Quit must not throw and must not leak registrations.                 |
+| `HostDestroyMidDispatchDoesNotCrash`                          | `LifecycleEdgeCasesTests`                      | `Object.Destroy(host)` from a handler must not crash dispatch.       |
+| `CrossKindReentrancyChainCompletes`                           | `ReentrantEmissionExtendedTests`               | All 6 (outer, inner) cross-kind permutations.                        |
+| `DeepRecursion10Levels`                                       | `ReentrantEmissionExtendedTests`               | Bounded self-recursion plus `IMessageBus.EmissionId` invariant.      |
+| `ReentrantUnsubscribeThenResubscribeSelf`                     | `ReentrantEmissionExtendedTests`               | Snapshot semantics for self-modifying handlers.                      |
+| `NestedHandlerThrowsDuringReentrantEmit`                      | `ReentrantEmissionExtendedTests`               | Inner throw aborts outer trailing handlers consistently.             |
+| `ReentrantInterceptorVeto`                                    | `ReentrantEmissionExtendedTests`               | Inner vetoed re-emit; outer trailing handler still runs.             |
+| `InterceptorMutationDuringReemitObservesFreshState`           | `ReentrantEmissionExtendedTests`               | Interceptor sees fresh state on re-emit, no carry-over.              |
 
 ## Where the Canonical Fixtures Live
 
-Two fixtures, both parameterized by `MessageScenario`:
+Three fixtures, all parameterized by `MessageScenario`:
 
 - `Tests/Runtime/Core/LifecycleEdgeCasesTests.cs` -- destruction, scene
   loading, token disable / re-enable, post-Reset, OnApplicationQuit,
@@ -54,6 +55,8 @@ Two fixtures, both parameterized by `MessageScenario`:
 - `Tests/Runtime/Core/ReentrantEmissionExtendedTests.cs` -- cross-kind
   reentrancy, deep recursion, self-resubscribe, nested-throw, interceptor
   veto, interceptor mutation. Default category (no gating).
+- `Tests/Runtime/Core/MutationInterceptorTests.cs` -- interceptor mutation and
+  reset from the interceptor phase. Default category (no gating).
 
 The supporting `LeakWatcher` utility lives at
 `Tests/Runtime/TestUtilities/LeakWatcher.cs`. See

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Restore isolated IL2CPP dispatch measurements by running high-cardinality
+  deregistration attribution after the published throughput windows
+  ([#397](https://github.com/Ambiguous-Interactive/DxMessaging/issues/397)).
+- Fix `DxMessagingStaticState.Reset()` from inside an interceptor so it stops
+  the remaining copied interceptor snapshot and handler pipeline instead of
+  invoking callbacks against reset bus state
+  ([#395](https://github.com/Ambiguous-Interactive/DxMessaging/issues/395)).
 - Fix Flow Graph object navigation and relationship-card readability. Live
   component and route details can select and ping their exact receiver. Broadcast
   and targeted route details also expose a source or target action when the

--- a/Runtime/Core/MessageBus/MessageBus.cs
+++ b/Runtime/Core/MessageBus/MessageBus.cs
@@ -5138,6 +5138,7 @@ namespace DxMessaging.Core.MessageBus
                 return true;
             }
 
+            long resetGeneration = _resetGeneration;
             try
             {
                 IList<List<object>> prioritizedInterceptors = interceptorHandlers.Values;
@@ -5152,7 +5153,7 @@ namespace DxMessaging.Core.MessageBus
                         UntargetedInterceptor<T> typedTransformer = DxUnsafe.As<
                             UntargetedInterceptor<T>
                         >(interceptorObjects[i]);
-                        if (!typedTransformer(ref message))
+                        if (!typedTransformer(ref message) || _resetGeneration != resetGeneration)
                         {
                             return false;
                         }
@@ -5161,7 +5162,10 @@ namespace DxMessaging.Core.MessageBus
             }
             finally
             {
-                _innerInterceptorsStack.Push(interceptorObjects);
+                if (_resetGeneration == resetGeneration)
+                {
+                    _innerInterceptorsStack.Push(interceptorObjects);
+                }
             }
 
             return true;
@@ -5180,6 +5184,7 @@ namespace DxMessaging.Core.MessageBus
                 return true;
             }
 
+            long resetGeneration = _resetGeneration;
             try
             {
                 IList<List<object>> prioritizedInterceptors = interceptorHandlers.Values;
@@ -5194,7 +5199,10 @@ namespace DxMessaging.Core.MessageBus
                         TargetedInterceptor<T> typedTransformer = DxUnsafe.As<
                             TargetedInterceptor<T>
                         >(interceptorObjects[i]);
-                        if (!typedTransformer(ref target, ref message))
+                        if (
+                            !typedTransformer(ref target, ref message)
+                            || _resetGeneration != resetGeneration
+                        )
                         {
                             return false;
                         }
@@ -5203,7 +5211,10 @@ namespace DxMessaging.Core.MessageBus
             }
             finally
             {
-                _innerInterceptorsStack.Push(interceptorObjects);
+                if (_resetGeneration == resetGeneration)
+                {
+                    _innerInterceptorsStack.Push(interceptorObjects);
+                }
             }
 
             return true;
@@ -5222,6 +5233,7 @@ namespace DxMessaging.Core.MessageBus
                 return true;
             }
 
+            long resetGeneration = _resetGeneration;
             try
             {
                 IList<List<object>> prioritizedInterceptors = interceptorHandlers.Values;
@@ -5236,7 +5248,10 @@ namespace DxMessaging.Core.MessageBus
                         BroadcastInterceptor<T> typedTransformer = DxUnsafe.As<
                             BroadcastInterceptor<T>
                         >(interceptorObjects[i]);
-                        if (!typedTransformer(ref source, ref message))
+                        if (
+                            !typedTransformer(ref source, ref message)
+                            || _resetGeneration != resetGeneration
+                        )
                         {
                             return false;
                         }
@@ -5245,7 +5260,10 @@ namespace DxMessaging.Core.MessageBus
             }
             finally
             {
-                _innerInterceptorsStack.Push(interceptorObjects);
+                if (_resetGeneration == resetGeneration)
+                {
+                    _innerInterceptorsStack.Push(interceptorObjects);
+                }
             }
 
             return true;

--- a/Tests/Runtime/Benchmarks/DispatchThroughputBenchmarks.cs
+++ b/Tests/Runtime/Benchmarks/DispatchThroughputBenchmarks.cs
@@ -56,6 +56,9 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
 
     public sealed class DispatchThroughputBenchmarks
     {
+        internal const int PublishedDispatchOrder = 0;
+        internal const int DeregistrationAttributionOrder = 1;
+
         [Test, Performance, Category("PerfBench")]
         public void MessageRegistrationHandlePhysicalSize()
         {
@@ -122,11 +125,22 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
         // deliberately measure one-time first-touch JIT cost, which cannot be re-measured cold.
         private const int WarmFloodTrials = 7;
 
-        [Test, Performance, Category("PerfBench")]
+        [Test, Performance, Category("PerfBench"), Order(PublishedDispatchOrder)]
         [TestCaseSource(nameof(DispatchBenchmarkCases))]
         public void DispatchBenchmark(DispatchBenchmarkScenario scenario)
         {
             _ = RunScenario(scenario);
+        }
+
+        [Test, Performance, Category("PerfBench"), Order(DeregistrationAttributionOrder)]
+        [TestCaseSource(nameof(DeregistrationAttributionBenchmarkCases))]
+        public void DeregistrationAttributionBenchmark(DeregistrationAttributionOperation operation)
+        {
+            DispatchBenchmarkResult result = DeregistrationAttributionBenchmarks.RunScenario(
+                operation
+            );
+            Debug.Log(result.ToStructuredLog());
+            TestContext.Out.WriteLine(result.ToCsvRow());
         }
 
         [Test, Explicit, Performance, Category("PerfBaseline")]
@@ -207,6 +221,20 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
             foreach (DispatchBenchmarkScenario scenario in DispatchBenchmarkScenarios.All)
             {
                 yield return new TestCaseData(scenario).SetName(scenario.ToString());
+            }
+        }
+
+        private static IEnumerable<TestCaseData> DeregistrationAttributionBenchmarkCases()
+        {
+            foreach (
+                DeregistrationAttributionOperation operation in Enum.GetValues(
+                    typeof(DeregistrationAttributionOperation)
+                )
+            )
+            {
+                yield return new TestCaseData(operation).SetName(
+                    DeregistrationAttributionBenchmarks.ScenarioKey(operation)
+                );
             }
         }
 

--- a/Tests/Runtime/Benchmarks/RegistrationLifecycleBenchmarkContractTests.cs
+++ b/Tests/Runtime/Benchmarks/RegistrationLifecycleBenchmarkContractTests.cs
@@ -4,6 +4,7 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
     using NUnit.Framework;
 
     public sealed class RegistrationLifecycleBenchmarkContractTests
@@ -143,6 +144,55 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
                     $"{operation}: scenario key must encode the calibrated cardinality."
                 );
             }
+        }
+
+        [Test]
+        public void PublishedDispatchAndAttributionUseSameSupportedMethodOrderBoundary()
+        {
+            MethodInfo dispatchMethod = typeof(DispatchThroughputBenchmarks).GetMethod(
+                nameof(DispatchThroughputBenchmarks.DispatchBenchmark)
+            );
+            MethodInfo attributionMethod = typeof(DispatchThroughputBenchmarks).GetMethod(
+                nameof(DispatchThroughputBenchmarks.DeregistrationAttributionBenchmark)
+            );
+
+            Assert.IsNotNull(dispatchMethod);
+            Assert.IsNotNull(attributionMethod);
+            Assert.AreEqual(typeof(DispatchThroughputBenchmarks), dispatchMethod.DeclaringType);
+            Assert.AreEqual(typeof(DispatchThroughputBenchmarks), attributionMethod.DeclaringType);
+
+            OrderAttribute dispatchOrder = dispatchMethod.GetCustomAttribute<OrderAttribute>();
+            OrderAttribute attributionOrder =
+                attributionMethod.GetCustomAttribute<OrderAttribute>();
+            Assert.IsNotNull(dispatchOrder);
+            Assert.IsNotNull(attributionOrder);
+            Assert.AreEqual(
+                DispatchThroughputBenchmarks.PublishedDispatchOrder,
+                dispatchOrder.Order
+            );
+            Assert.AreEqual(
+                DispatchThroughputBenchmarks.DeregistrationAttributionOrder,
+                attributionOrder.Order
+            );
+            Assert.Less(
+                dispatchOrder.Order,
+                attributionOrder.Order,
+                "Published dispatch windows must complete before high-cardinality attribution."
+            );
+
+            MethodInfo[] independentAttributionEntries = typeof(DeregistrationAttributionBenchmarks)
+                .GetMethods(
+                    BindingFlags.Public
+                        | BindingFlags.NonPublic
+                        | BindingFlags.Static
+                        | BindingFlags.Instance
+                )
+                .Where(method => method.GetCustomAttribute<TestAttribute>() != null)
+                .ToArray();
+            Assert.IsEmpty(
+                independentAttributionEntries,
+                "Attribution must not regain an independently scheduled benchmark fixture entry."
+            );
         }
 
         private static IEnumerable<TestCaseData> LifecycleOperationCases()

--- a/Tests/Runtime/Benchmarks/RegistrationLifecycleBenchmarks.cs
+++ b/Tests/Runtime/Benchmarks/RegistrationLifecycleBenchmarks.cs
@@ -463,19 +463,10 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
     /// state. Every row uses a high-cardinality, same-type population so the timed region is long
     /// enough to compare without folding registration setup into the clock.
     /// </summary>
-    public sealed class DeregistrationAttributionBenchmarks
+    internal static class DeregistrationAttributionBenchmarks
     {
         internal const int Cardinality = 131_072;
         private const int TimingTrials = 7;
-
-        [Test, Performance, Category("PerfBench")]
-        [TestCaseSource(nameof(BenchmarkCases))]
-        public void DeregistrationAttributionBenchmark(DeregistrationAttributionOperation operation)
-        {
-            DispatchBenchmarkResult result = RunScenario(operation);
-            Debug.Log(result.ToStructuredLog());
-            TestContext.Out.WriteLine(result.ToCsvRow());
-        }
 
         internal static DeregistrationAttributionObservation ExecuteOnceForContract(
             DeregistrationAttributionOperation operation,
@@ -539,20 +530,6 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
                     $"DeregistrationAttribution_TokenDisable_{Cardinality}",
                 _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, null),
             };
-        }
-
-        private static IEnumerable<TestCaseData> BenchmarkCases()
-        {
-            foreach (
-                DeregistrationAttributionOperation operation in Enum.GetValues(
-                    typeof(DeregistrationAttributionOperation)
-                )
-            )
-            {
-                yield return new TestCaseData(operation).SetName(
-                    $"DeregistrationAttribution_{operation}_{Cardinality}"
-                );
-            }
         }
 
         private static void ValidateCardinality(int cardinality)

--- a/Tests/Runtime/Core/MutationInterceptorTests.cs
+++ b/Tests/Runtime/Core/MutationInterceptorTests.cs
@@ -2,8 +2,11 @@
 namespace DxMessaging.Tests.Runtime.Core
 {
     using System;
+    using System.Collections.Generic;
+    using System.Reflection;
     using DxMessaging.Core;
     using DxMessaging.Core.Extensions;
+    using DxMessaging.Core.MessageBus;
     using DxMessaging.Tests.Runtime;
     using DxMessaging.Tests.Runtime.Scripts.Components;
     using DxMessaging.Tests.Runtime.Scripts.Messages;
@@ -77,6 +80,166 @@ namespace DxMessaging.Tests.Runtime.Core
             {
                 token.RemoveRegistration(secondHandle.Value);
             }
+        }
+
+        [Test]
+        public void ResetFromInterceptorStopsSnapshotAndAllowsFreshRegistration(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            using LeakWatcher watcher = LeakWatcher.Watch(scenario.DisplayName);
+            GameObject host = new(
+                nameof(ResetFromInterceptorStopsSnapshotAndAllowsFreshRegistration)
+                    + "_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(host);
+            EmptyMessageAwareComponent component = host.GetComponent<EmptyMessageAwareComponent>();
+            MessageRegistrationToken token = GetToken(component);
+            InstanceId hostId = host;
+            IMessageBus bus = MessageHandler.MessageBus;
+            int resettingCount = 0;
+            int trailingCount = 0;
+            int handlerCount = 0;
+
+            _ = RegisterInterceptor(
+                scenario,
+                token,
+                () =>
+                {
+                    ++resettingCount;
+                    DxMessagingStaticState.Reset();
+                    return true;
+                },
+                priority: 0
+            );
+            _ = RegisterInterceptor(
+                scenario,
+                token,
+                () =>
+                {
+                    ++trailingCount;
+                    return true;
+                },
+                priority: 0
+            );
+            _ = ScenarioCallbacks.RegisterCountingHandler(
+                scenario,
+                token,
+                hostId,
+                () => ++handlerCount
+            );
+
+            Assert.DoesNotThrow(
+                () => EmitForScenario(scenario, hostId),
+                "[{0}] Reset from an interceptor must stop dispatch without throwing.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                1,
+                resettingCount,
+                "[{0}] The resetting interceptor must run exactly once.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                0,
+                trailingCount,
+                "[{0}] Reset must stop later interceptors from the copied in-flight snapshot.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                0,
+                handlerCount,
+                "[{0}] Reset in the interceptor phase must stop the handler phase.",
+                scenario.Kind
+            );
+            FieldInfo interceptorStackField = typeof(MessageBus).GetField(
+                "_innerInterceptorsStack",
+                BindingFlags.Instance | BindingFlags.NonPublic
+            );
+            Assert.IsNotNull(
+                interceptorStackField,
+                "[{0}] The interceptor snapshot cache field must remain discoverable.",
+                scenario.Kind
+            );
+            Stack<List<object>> interceptorStack =
+                (Stack<List<object>>)interceptorStackField.GetValue(bus);
+            Assert.AreEqual(
+                0,
+                interceptorStack.Count,
+                "[{0}] Reset must not retain the in-flight interceptor snapshot in the cache.",
+                scenario.Kind
+            );
+            Assert.AreEqual(0, bus.RegisteredUntargeted, "[{0}] Untargeted leak.", scenario.Kind);
+            Assert.AreEqual(0, bus.RegisteredTargeted, "[{0}] Targeted leak.", scenario.Kind);
+            Assert.AreEqual(0, bus.RegisteredBroadcast, "[{0}] Broadcast leak.", scenario.Kind);
+            Assert.AreEqual(
+                0,
+                bus.RegisteredInterceptors,
+                "[{0}] Interceptor leak.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                0,
+                bus.RegisteredPostProcessors,
+                "[{0}] Post-processor leak.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                0,
+                bus.RegisteredGlobalAcceptAll,
+                "[{0}] Global handler leak.",
+                scenario.Kind
+            );
+
+            Assert.DoesNotThrow(
+                () => EmitForScenario(scenario, hostId),
+                "[{0}] An emission immediately after Reset must be a silent no-op.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                1,
+                resettingCount,
+                "[{0}] Reset interceptor survived Reset.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                0,
+                trailingCount,
+                "[{0}] Trailing interceptor survived Reset.",
+                scenario.Kind
+            );
+            Assert.AreEqual(0, handlerCount, "[{0}] Handler survived Reset.", scenario.Kind);
+
+            GameObject rebornHost = new(
+                nameof(ResetFromInterceptorStopsSnapshotAndAllowsFreshRegistration)
+                    + "_Reborn_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(rebornHost);
+            EmptyMessageAwareComponent rebornComponent =
+                rebornHost.GetComponent<EmptyMessageAwareComponent>();
+            MessageRegistrationToken rebornToken = GetToken(rebornComponent);
+            InstanceId rebornId = rebornHost;
+            int rebornCount = 0;
+            _ = ScenarioCallbacks.RegisterCountingHandler(
+                scenario,
+                rebornToken,
+                rebornId,
+                () => ++rebornCount
+            );
+
+            EmitForScenario(scenario, rebornId);
+            Assert.AreEqual(
+                1,
+                rebornCount,
+                "[{0}] A fresh post-reset registration must dispatch normally.",
+                scenario.Kind
+            );
+            rebornToken.UnregisterAll();
         }
 
         private static MessageRegistrationHandle RegisterInterceptor(

--- a/Tests/Runtime/Core/ReentrantEmissionExtendedTests.cs
+++ b/Tests/Runtime/Core/ReentrantEmissionExtendedTests.cs
@@ -171,6 +171,110 @@ namespace DxMessaging.Tests.Runtime.Core
             token.RemoveRegistration(outerHandle);
         }
 
+        [Test]
+        public void PostProcessorCrossKindReentrancyRestoresOuterEmissionId(
+            [ValueSource(nameof(CrossKindReentrancyPairs))] CrossKindReentrancyCase pair
+        )
+        {
+            using LeakWatcher watcher = LeakWatcher.Watch(pair.ToString());
+            MessageScenario outerScenario = pair.Outer;
+            MessageScenario innerScenario = pair.Inner;
+            GameObject host = new(
+                nameof(PostProcessorCrossKindReentrancyRestoresOuterEmissionId)
+                    + outerScenario.Kind
+                    + innerScenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(host);
+            EmptyMessageAwareComponent component = host.GetComponent<EmptyMessageAwareComponent>();
+            MessageRegistrationToken token = GetToken(component);
+            InstanceId hostId = host;
+            IMessageBus bus = MessageHandler.MessageBus;
+
+            long outerBeforeNested = -1;
+            long nested = -1;
+            long outerAfterNested = -1;
+            long trailingOuter = -1;
+            List<string> trace = new(4);
+
+            try
+            {
+                _ = RegisterCountingHandler(outerScenario, token, hostId, () => { });
+                _ = RegisterCountingHandler(
+                    innerScenario,
+                    token,
+                    hostId,
+                    () =>
+                    {
+                        trace.Add("nested-handler");
+                        nested = bus.EmissionId;
+                    }
+                );
+                _ = ScenarioCallbacks.RegisterCountingPostProcessor(
+                    outerScenario,
+                    token,
+                    hostId,
+                    () =>
+                    {
+                        trace.Add("outer-before");
+                        outerBeforeNested = bus.EmissionId;
+                        EmitForScenario(innerScenario, hostId);
+                        outerAfterNested = bus.EmissionId;
+                        trace.Add("outer-after");
+                    },
+                    priority: 0
+                );
+                _ = ScenarioCallbacks.RegisterCountingPostProcessor(
+                    outerScenario,
+                    token,
+                    hostId,
+                    () =>
+                    {
+                        trace.Add("outer-trailing");
+                        trailingOuter = bus.EmissionId;
+                    },
+                    priority: 1
+                );
+
+                EmitForScenario(outerScenario, hostId);
+
+                CollectionAssert.AreEqual(
+                    new[] { "outer-before", "nested-handler", "outer-after", "outer-trailing" },
+                    trace,
+                    "[{0}] Cross-kind post-processor reentrancy order changed.",
+                    pair
+                );
+                Assert.AreNotEqual(
+                    outerBeforeNested,
+                    nested,
+                    "[{0}] A nested emission must receive a distinct EmissionId.",
+                    pair
+                );
+                Assert.AreEqual(
+                    outerBeforeNested + 1,
+                    nested,
+                    "[{0}] The synchronous nested emission must immediately follow the outer emission.",
+                    pair
+                );
+                Assert.AreEqual(
+                    outerBeforeNested,
+                    outerAfterNested,
+                    "[{0}] The outer post-processor must regain its scoped EmissionId after the nested emission returns.",
+                    pair
+                );
+                Assert.AreEqual(
+                    outerBeforeNested,
+                    trailingOuter,
+                    "[{0}] A trailing outer post-processor must observe the restored outer EmissionId.",
+                    pair
+                );
+            }
+            finally
+            {
+                token.UnregisterAll();
+            }
+        }
+
         /// <summary>
         /// Self-recursion bounded at <see cref="DeepRecursionLimit"/> levels.
         /// Cross-checks invocation count via the test-side <c>depth</c>

--- a/Tests/Runtime/Core/TokenInterceptorBusRoutingTests.cs
+++ b/Tests/Runtime/Core/TokenInterceptorBusRoutingTests.cs
@@ -36,7 +36,6 @@ namespace DxMessaging.Tests.Runtime.Core
     [TestFixture]
     public sealed class TokenInterceptorBusRoutingTests
     {
-        private const int OwnerInstanceId = 23;
         private const int ContextInstanceId = 29;
 
         [SetUp]
@@ -57,7 +56,7 @@ namespace DxMessaging.Tests.Runtime.Core
                 MessageScenario scenario
         )
         {
-            using TokenScope scope = TokenScope.Create();
+            using TokenBusRoutingScope scope = TokenBusRoutingScope.Create();
             InstanceId context = new(ContextInstanceId);
             int intercepted = 0;
 
@@ -107,7 +106,7 @@ namespace DxMessaging.Tests.Runtime.Core
         [Test]
         public void InterceptorsStagedWhileDisabledLandOnTokenBusAtEnable()
         {
-            using TokenScope scope = TokenScope.Create(enable: false);
+            using TokenBusRoutingScope scope = TokenBusRoutingScope.Create(enable: false);
             InstanceId context = new(ContextInstanceId);
             int untargetedIntercepted = 0;
             int targetedIntercepted = 0;
@@ -195,7 +194,10 @@ namespace DxMessaging.Tests.Runtime.Core
         {
             BusType originalBus = new();
             BusType retargetedBus = new();
-            using TokenScope scope = TokenScope.Create(enable: false, bus: originalBus);
+            using TokenBusRoutingScope scope = TokenBusRoutingScope.Create(
+                enable: false,
+                bus: originalBus
+            );
             int intercepted = 0;
 
             using (
@@ -260,7 +262,10 @@ namespace DxMessaging.Tests.Runtime.Core
         {
             BusType originalBus = new();
             BusType retargetedBus = new();
-            using TokenScope scope = TokenScope.Create(enable: true, bus: originalBus);
+            using TokenBusRoutingScope scope = TokenBusRoutingScope.Create(
+                enable: true,
+                bus: originalBus
+            );
             int intercepted = 0;
 
             using (
@@ -324,57 +329,58 @@ namespace DxMessaging.Tests.Runtime.Core
             SimpleBroadcastMessage broadcast = new();
             broadcast.EmitBroadcast(context, messageBus);
         }
+    }
 
-        /// <summary>
-        /// Pairs a fresh isolated <see cref="BusType"/>, an active
-        /// <see cref="MessageHandler"/> with NO default bus, and a
-        /// <see cref="MessageRegistrationToken"/> bound to that bus so the token's
-        /// bus binding is the only route to the custom bus.
-        /// </summary>
-        private sealed class TokenScope : IDisposable
+    /// <summary>
+    /// Pairs an isolated bus with an active handler that has no default bus and a token bound to
+    /// that bus. Routing fixtures share this scope so the token binding is their only custom-bus
+    /// route.
+    /// </summary>
+    internal sealed class TokenBusRoutingScope : IDisposable
+    {
+        private const int OwnerInstanceId = 23;
+        private bool _disposed;
+
+        internal IMessageBus Bus { get; }
+
+        internal MessageHandler Handler { get; }
+
+        internal MessageRegistrationToken Token { get; }
+
+        private TokenBusRoutingScope(
+            IMessageBus bus,
+            MessageHandler handler,
+            MessageRegistrationToken token
+        )
         {
-            private bool _disposed;
+            Bus = bus;
+            Handler = handler;
+            Token = token;
+        }
 
-            internal BusType Bus { get; }
-
-            internal MessageHandler Handler { get; }
-
-            internal MessageRegistrationToken Token { get; }
-
-            private TokenScope(BusType bus, MessageHandler handler, MessageRegistrationToken token)
+        internal static TokenBusRoutingScope Create(bool enable = true, IMessageBus bus = null)
+        {
+            IMessageBus resolvedBus = bus ?? new BusType();
+            MessageHandler handler = new(new InstanceId(OwnerInstanceId)) { active = true };
+            MessageRegistrationToken token = MessageRegistrationToken.Create(handler, resolvedBus);
+            if (enable)
             {
-                Bus = bus;
-                Handler = handler;
-                Token = token;
+                token.Enable();
             }
 
-            internal static TokenScope Create(bool enable = true, BusType bus = null)
-            {
-                BusType resolvedBus = bus ?? new BusType();
-                MessageHandler handler = new(new InstanceId(OwnerInstanceId)) { active = true };
-                MessageRegistrationToken token = MessageRegistrationToken.Create(
-                    handler,
-                    resolvedBus
-                );
-                if (enable)
-                {
-                    token.Enable();
-                }
+            return new TokenBusRoutingScope(resolvedBus, handler, token);
+        }
 
-                return new TokenScope(resolvedBus, handler, token);
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
             }
 
-            public void Dispose()
-            {
-                if (_disposed)
-                {
-                    return;
-                }
-
-                _disposed = true;
-                Token.Dispose();
-                Handler.active = false;
-            }
+            _disposed = true;
+            Token.Dispose();
+            Handler.active = false;
         }
     }
 }

--- a/Tests/Runtime/Core/TokenPostProcessorBusRoutingTests.cs
+++ b/Tests/Runtime/Core/TokenPostProcessorBusRoutingTests.cs
@@ -1,0 +1,332 @@
+#if UNITY_2021_3_OR_NEWER
+namespace DxMessaging.Tests.Runtime.Core
+{
+    using System;
+    using DxMessaging.Core;
+    using DxMessaging.Core.MessageBus;
+    using DxMessaging.Tests.Runtime;
+    using DxMessaging.Tests.Runtime.Scripts.Messages;
+    using NUnit.Framework;
+    using BusType = DxMessaging.Core.MessageBus.MessageBus;
+
+    [TestFixture]
+    public sealed class TokenPostProcessorBusRoutingTests
+    {
+        private const int ContextInstanceId = 37;
+
+        [SetUp]
+        public void ResetBeforeTest()
+        {
+            DxMessagingStaticState.Reset();
+        }
+
+        [TearDown]
+        public void ResetAfterTest()
+        {
+            DxMessagingStaticState.Reset();
+        }
+
+        [Test]
+        public void PostProcessorRegisteredViaTokenRunsOnTokenBusOnly(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.AllKindsIncludingWithoutContext)
+            )]
+                MessageScenario scenario
+        )
+        {
+            using TokenBusRoutingScope scope = TokenBusRoutingScope.Create();
+            using TokenBusRoutingScope customHandlerScope = TokenBusRoutingScope.Create(
+                bus: scope.Bus
+            );
+            using TokenBusRoutingScope globalHandlerScope = TokenBusRoutingScope.Create(
+                bus: MessageHandler.MessageBus
+            );
+            InstanceId context = new(ContextInstanceId);
+            int processed = 0;
+
+            using (
+                LeakWatcher customWatcher = new(
+                    bus: scope.Bus,
+                    throwOnLeak: true,
+                    label: scenario.DisplayName + "_Custom"
+                )
+            )
+            using (
+                LeakWatcher globalWatcher = new(
+                    throwOnLeak: true,
+                    label: scenario.DisplayName + "_Global"
+                )
+            )
+            {
+                try
+                {
+                    _ = RegisterHandler(scenario, customHandlerScope.Token, context);
+                    _ = RegisterHandler(scenario, globalHandlerScope.Token, context);
+                    _ = ScenarioCallbacks.RegisterCountingPostProcessor(
+                        scenario,
+                        scope.Token,
+                        context,
+                        () => ++processed
+                    );
+
+                    ScenarioCallbacks.EmitForKind(scenario, scope.Bus, context);
+                    Assert.AreEqual(
+                        1,
+                        processed,
+                        "[{0}] A post-processor registered through a custom-bus token must run on that bus.",
+                        scenario.Kind
+                    );
+
+                    ScenarioCallbacks.EmitForKind(scenario, messageBus: null, context);
+                    Assert.AreEqual(
+                        1,
+                        processed,
+                        "[{0}] A custom-bus token post-processor must not run on the global bus.",
+                        scenario.Kind
+                    );
+                }
+                finally
+                {
+                    scope.Token.UnregisterAll();
+                    customHandlerScope.Token.UnregisterAll();
+                    globalHandlerScope.Token.UnregisterAll();
+                }
+            }
+        }
+
+        [Test]
+        public void PostProcessorStagedWhileDisabledFollowsRetargetedBusAtEnable(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.AllKindsIncludingWithoutContext)
+            )]
+                MessageScenario scenario
+        )
+        {
+            BusType originalBus = new();
+            BusType retargetedBus = new();
+            using TokenBusRoutingScope scope = TokenBusRoutingScope.Create(
+                enable: false,
+                bus: originalBus
+            );
+            using TokenBusRoutingScope originalHandlerScope = TokenBusRoutingScope.Create(
+                bus: originalBus
+            );
+            using TokenBusRoutingScope retargetedHandlerScope = TokenBusRoutingScope.Create(
+                bus: retargetedBus
+            );
+            using TokenBusRoutingScope globalHandlerScope = TokenBusRoutingScope.Create(
+                bus: MessageHandler.MessageBus
+            );
+            InstanceId context = new(ContextInstanceId);
+            int processed = 0;
+
+            using (
+                LeakWatcher originalWatcher = new(
+                    bus: originalBus,
+                    throwOnLeak: true,
+                    label: scenario.DisplayName + "_Disabled_Original"
+                )
+            )
+            using (
+                LeakWatcher retargetedWatcher = new(
+                    bus: retargetedBus,
+                    throwOnLeak: true,
+                    label: scenario.DisplayName + "_Disabled_Retargeted"
+                )
+            )
+            using (
+                LeakWatcher globalWatcher = new(
+                    throwOnLeak: true,
+                    label: scenario.DisplayName + "_Disabled_Global"
+                )
+            )
+            {
+                try
+                {
+                    _ = RegisterHandler(scenario, originalHandlerScope.Token, context);
+                    _ = RegisterHandler(scenario, retargetedHandlerScope.Token, context);
+                    _ = RegisterHandler(scenario, globalHandlerScope.Token, context);
+                    _ = ScenarioCallbacks.RegisterCountingPostProcessor(
+                        scenario,
+                        scope.Token,
+                        context,
+                        () => ++processed
+                    );
+
+                    ScenarioCallbacks.EmitForKind(scenario, originalBus, context);
+                    ScenarioCallbacks.EmitForKind(scenario, retargetedBus, context);
+                    ScenarioCallbacks.EmitForKind(scenario, messageBus: null, context);
+                    Assert.AreEqual(
+                        0,
+                        processed,
+                        "[{0}] A post-processor staged on a disabled token must stay inert.",
+                        scenario.Kind
+                    );
+
+                    scope.Token.RetargetMessageBus(
+                        retargetedBus,
+                        MessageBusRebindMode.RebindActive
+                    );
+                    scope.Token.Enable();
+                    ScenarioCallbacks.EmitForKind(scenario, originalBus, context);
+                    Assert.AreEqual(
+                        0,
+                        processed,
+                        "[{0}] A disabled retarget must not replay the post-processor on the original bus.",
+                        scenario.Kind
+                    );
+
+                    ScenarioCallbacks.EmitForKind(scenario, retargetedBus, context);
+                    Assert.AreEqual(
+                        1,
+                        processed,
+                        "[{0}] Enable must register the staged post-processor on the retargeted bus.",
+                        scenario.Kind
+                    );
+
+                    ScenarioCallbacks.EmitForKind(scenario, messageBus: null, context);
+                    Assert.AreEqual(
+                        1,
+                        processed,
+                        "[{0}] Enabling a custom-bus token must not stage the post-processor on the global bus.",
+                        scenario.Kind
+                    );
+                }
+                finally
+                {
+                    scope.Token.UnregisterAll();
+                    originalHandlerScope.Token.UnregisterAll();
+                    retargetedHandlerScope.Token.UnregisterAll();
+                    globalHandlerScope.Token.UnregisterAll();
+                }
+            }
+        }
+
+        [Test]
+        public void RebindActiveMovesLivePostProcessorToNewBus(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.AllKindsIncludingWithoutContext)
+            )]
+                MessageScenario scenario
+        )
+        {
+            BusType originalBus = new();
+            BusType retargetedBus = new();
+            using TokenBusRoutingScope scope = TokenBusRoutingScope.Create(bus: originalBus);
+            using TokenBusRoutingScope originalHandlerScope = TokenBusRoutingScope.Create(
+                bus: originalBus
+            );
+            using TokenBusRoutingScope retargetedHandlerScope = TokenBusRoutingScope.Create(
+                bus: retargetedBus
+            );
+            InstanceId context = new(ContextInstanceId);
+            int processed = 0;
+
+            using (
+                LeakWatcher originalWatcher = new(
+                    bus: originalBus,
+                    throwOnLeak: true,
+                    label: scenario.DisplayName + "_Original"
+                )
+            )
+            using (
+                LeakWatcher retargetedWatcher = new(
+                    bus: retargetedBus,
+                    throwOnLeak: true,
+                    label: scenario.DisplayName + "_Retargeted"
+                )
+            )
+            {
+                try
+                {
+                    _ = RegisterHandler(scenario, originalHandlerScope.Token, context);
+                    _ = RegisterHandler(scenario, retargetedHandlerScope.Token, context);
+                    _ = ScenarioCallbacks.RegisterCountingPostProcessor(
+                        scenario,
+                        scope.Token,
+                        context,
+                        () => ++processed
+                    );
+
+                    ScenarioCallbacks.EmitForKind(scenario, originalBus, context);
+                    Assert.AreEqual(
+                        1,
+                        processed,
+                        "[{0}] Control failed: the live post-processor did not run on its original bus.",
+                        scenario.Kind
+                    );
+
+                    scope.Token.RetargetMessageBus(
+                        retargetedBus,
+                        MessageBusRebindMode.RebindActive
+                    );
+
+                    ScenarioCallbacks.EmitForKind(scenario, originalBus, context);
+                    Assert.AreEqual(
+                        1,
+                        processed,
+                        "[{0}] RebindActive must remove the live post-processor from the original bus.",
+                        scenario.Kind
+                    );
+
+                    ScenarioCallbacks.EmitForKind(scenario, retargetedBus, context);
+                    Assert.AreEqual(
+                        2,
+                        processed,
+                        "[{0}] RebindActive must register the live post-processor on the new bus.",
+                        scenario.Kind
+                    );
+                }
+                finally
+                {
+                    scope.Token.UnregisterAll();
+                    originalHandlerScope.Token.UnregisterAll();
+                    retargetedHandlerScope.Token.UnregisterAll();
+                }
+            }
+        }
+
+        private static MessageRegistrationHandle RegisterHandler(
+            MessageScenario scenario,
+            MessageRegistrationToken token,
+            InstanceId context
+        )
+        {
+            switch (scenario.Kind)
+            {
+                case MessageKind.Untargeted:
+                    return token.RegisterUntargeted<SimpleUntargetedMessage>(
+                        (ref SimpleUntargetedMessage _) => { }
+                    );
+                case MessageKind.Targeted:
+                    return token.RegisterTargeted<SimpleTargetedMessage>(
+                        context,
+                        (ref SimpleTargetedMessage _) => { }
+                    );
+                case MessageKind.Broadcast:
+                    return token.RegisterBroadcast<SimpleBroadcastMessage>(
+                        context,
+                        (ref SimpleBroadcastMessage _) => { }
+                    );
+                case MessageKind.TargetedWithoutTargeting:
+                    return token.RegisterTargetedWithoutTargeting<SimpleTargetedMessage>(
+                        (ref InstanceId _, ref SimpleTargetedMessage __) => { }
+                    );
+                case MessageKind.BroadcastWithoutSource:
+                    return token.RegisterBroadcastWithoutSource<SimpleBroadcastMessage>(
+                        (ref InstanceId _, ref SimpleBroadcastMessage __) => { }
+                    );
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(scenario),
+                        scenario.Kind,
+                        "Unsupported message kind."
+                    );
+            }
+        }
+    }
+}
+#endif

--- a/Tests/Runtime/Core/TokenPostProcessorBusRoutingTests.cs.meta
+++ b/Tests/Runtime/Core/TokenPostProcessorBusRoutingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 511347aed8484342227a893ab04d14c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime/Core/UntypedDispatchTests.cs
+++ b/Tests/Runtime/Core/UntypedDispatchTests.cs
@@ -4,11 +4,13 @@ namespace DxMessaging.Tests.Runtime.Core
     using System;
     using System.Collections.Generic;
     using DxMessaging.Core;
+    using DxMessaging.Core.Attributes;
     using DxMessaging.Core.MessageBus;
     using DxMessaging.Core.Messages;
     using DxMessaging.Tests.Runtime.Scripts.Components;
     using NUnit.Framework;
     using UnityEngine;
+    using BusType = DxMessaging.Core.MessageBus.MessageBus;
 
     public sealed class UntypedDispatchTests : MessagingTestBase
     {
@@ -114,6 +116,29 @@ namespace DxMessaging.Tests.Runtime.Core
             );
         }
 
+        [Test]
+        public void FirstUntypedDispatchUsesGeneratedAotBridge(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            IMessageBus bus = new BusType();
+            InstanceId target = new(0x6A17_3001);
+            InstanceId source = new(0x6A17_3002);
+
+            Assert.DoesNotThrow(
+                () => DispatchFirstGeneratedMessage(bus, scenario.Kind, target, source),
+                "[{0}] A source-generated message must support its first-ever untyped dispatch without a prior registration or typed emit.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                1,
+                bus.EmissionId,
+                "[{0}] The generated bridge must enter the typed dispatch path exactly once.",
+                scenario.Kind
+            );
+        }
+
         public readonly struct MultiKindMessage
             : IUntargetedMessage,
                 ITargetedMessage,
@@ -201,6 +226,38 @@ namespace DxMessaging.Tests.Runtime.Core
                     throw new ArgumentOutOfRangeException(nameof(kind), kind, null);
             }
         }
+
+        private static void DispatchFirstGeneratedMessage(
+            IMessageBus bus,
+            MessageKind kind,
+            InstanceId target,
+            InstanceId source
+        )
+        {
+            switch (kind)
+            {
+                case MessageKind.Untargeted:
+                    bus.UntypedUntargetedBroadcast(new ColdUntargetedMessage());
+                    break;
+                case MessageKind.Targeted:
+                    bus.UntypedTargetedBroadcast(target, new ColdTargetedMessage());
+                    break;
+                case MessageKind.Broadcast:
+                    bus.UntypedSourcedBroadcast(source, new ColdBroadcastMessage());
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(kind), kind, null);
+            }
+        }
     }
+
+    [DxUntargetedMessage]
+    internal readonly partial struct ColdUntargetedMessage { }
+
+    [DxTargetedMessage]
+    internal readonly partial struct ColdTargetedMessage { }
+
+    [DxBroadcastMessage]
+    internal readonly partial struct ColdBroadcastMessage { }
 }
 #endif

--- a/Tests/Runtime/TestUtilities/ScenarioCallbacks.cs
+++ b/Tests/Runtime/TestUtilities/ScenarioCallbacks.cs
@@ -3,6 +3,7 @@ namespace DxMessaging.Tests.Runtime
 {
     using System;
     using DxMessaging.Core;
+    using DxMessaging.Core.Extensions;
     using DxMessaging.Core.MessageBus;
     using DxMessaging.Tests.Runtime.Scripts.Messages;
 
@@ -165,6 +166,20 @@ namespace DxMessaging.Tests.Runtime
                         priority
                     );
                 }
+                case MessageKind.TargetedWithoutTargeting:
+                {
+                    return token.RegisterTargetedWithoutTargetingPostProcessor<SimpleTargetedMessage>(
+                        (ref InstanceId _, ref SimpleTargetedMessage __) => onInvoked(),
+                        priority: priority
+                    );
+                }
+                case MessageKind.BroadcastWithoutSource:
+                {
+                    return token.RegisterBroadcastWithoutSourcePostProcessor<SimpleBroadcastMessage>(
+                        (ref InstanceId _, ref SimpleBroadcastMessage __) => onInvoked(),
+                        priority: priority
+                    );
+                }
                 default:
                 {
                     throw new ArgumentOutOfRangeException(
@@ -274,15 +289,17 @@ namespace DxMessaging.Tests.Runtime
                     return;
                 }
                 case MessageKind.Targeted:
+                case MessageKind.TargetedWithoutTargeting:
                 {
                     SimpleTargetedMessage message = new();
-                    ScenarioHarness.EmitTargeted(scenario, ref message, context, messageBus);
+                    message.EmitTargeted(context, messageBus);
                     return;
                 }
                 case MessageKind.Broadcast:
+                case MessageKind.BroadcastWithoutSource:
                 {
                     SimpleBroadcastMessage message = new();
-                    ScenarioHarness.EmitBroadcast(scenario, ref message, context, messageBus);
+                    message.EmitBroadcast(context, messageBus);
                     return;
                 }
                 default:

--- a/docs/runbooks/perf-benchmark-methodology.md
+++ b/docs/runbooks/perf-benchmark-methodology.md
@@ -144,9 +144,11 @@ they are report-only -- rendered as wall clock, never gated.
   multi-second destructive windows collect ambient editor allocations, and a
   faster implementation would look like an allocation win merely by shortening
   exposure. Prove allocation changes with structural or short-window differential
-  guards instead. These diagnostic wall-clock rows are not hard regression gates.
-  Do not compare them with the 1000-type flood rows because their registration
-  topology differs.
+  guards instead. The attribution entry and the published dispatch entry share
+  `DispatchThroughputBenchmarks`: method-level NUnit `Order` runs every dispatch
+  scenario before the repeated 131072-registration attribution setup. These
+  diagnostic wall-clock rows are not hard regression gates. Do not compare them
+  with the 1000-type flood rows because their registration topology differs.
 - **Noise control on the wall-clock floods.** A single one-shot sample of a ~1 ms
   operation on a shared CI runner swings run-to-run by tens of percent (scheduler
   preemption, or a GC landing inside the timed window). Two mitigations: (1) the


### PR DESCRIPTION
## Summary

- stop interceptor dispatch cleanly when an interceptor resets the bus, including dropping reset-invalidated delegate snapshots instead of repooling them
- cover post-processor cross-kind reentrancy, token bus routing/rebind, and first-ever generated untyped dispatch across the shared message-kind matrices
- restore isolated IL2CPP dispatch measurements by ordering the co-located dispatch suite before high-cardinality deregistration attribution

## Root cause

Interceptor dispatch copied priority buckets but did not re-check the reset generation after user callbacks. Reset therefore allowed later copied interceptors to run, and the unwinding frame could repopulate the cleared snapshot cache with pre-reset delegates.

The reported empty-bus throughput drop was measurement contamination rather than a matching dispatch-runtime regression. Exact-old code measured 48.29M emits/sec on the current runner, while current runtime with the pre-#391 harness measured 47.80M. The new 131072-registration attribution workload had become an independently scheduled fixture before the published dispatch window. Both entries now share one fixture with supported NUnit method ordering, guarded structurally.

## Impact

Reset from an interceptor now terminates that emission safely and does not retain reset callbacks. The missing runtime/AOT contracts are pinned without per-kind triplets or new hot-path allocations. Published dispatch numbers again run before destructive high-cardinality attribution.

## Validation

- controlled red proofs across all three interceptor kinds for continued execution and snapshot retention
- focused Unity MCP: interceptor reset 3/3, post-processor reentrancy 6/6, token post-processor routing 15/15, cold untyped dispatch 3/3
- interceptor allocation matrix 6/6
- full Runtime PlayMode assembly: 1,046 passed, 0 failed, 1 skipped
- source-generator suite: 246 passed
- `npm run validate:all`, JavaScript tests (410/410), formatting, Markdown, spelling, meta validation, and pre-commit
- four adversarial review passes, zero remaining findings

Closes #395
Closes #397

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core dispatch-path change around reset during interceptor execution affects all three interceptor kinds; mitigated by broad parameterized tests. Perf harness reordering is test-only but affects published IL2CPP measurement interpretation.
> 
> **Overview**
> Fixes **`DxMessagingStaticState.Reset()` from an interceptor** by re-checking `_resetGeneration` after each interceptor callback in untargeted, targeted, and broadcast interceptor loops. A reset now **stops the remaining copied snapshot** (no trailing interceptors or handlers) and **skips repooling** interceptor delegate lists when the generation changed, so pre-reset delegates are not pushed back onto `_innerInterceptorsStack`.
> 
> **Benchmark isolation (#397):** high-cardinality deregistration attribution is no longer its own NUnit fixture; it runs as a second ordered method on `DispatchThroughputBenchmarks` so published dispatch throughput always completes before the destructive 131072-registration setup. A contract test pins that ordering and that attribution has no independent `[Test]` entry.
> 
> **Tests and docs:** adds `ResetFromInterceptorStopsSnapshotAndAllowsFreshRegistration` (kind-matrix), post-processor **cross-kind reentrancy** `EmissionId` restoration, **`TokenPostProcessorBusRoutingTests`** (custom bus, disable/retarget/enable, `RebindActive`) via shared **`TokenBusRoutingScope`**, and **first-ever generated untyped dispatch** cold-bridge coverage. `ScenarioCallbacks` gains without-context post-processor kinds and simplified emits for extended message kinds. Lifecycle edge-coverage doc lists the new reset scenario and third fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c6d7eca3f835478f5017e939feca139e26d443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->