### PR TITLE
Stop a superseded Unity run from holding the concurrency group

### DIFF
--- a/.github/workflows/perf-numbers.yml
+++ b/.github/workflows/perf-numbers.yml
@@ -69,8 +69,14 @@ on:
 # this workflow do not race each other. A separate freshness check still guards
 # against unrelated default-branch pushes landing while the benchmarks run. We do
 # NOT cancel in-progress runs -- that would abort an in-flight benchmark.
+#
+# Pull-request runs add the head SHA, so that merge-path serialization does not
+# also queue a pull request's current head behind a superseded run whose only
+# remaining act is to abort on the per-leg head guard (#332). Benchmarks stay
+# mutually exclusive through the organization build lock, and every licensed leg
+# re-checks the pull-request head before it can reach that lock.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number && format('{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.sha) || github.ref }}
   cancel-in-progress: false
 
 # Top-level least-privilege. The default-branch refresh job (commit-perf-doc)
@@ -152,7 +158,12 @@ jobs:
       actions: read
       contents: read
     concurrency:
-      group: ${{ github.workflow }}-runner-preflight-${{ github.ref }}
+      # Keyed exactly like the workflow-level group. A `github.ref`-only key was
+      # unreachable while that group serialized every run of a pull request; now
+      # that it does not, the key has to match, or a newer run would cancel a
+      # superseded run's preflight, skip that run's benchmarks, and leave its
+      # aggregate reporting a result shape the gate below does not describe.
+      group: ${{ github.workflow }}-runner-preflight-${{ github.event.pull_request.number && format('{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.sha) || github.ref }}
       cancel-in-progress: true
     outputs:
       has-autocommit-app: ${{ steps.check-autocommit-app.outputs.has-app }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -13,7 +13,18 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: unity-tests-${{ github.event.pull_request.number || github.ref }}
+  # Push runs share one group per ref, so consecutive default-branch pushes stay
+  # serialized. Pull-request runs add the head SHA. Serializing those bought
+  # nothing and cost the head that matters: `cancel-in-progress: false` below is
+  # deliberate (a hard cancel mid-lease is the seat leak the four-layer
+  # license-return guarantee exists to prevent), so a superseded run held the
+  # shared group while its remaining legs waited on a scarce self-hosted runner
+  # purely to abort on the per-leg head guard, and the run for the current head
+  # sat pending with zero jobs for as long as that took -- 33 minutes on #402.
+  # Licensed Unity work is serialized by the organization build lock, not by this
+  # group, and every leg re-checks the pull-request head before it can reach that
+  # lock, so two runs of one pull request can never both do licensed work (#332).
+  group: unity-tests-${{ github.event.pull_request.number && format('{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.sha) || github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -26,16 +37,15 @@ jobs:
   head-check:
     name: Unity head freshness
     # A second push to a pull request queues a second full matrix and does not
-    # retire the first. `cancel-in-progress: false` above is deliberate -- a
-    # hard cancel mid-lock is the exact scenario the four-layer license-return
-    # guarantee exists to avoid -- so the superseded run keeps the concurrency
-    # group until it has burned through every leg, and the run for the commit
-    # that matters cannot start. `Unity CI Success` is then absent on the
-    # current head, which reads as a blocked pull request on a check nobody
-    # misconfigured.
+    # retire the first: `cancel-in-progress: false` above is deliberate, because
+    # a hard cancel mid-lock is the exact scenario the four-layer license-return
+    # guarantee exists to avoid. The head-SHA-keyed concurrency group above lets
+    # the new run start anyway, so what is left to avoid is the superseded run
+    # handing a scarce self-hosted runner to every remaining leg purely so that
+    # leg can abort.
     #
     # Deciding it here, on GitHub-hosted infrastructure and before the lock is
-    # in reach, costs a superseded run one cheap job instead of nine
+    # in reach, costs a superseded run one cheap job instead of four
     # self-hosted ones. The per-leg `Require current PR head before setup`
     # guard stays: it covers the push that lands after this job has already
     # passed.
@@ -109,7 +119,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     concurrency:
-      group: ${{ github.workflow }}-runner-preflight-${{ github.ref }}
+      # Keyed exactly like the workflow-level group. A `github.ref`-only key was
+      # unreachable while that group serialized every run of a pull request; now
+      # that it does not, the key has to match, or a newer run would cancel a
+      # superseded run's preflight, skip that run's whole matrix, and leave its
+      # aggregate reporting a result shape the gate below does not describe.
+      group: ${{ github.workflow }}-runner-preflight-${{ github.event.pull_request.number && format('{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.sha) || github.ref }}
       cancel-in-progress: true
     steps:
       - name: Require a registered Unity runner

--- a/.llm/index.json
+++ b/.llm/index.json
@@ -196,7 +196,7 @@
         "category": "github-actions",
         "tags": "github-actions, ci-cd, workflow, security, consistency, yaml"
       },
-      "lineCount": 150,
+      "lineCount": 154,
       "references": [
         ".llm/skills/github-workflow-consistency/references/cicd-devcontainer-workflows.md",
         ".llm/skills/github-workflow-consistency/references/git-renormalize-patterns.md",

--- a/.llm/skills/github-workflow-consistency/SKILL.md
+++ b/.llm/skills/github-workflow-consistency/SKILL.md
@@ -29,6 +29,10 @@ publishing, and the tag-selected manual release dispatch.
 - Every workflow declares
   `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }`
   and an explicit `permissions` block (default `contents: read`; never omit it).
+- A workflow that must keep `cancel-in-progress: false` because a mid-run cancel leaks a
+  resource -- the licensed Unity workflows and their Unity seat -- keys its group, and every
+  job-level group in the same file, by pull-request head SHA, so a superseded run cannot hold
+  the group while the current head waits. `npm run validate:unity-pr-policy` enforces the key.
 - Every job declares `timeout-minutes`. Guides: lint 5, build 15-30, tests 30-60, deploy 10-15.
 - Every `actions/checkout` declares `persist-credentials` explicitly and uses `false`. Push
   credentials are scoped to the one step that needs them: either

--- a/docs/runbooks/required-checks.md
+++ b/docs/runbooks/required-checks.md
@@ -90,12 +90,16 @@ and each is validated rather than assumed:
 - **A superseded head.** `concurrency` on this workflow sets
   `cancel-in-progress: false` on purpose, because hard-cancelling a run that
   holds the organization build lock is the scenario the license-return guarantee
-  exists to prevent. Without a gate, the run for the older commit keeps the
-  concurrency group through every matrix leg and the current head cannot start. The
-  `head-check` job compares the event's head SHA against the live pull-request
-  head on `ubuntu-latest`, before the lock is in reach, and publishes a
-  `superseded` output that both licensed jobs gate on. It fails open: a lookup
-  that returns no SHA runs the full matrix. The per-leg
+  exists to prevent. The group is keyed by pull-request head SHA so that policy
+  does not also queue the current head behind a superseded run: push runs keep
+  the `github.ref` key and stay serialized, pull-request runs partition per head,
+  and every job-level group in the file uses the same key. Nothing is cancelled,
+  and licensed work stays mutually exclusive through the organization build lock.
+  On top of that, the `head-check` job compares the event's head SHA against the
+  live pull-request head on `ubuntu-latest`, before the lock is in reach, and
+  publishes a `superseded` output that both licensed jobs gate on, so a
+  superseded run costs one cheap hosted job instead of four self-hosted ones. It
+  fails open: a lookup that returns no SHA runs the full matrix. The per-leg
   `Require current PR head before setup` guard still covers a push that lands
   after `head-check` has already passed.
 

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -59,6 +59,20 @@ BLANKET_PR_REJECTION = re.compile(
 SUPERSEDED_GUARD = re.compile(
     r"needs\.head-check\.outputs\.superseded\s*!=\s*'true'\s*&&"
 )
+# `cancel-in-progress: false` stays, so the concurrency GROUP carries the head
+# instead: push runs serialize per ref, pull-request runs partition per head SHA.
+# Without the SHA a superseded run held the group while its remaining legs waited
+# on a scarce self-hosted runner purely to abort, and the run for the current head
+# sat pending with zero jobs for as long as that took (#332). Every group in the
+# workflow must use this one key -- a job-level group keyed only by `github.ref`
+# would let a newer run cancel a superseded run's preflight, skipping that run's
+# licensed matrix and leaving its aggregate to report a result shape the gate
+# does not enumerate.
+PER_HEAD_CONCURRENCY_KEY = (
+    "${{ github.event.pull_request.number && "
+    "format('{0}-{1}', github.event.pull_request.number, "
+    "github.event.pull_request.head.sha) || github.ref }}"
+)
 WORKFLOW_EDITOR_MUTATION = re.compile(
     r"^\s*(?:"
     r"(?:Start-Process(?:\s+-FilePath)?|&|cmd(?:\.exe)?\s+/[ck])\s+"
@@ -747,6 +761,45 @@ def validate_lock_window_timeout_budget(job: str, label: str) -> None:
     )
 
 
+def concurrency_groups(source: str) -> list[str]:
+    """Return the `group:` value of every workflow-level and job-level concurrency block."""
+    lines = source.splitlines()
+    groups = []
+    for index, line in enumerate(lines):
+        block = re.match(r"^(?P<indent>[ \t]*)concurrency:[ \t]*$", line)
+        if block is None:
+            continue
+        indent = len(block.group("indent"))
+        found = None
+        for nested in lines[index + 1 :]:
+            if nested.strip() == "":
+                continue
+            if len(nested) - len(nested.lstrip()) <= indent:
+                break
+            key = re.match(r"^[ \t]*group: (?P<value>.+?)[ \t]*$", nested)
+            if key is not None:
+                found = key.group("value")
+        groups.append(found)
+    return groups
+
+
+def validate_per_head_concurrency(source: str, label: str) -> None:
+    """Every concurrency group in a licensed Unity workflow partitions per head SHA."""
+    groups = concurrency_groups(source)
+    require(bool(groups), f"{label}: no concurrency block declared")
+    for group in groups:
+        require(
+            group is not None,
+            f"{label}: every concurrency block must name a group",
+        )
+        require(
+            str(group).endswith(PER_HEAD_CONCURRENCY_KEY),
+            f"{label}: concurrency group {group!r} must end with the per-head key "
+            f"{PER_HEAD_CONCURRENCY_KEY!r} so a superseded pull-request run cannot "
+            "hold it while the run for the current head waits",
+        )
+
+
 def validate_licensed_workflow_policy(source: str) -> str:
     concurrency = re.search(
         r"^concurrency:\n(?P<body>(?:^  .+\n)+)",
@@ -760,6 +813,7 @@ def validate_licensed_workflow_policy(source: str) -> str:
         == ["  cancel-in-progress: false"],
         "Unity workflow concurrency must use one literal cancel-in-progress: false",
     )
+    validate_per_head_concurrency(source, "unity-tests.yml")
 
     licensed = job_block(source, "unity-tests")
     require(
@@ -3214,6 +3268,7 @@ def validate_perf_pr_policy() -> None:
     """Keep PR performance evidence trusted, current, and credential-free."""
     perf_path = Path(".github/workflows/perf-numbers.yml")
     source = perf_path.read_text(encoding="utf-8")
+    validate_per_head_concurrency(source, "perf-numbers.yml")
     preflight = job_block(source, "runner-preflight")
     benchmark = job_block(source, "perf-benchmarks")
     comment = job_block(source, "comment-perf-doc")
@@ -4115,6 +4170,12 @@ steps:
         "  cancel-in-progress: false\n",
         "  cancel-in-progress: true\n",
         "top-level cancellation policy",
+    )
+    require_policy_mutation_rejected(
+        source,
+        f"  group: unity-tests-{PER_HEAD_CONCURRENCY_KEY}\n",
+        "  group: unity-tests-${{ github.event.pull_request.number || github.ref }}\n",
+        "per-head concurrency group",
     )
     require_policy_mutation_rejected(
         source,

--- a/scripts/validate-unity-pr-policy.py
+++ b/scripts/validate-unity-pr-policy.py
@@ -761,10 +761,10 @@ def validate_lock_window_timeout_budget(job: str, label: str) -> None:
     )
 
 
-def concurrency_groups(source: str) -> list[str]:
-    """Return the `group:` value of every workflow-level and job-level concurrency block."""
+def concurrency_groups(source: str) -> list[str | None]:
+    """Return each concurrency block's `group:`, or None where the block declares none."""
     lines = source.splitlines()
-    groups = []
+    groups: list[str | None] = []
     for index, line in enumerate(lines):
         block = re.match(r"^(?P<indent>[ \t]*)concurrency:[ \t]*$", line)
         if block is None:
@@ -792,8 +792,9 @@ def validate_per_head_concurrency(source: str, label: str) -> None:
             group is not None,
             f"{label}: every concurrency block must name a group",
         )
+        assert group is not None
         require(
-            str(group).endswith(PER_HEAD_CONCURRENCY_KEY),
+            group.endswith(PER_HEAD_CONCURRENCY_KEY),
             f"{label}: concurrency group {group!r} must end with the per-head key "
             f"{PER_HEAD_CONCURRENCY_KEY!r} so a superseded pull-request run cannot "
             "hold it while the run for the current head waits",


### PR DESCRIPTION
## Problem

A `Unity Tests` or `Performance Numbers` run that is superseded **mid-flight** keeps its
concurrency group. `cancel-in-progress: false` is deliberate -- a hard cancel mid-lease is the
seat leak the four-layer license-return guarantee exists to prevent -- so the superseded run
holds the group until every remaining leg has been handed a scarce self-hosted Windows runner
purely so it can abort on `Require current PR head before setup`. The run for the commit that
matters sits `pending` with **zero jobs**, which is also why `gh pr checks` reports no Unity
entries at all and the pull request reads as settled (#332).

## What the measurement says

Every failed leg of the last 60 runs of each workflow, joined against its own step outcomes:

| | |
| --- | --- |
| Doomed legs that consumed a self-hosted runner | 41 |
| Their total on-runner time | 8.0 min |
| Their total queue wait for a runner | 440.6 min |

The wait is the entire cost -- 55x the work. That rules out the fix this issue first proposed
(have the head guard cancel its own run). Within one superseded run the doomed legs run
back-to-back once a runner frees up: run `31753050140` shows queue waits of 1624s, 1637s and
1650s, so self-retiring on the first leg would have saved **26 seconds**. Run `31759789857`
(PR #402, yesterday) is the shape that matters: **one** doomed leg, 1991s of queue wait, 11s of
work. Self-retirement would have saved nothing at all there.

What costs 33 minutes is not the doomed legs. It is queueing the current head behind them.

## Fix

Keep `cancel-in-progress: false`. Move the head into the **group identity** instead:

```yaml
group: unity-tests-${{ github.event.pull_request.number && format('{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.sha) || github.ref }}
```

- **Push runs are unchanged.** `github.event.pull_request` is null, so the key is still
  `github.ref` and consecutive default-branch pushes stay serialized. That is the property the
  perf workflow's group comment asks for, and it is preserved exactly.
- **Pull-request runs partition per head**, so a superseded run cannot hold the group.
- **Nothing is cancelled**, so the constraint that a leg holding the organization lock must
  never be cancelled mid-lease is satisfied by construction rather than by a check.

Two runs of one pull request can never both do licensed work: each leg passes
`Require current PR head before setup`, then `Require current PR head before lock acquisition`,
and `acquire-build-lock` itself takes the pull-request identity and drops stale waiters. The
mutual exclusion that matters was always the organization build lock, never this group.

Job-level preflight groups take the same key. Theirs was unreachable while the workflow group
serialized every run of a pull request. Left on `github.ref` it would now let a newer run cancel
a superseded run's preflight, skip that run's whole licensed matrix, and leave its aggregate
reporting a result shape `Verify Unity CI result shape` does not enumerate.

## Scope of the class

Only two workflows are both `pull_request`-triggered and self-hosted, and both are fixed.
`release.yml`, `unity-benchmarks.yml` and `runner-bootstrap.yml` are self-hosted but never run on
`pull_request`, so no head guard applies to them. `deploy-docs.yml` keeps
`cancel-in-progress: false` on a GitHub-hosted runner with no head guard and no scarce resource.

## Honest residual

Two shapes of superseded leg remain, and neither is new:

- A leg **queued** when the head moves still takes a runner slot for about eleven seconds before
  `Require current PR head before setup` aborts it. That is the issue's third acceptance
  criterion met in substance rather than literally.
- A leg **already running** when the head moves finishes normally. On this pull request the
  superseded perf leg had acquired the organization lock two minutes before the push and ran its
  full benchmark. That is not a gap -- it is the constraint this issue puts on any fix.

There is also a new accumulation to be honest about. `cancel-in-progress: false` used to collapse
pending runs, so a group held at most one in-flight run plus one pending one no matter how many
pushes landed. Per-head groups remove that cap: N pushes now materialize N runs, and the doomed
leg count grows with the push count instead of staying at four. Two pushes, the common case,
dispatch exactly as many legs as before; the three pushes on this pull request produced eight
doomed Unity legs instead of four, about 96 seconds of runner time instead of 48, against the
10-33 minutes of `pending` removed.

Having the doomed run cancel itself would cap it again -- one doomed dispatch per superseded run
rather than four -- but it needs `actions: write` on the job that also carries the Unity serial
and the build-lock App key, and it puts a cancellation path into the workflow whose whole design
is that no cancellation path exists. Eight minutes of doomed-leg runner time across 120 runs does
not buy that. Filed as #406 with the measured numbers and explicit revisit conditions, so the
trade is not rediscovered by accident once this issue closes.

## Docs

`docs/runbooks/required-checks.md` still said a superseded run "keeps the concurrency group
through every matrix leg and the current head cannot start", which is the behavior this removes.
`.llm/skills/github-workflow-consistency/SKILL.md` records the rule, since its blanket
`cancel-in-progress: true` line did not describe the licensed Unity workflows.

## Verification

- `npm test` 421 pass; `validate:all`, `format:check`, `lint:markdown`, `check:spelling`,
  `actionlint`, `yamllint` and the pre-commit hook set all pass.
- `validate:unity-pr-policy` gained a per-head concurrency invariant covering **every**
  concurrency block in both workflows. Proved by mutation: reverting either group in either file
  to a ref-only key is rejected, a concurrency block with no group at all is rejected, and a
  `group:` key outside a concurrency block is correctly ignored. The workflow-level revert is
  additionally wired into the existing `require_policy_mutation_rejected` harness.
- Live supersession experiment on this pull request: see the comment below.

Closes #332
