### PR TITLE
Make the EditMode scene-safety scan linear instead of quadratic

### DIFF
--- a/.llm/index.json
+++ b/.llm/index.json
@@ -499,7 +499,7 @@
         "category": "testing",
         "tags": "testing, unity, performance, play-mode, domain-reload"
       },
-      "lineCount": 69,
+      "lineCount": 71,
       "references": [
         ".llm/skills/unity-test-execution/references/fast-unity-tests.md",
         ".llm/skills/unity-test-execution/references/single-thread-contract.md",

--- a/.llm/skills/unity-test-execution/SKILL.md
+++ b/.llm/skills/unity-test-execution/SKILL.md
@@ -42,12 +42,14 @@ How the DxMessaging Unity suites are hosted, selected, and executed, plus the le
 1. **`[UnityTest]` only when the body yields.** A no-yield `[UnityTest]` still pays per-method enumerator scheduling. Convert it to `[Test]`; it stays in the PlayMode assembly, so `MessageAwareComponent.OnEnable` and the `[UnitySetUp]`/`[UnityTearDown]` brackets still run. The migration is complete and the `pendingMigration` allowlist is empty.
 1. **No real-time waits.** `Thread.Sleep`, `Task.Delay`, `WaitForSeconds`, `WaitForSecondsRealtime`, and `Time.timeScale` are banned everywhere under `Tests/`. Poll a frame budget or a synchronous condition instead.
 1. **Keep the standalone leg on Release C++.** Debug C++ saves native compile time but makes the IL2CPP player far slower overall. Never touch `Il2CppCodeGeneration` on the correctness leg; that codegen fidelity is why the leg exists.
+1. **Source-scanning contract tests stay linear in corpus size.** A test that scans `Tests/`, `Runtime/`, or `Editor/` grows with the tree it guards, so a scan that is superlinear in file length spends its CI margin silently and then fails on the largest file. Never re-scan the whole source, or a `Substring(0, index)` prefix of it, inside a per-candidate loop, and never build an interpolated `Regex` inside one - interpolated patterns evict each other from the 15-entry regex cache and recompile every call. Compute per-file lookups once (line starts, matching braces, enclosing scope ends, declarations grouped by name) and query them, as `EditModeGameObjectConstructionScanner.ScanIndex` does. That one fix took `WallstopStudios.DxMessaging.Tests.Editor` from 432 s to 107 s. Verify a scanner rewrite by diffing its findings against the previous implementation over every C# file in the repository, not by re-running the suite.
 
 ### Drift guards
 
 - `TestAttributeContractTests.TestSourcesAvoidRealTimeWaitAntiPatterns` source-scans `Tests/` for banned wait tokens.
 - `TestAttributeContractTests.NoYieldUnityTestsMustBePlainTest` source-scans for `[UnityTest]` methods that never yield. A source scan is required: a `yield break`-only method is still a compiler iterator, so reflection cannot detect it.
 - `scripts/__tests__/run-ci-tests-enter-play-mode.test.js` asserts the runner emits the reload-disable into each ephemeral project, not into the gitignored `.unity-test-project`.
+- `EditModeSceneSafetyContractTests.ScannerResultsDoNotDependOnSurroundingFileSize` runs every scanner case alone and again after unrelated surrounding code, so a per-file index that resolves the wrong entry in a large file fails there rather than in the corpus scan.
 - `SuiteWallClockBudgetTest` fails the default suite past a per-version hard ceiling (300 s on 2021.3, 180 s on 2022.3 and 6000.x) and warns past a 60 s soft budget. Write new budget assertions RED first.
 
 ### Single-thread contract

--- a/Tests/Editor/EditModeSceneSafetyContractTests.cs
+++ b/Tests/Editor/EditModeSceneSafetyContractTests.cs
@@ -2,9 +2,11 @@
 namespace DxMessaging.Tests.Editor
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Text;
     using System.Text.RegularExpressions;
     using NUnit.Framework;
     using UnityEngine;
@@ -23,51 +25,127 @@ namespace DxMessaging.Tests.Editor
             StringComparer.Ordinal
         );
 
-        [TestCase("GameObject host = new GameObject(\"classic\");", 1)]
-        [TestCase("GameObject host = new GameObject { name = \"initializer\" };", 1)]
-        [TestCase("UnityEngine.GameObject host = new UnityEngine.GameObject(\"qualified\");", 1)]
-        [TestCase("GameObject host = new(\"target typed\");", 1)]
-        [TestCase("GameObject host = (new(\"parenthesized\"));", 1)]
-        [TestCase("GameObject host;\nhost = new(\"deferred\");", 1)]
-        [TestCase("GameObject host;\nhost = (new(\"parenthesized deferred\"));", 1)]
-        [TestCase(
-            "void First() { GameObject receiver = new(\"unsafe\"); }\n"
-                + "void Second() { FlowGraphComponentNode receiver = new(); }",
-            1
-        )]
-        [TestCase("// GameObject host = new(\"comment\");", 0)]
-        [TestCase("string sample = \"GameObject host = new(\\\"text\\\");\";", 0)]
-        [TestCase(
-            "GameObject host = EditorUtility.CreateGameObjectWithHideFlags(\"safe\", HideFlags.HideAndDontSave);",
-            0
-        )]
-        [TestCase("GameObject Host { get; } = new(\"property\");", 1)]
-        [TestCase("GameObject CreateHost() => new(\"arrow\");", 1)]
-        [TestCase("GameObject CreateHost() { return new(\"return\"); }", 1)]
-        [TestCase("GameObject CreateHost() { return condition ? new(\"return\") : null; }", 1)]
-        [TestCase("GameObject Host { get { return new(\"getter\"); } }", 1)]
-        [TestCase("Func<GameObject> factory = () => new(\"lambda\");", 1)]
-        [TestCase("GameObject host = condition ? new(\"branch\") : null;", 1)]
-        [TestCase("GameObject[] hosts = { new(\"array\") };", 1)]
-        [TestCase("GameObject[] hosts = new GameObject[] { new(\"explicit array\") };", 1)]
-        [TestCase("GameObject host; this.host = new(\"member\");", 1)]
-        [TestCase("GameObject host; host ??= new(\"coalesce\");", 1)]
-        [TestCase("using GO = UnityEngine.GameObject; GO host = new GO(\"alias\");", 1)]
-        [TestCase("GameObject.CreatePrimitive(PrimitiveType.Cube);", 1)]
-        [TestCase("Object.Instantiate(prefab);", 1)]
-        [TestCase("Object.Instantiate<GameObject>(prefab);", 1)]
-        [TestCase("PrefabUtility.InstantiatePrefab(prefab);", 1)]
-        [TestCase("EditorUtility.CreateGameObjectWithHideFlags(\"unsafe\", HideFlags.None);", 1)]
-        [TestCase(
-            "EditorUtility.CreateGameObjectWithHideFlags(\"unsafe\", condition ? HideFlags.HideAndDontSave : HideFlags.None);",
-            1
-        )]
-        [TestCase("string value = $\"{new GameObject(\"unsafe\")}\";", 1)]
-        [TestCase(
-            "GameObject receiver; void Probe() { FlowGraphComponentNode receiver; receiver = new(); }",
-            0
-        )]
-        [TestCase("GameObject host = condition ? Make() : Wrap(new());", 0)]
+        private static readonly string ScanFiller = BuildScanFiller(200);
+
+        private static IEnumerable<TestCaseData> ConstructionCases()
+        {
+            yield return Case("classic", "GameObject host = new GameObject(\"classic\");", 1);
+            yield return Case(
+                "object initializer",
+                "GameObject host = new GameObject { name = \"initializer\" };",
+                1
+            );
+            yield return Case(
+                "qualified",
+                "UnityEngine.GameObject host = new UnityEngine.GameObject(\"qualified\");",
+                1
+            );
+            yield return Case("target typed", "GameObject host = new(\"target typed\");", 1);
+            yield return Case("parenthesized", "GameObject host = (new(\"parenthesized\"));", 1);
+            yield return Case("deferred", "GameObject host;\nhost = new(\"deferred\");", 1);
+            yield return Case(
+                "parenthesized deferred",
+                "GameObject host;\nhost = (new(\"parenthesized deferred\"));",
+                1
+            );
+            yield return Case(
+                "shadowed local in a sibling method",
+                "void First() { GameObject receiver = new(\"unsafe\"); }\n"
+                    + "void Second() { FlowGraphComponentNode receiver = new(); }",
+                1
+            );
+            yield return Case("comment", "// GameObject host = new(\"comment\");", 0);
+            yield return Case(
+                "string literal",
+                "string sample = \"GameObject host = new(\\\"text\\\");\";",
+                0
+            );
+            yield return Case(
+                "hide flag factory",
+                "GameObject host = EditorUtility.CreateGameObjectWithHideFlags(\"safe\", HideFlags.HideAndDontSave);",
+                0
+            );
+            yield return Case(
+                "property initializer",
+                "GameObject Host { get; } = new(\"property\");",
+                1
+            );
+            yield return Case("expression bodied", "GameObject CreateHost() => new(\"arrow\");", 1);
+            yield return Case("return", "GameObject CreateHost() { return new(\"return\"); }", 1);
+            yield return Case(
+                "conditional return",
+                "GameObject CreateHost() { return condition ? new(\"return\") : null; }",
+                1
+            );
+            yield return Case("getter", "GameObject Host { get { return new(\"getter\"); } }", 1);
+            yield return Case(
+                "lambda factory",
+                "Func<GameObject> factory = () => new(\"lambda\");",
+                1
+            );
+            yield return Case(
+                "ternary branch",
+                "GameObject host = condition ? new(\"branch\") : null;",
+                1
+            );
+            yield return Case("array initializer", "GameObject[] hosts = { new(\"array\") };", 1);
+            yield return Case(
+                "explicit array initializer",
+                "GameObject[] hosts = new GameObject[] { new(\"explicit array\") };",
+                1
+            );
+            yield return Case("member target", "GameObject host; this.host = new(\"member\");", 1);
+            yield return Case(
+                "null coalescing assignment",
+                "GameObject host; host ??= new(\"coalesce\");",
+                1
+            );
+            yield return Case(
+                "using alias",
+                "using GO = UnityEngine.GameObject; GO host = new GO(\"alias\");",
+                1
+            );
+            yield return Case(
+                "create primitive",
+                "GameObject.CreatePrimitive(PrimitiveType.Cube);",
+                1
+            );
+            yield return Case("instantiate", "Object.Instantiate(prefab);", 1);
+            yield return Case("generic instantiate", "Object.Instantiate<GameObject>(prefab);", 1);
+            yield return Case("instantiate prefab", "PrefabUtility.InstantiatePrefab(prefab);", 1);
+            yield return Case(
+                "hide flag factory without hide and dont save",
+                "EditorUtility.CreateGameObjectWithHideFlags(\"unsafe\", HideFlags.None);",
+                1
+            );
+            yield return Case(
+                "hide flag factory with a conditional flag",
+                "EditorUtility.CreateGameObjectWithHideFlags(\"unsafe\", condition ? HideFlags.HideAndDontSave : HideFlags.None);",
+                1
+            );
+            yield return Case(
+                "interpolation hole",
+                "string value = $\"{new GameObject(\"unsafe\")}\";",
+                1
+            );
+            yield return Case(
+                "shadowed local in a nested scope",
+                "GameObject receiver; void Probe() { FlowGraphComponentNode receiver; receiver = new(); }",
+                0
+            );
+            yield return Case(
+                "nested call argument",
+                "GameObject host = condition ? Make() : Wrap(new());",
+                0
+            );
+        }
+
+        private static TestCaseData Case(string name, string source, int expectedCount)
+        {
+            return new TestCaseData(source, expectedCount).SetName($"{{m}}({name})");
+        }
+
+        [TestCaseSource(nameof(ConstructionCases))]
         public void ScannerFindsOnlyActiveSceneGameObjectConstruction(
             string source,
             int expectedCount
@@ -81,6 +159,49 @@ namespace DxMessaging.Tests.Editor
                 Is.EqualTo(expectedCount),
                 $"Source '{source}' should report {expectedCount} unsafe construction(s), but "
                     + $"reported {actual.Count}: {string.Join(" | ", actual.Select(item => item.Display))}."
+            );
+        }
+
+        /// <summary>
+        /// The scanner answers line numbers, scope ends, and declaration lookups against a
+        /// per-file index, and every one of those is position-sensitive. The isolated cases are
+        /// all single-scope one-liners, so they cannot catch an index that resolves the wrong
+        /// entry once a file is large. Embedding each case after unrelated but structurally busy
+        /// code -- nested scopes, hundreds of declarations, and a benign target-typed
+        /// construction per method -- pins those lookups to the right entry.
+        /// <see cref="EditModeFixturesDoNotConstructGameObjectsInDeveloperScenes"/> remains the
+        /// scale guard; it scans the real corpus and is what caught the quadratic scan.
+        /// </summary>
+        [TestCaseSource(nameof(ConstructionCases))]
+        public void ScannerResultsDoNotDependOnSurroundingFileSize(string source, int expectedCount)
+        {
+            int fillerLines = ScanFiller.Count(character => character == '\n');
+
+            IReadOnlyList<EditModeGameObjectConstruction> isolated =
+                EditModeGameObjectConstructionScanner.Find("Tests/Editor/Probe.cs", source);
+            IReadOnlyList<EditModeGameObjectConstruction> embedded =
+                EditModeGameObjectConstructionScanner.Find(
+                    "Tests/Editor/Probe.cs",
+                    ScanFiller + source
+                );
+
+            Assert.That(
+                embedded.Count,
+                Is.EqualTo(expectedCount),
+                $"Source '{source}' preceded by {ScanFiller.Length} characters of unrelated code "
+                    + $"should still report {expectedCount} unsafe construction(s), but reported "
+                    + $"{embedded.Count}: {string.Join(" | ", embedded.Select(item => item.Display))}."
+            );
+            Assert.That(
+                embedded.Select(item => item.SourceLine).ToArray(),
+                Is.EqualTo(isolated.Select(item => item.SourceLine).ToArray()),
+                $"Source '{source}' should report the same lines regardless of file size."
+            );
+            Assert.That(
+                embedded.Select(item => item.LineNumber).ToArray(),
+                Is.EqualTo(isolated.Select(item => item.LineNumber + fillerLines).ToArray()),
+                $"Source '{source}' should report line numbers offset by exactly the "
+                    + $"{fillerLines} filler lines that precede it."
             );
         }
 
@@ -225,6 +346,33 @@ namespace DxMessaging.Tests.Editor
             }
         }
 
+        /// <summary>
+        /// Unrelated but structurally busy code: nested scopes, local declarations, and a benign
+        /// target-typed construction per method, none of which the scanner may report.
+        /// </summary>
+        private static string BuildScanFiller(int methods)
+        {
+            StringBuilder builder = new();
+            for (int index = 0; index < methods; index++)
+            {
+                builder
+                    .Append("private int DxFiller")
+                    .Append(index)
+                    .Append("(int dxSeed")
+                    .Append(index)
+                    .Append(")\n{\n    List<int> dxValues")
+                    .Append(index)
+                    .Append(" = new();\n    dxValues")
+                    .Append(index)
+                    .Append(".Add(dxSeed")
+                    .Append(index)
+                    .Append(");\n    return dxValues")
+                    .Append(index)
+                    .Append("[0];\n}\n");
+            }
+            return builder.ToString();
+        }
+
         private static string GetPackageRoot()
         {
             return Path.GetFullPath(
@@ -302,6 +450,57 @@ namespace DxMessaging.Tests.Editor
             RegexOptions.Compiled
         );
 
+        private static readonly Regex ArrayInitializerTarget = new(
+            @"\b(?:(?:global::)?UnityEngine\.)?GameObject\s*\[\]\s+[A-Za-z_]\w*\s*=\s*{[^}]*$",
+            RegexOptions.Compiled
+        );
+
+        private static readonly Regex ReturnKeyword = new(@"\breturn\b", RegexOptions.Compiled);
+
+        private static readonly Regex GameObjectFactoryLambda = new(
+            @"\bFunc\s*<\s*(?:(?:global::)?UnityEngine\.)?GameObject\s*>[^;]*=>[^;]*$",
+            RegexOptions.Compiled
+        );
+
+        private static readonly Regex GetterReturn = new(
+            @"\bget\s*{[^{}]*\breturn\b",
+            RegexOptions.Compiled
+        );
+
+        private static readonly Regex EmptyTargetPrefix = new(
+            @"^\s*\(*\s*$",
+            RegexOptions.Compiled
+        );
+
+        private static readonly Regex ExemptionIdFormat = new(
+            @"^[a-z0-9]+(?:-[a-z0-9]+)*$",
+            RegexOptions.Compiled
+        );
+
+        /// <summary>
+        /// Name-agnostic form of the per-name declaration probe. Matching it once per file and
+        /// grouping by name replaces one whole-prefix scan per construction, which is what made
+        /// the scan superlinear in file length.
+        /// </summary>
+        private static readonly Regex Declaration = new(
+            @"(?<type>[A-Za-z_][\w.:<>?\[\]]*)\s+(?<name>[A-Za-z_]\w*)\s*(?:[;=,\){])",
+            RegexOptions.Compiled
+        );
+
+        /// <summary>
+        /// Patterns interpolated from a GameObject type name. Building them inline recompiles on
+        /// every call, because interpolated patterns evict each other from the regex cache.
+        /// </summary>
+        private static readonly ConcurrentDictionary<string, Regex> InterpolatedPatterns = new();
+
+        private static Regex ForPattern(string pattern)
+        {
+            return InterpolatedPatterns.GetOrAdd(
+                pattern,
+                key => new Regex(key, RegexOptions.Compiled)
+            );
+        }
+
         internal static IReadOnlyList<EditModeGameObjectConstruction> Find(
             string relativePath,
             string source
@@ -329,6 +528,7 @@ namespace DxMessaging.Tests.Editor
                 gameObjectTypes.Add(alias.Groups["alias"].Value);
             }
 
+            ScanIndex scan = new(sanitized, gameObjectTypes);
             List<int> constructionIndexes = new();
             foreach (Match construction in ExplicitConstruction.Matches(sanitized))
             {
@@ -340,7 +540,7 @@ namespace DxMessaging.Tests.Editor
 
             foreach (Match construction in ImplicitConstruction.Matches(sanitized))
             {
-                if (IsGameObjectTarget(sanitized, construction.Index, gameObjectTypes))
+                if (IsGameObjectTarget(scan, construction.Index))
                 {
                     constructionIndexes.Add(construction.Index);
                 }
@@ -381,15 +581,7 @@ namespace DxMessaging.Tests.Editor
             List<EditModeGameObjectConstruction> results = new();
             foreach (int index in constructionIndexes.Distinct().OrderBy(value => value))
             {
-                int lineNumber = 1;
-                for (int cursor = 0; cursor < index; cursor++)
-                {
-                    if (sanitized[cursor] == '\n')
-                    {
-                        lineNumber++;
-                    }
-                }
-
+                int lineNumber = scan.LineNumberAt(index);
                 string sourceLine = sourceLines[lineNumber - 1].Trim();
                 string exemptionId = ParseExemptionId(lexed.LineComments, lineNumber);
                 results.Add(
@@ -405,12 +597,10 @@ namespace DxMessaging.Tests.Editor
             return results;
         }
 
-        private static bool IsGameObjectTarget(
-            string source,
-            int constructionIndex,
-            ISet<string> gameObjectTypes
-        )
+        private static bool IsGameObjectTarget(ScanIndex scan, int constructionIndex)
         {
+            string source = scan.Source;
+            ISet<string> gameObjectTypes = scan.GameObjectTypes;
             int statementStart = source.LastIndexOf(';', Math.Max(0, constructionIndex - 1));
             string statement = source.Substring(
                 statementStart + 1,
@@ -422,10 +612,7 @@ namespace DxMessaging.Tests.Editor
                     IsTopLevelTargetExpression(statement)
                     || IsParenthesizedTargetExpression(statement)
                     || IsExplicitGameObjectArrayInitializer(statement, gameObjectTypes)
-                    || Regex.IsMatch(
-                        statement,
-                        @"\b(?:(?:global::)?UnityEngine\.)?GameObject\s*\[\]\s+[A-Za-z_]\w*\s*=\s*{[^}]*$"
-                    )
+                    || ArrayInitializerTarget.IsMatch(statement)
                 )
             )
             {
@@ -436,10 +623,10 @@ namespace DxMessaging.Tests.Editor
             string window = source.Substring(windowStart, constructionIndex - windowStart);
             if (
                 gameObjectTypes.Any(type =>
-                    Regex.IsMatch(
-                        window,
-                        $@"(?:^|[^\w.]){Regex.Escape(type)}\s+[A-Za-z_]\w*\s*{{[^{{}}]*}}\s*=\s*$"
-                    )
+                    ForPattern(
+                            $@"(?:^|[^\w.]){Regex.Escape(type)}\s+[A-Za-z_]\w*\s*{{[^{{}}]*}}\s*=\s*$"
+                        )
+                        .IsMatch(window)
                 )
             )
             {
@@ -449,35 +636,25 @@ namespace DxMessaging.Tests.Editor
             Match assigned = AssignedTarget.Match(statement);
             if (assigned.Success)
             {
-                return ResolvesToGameObject(
-                    source,
-                    assigned.Groups["name"].Value,
-                    constructionIndex,
-                    gameObjectTypes
-                );
+                return scan.ResolvesToGameObject(assigned.Groups["name"].Value, constructionIndex);
             }
 
-            if (Regex.IsMatch(statement, @"\breturn\b"))
+            if (ReturnKeyword.IsMatch(statement))
             {
-                if (IsInsideGameObjectReturningMethod(source, constructionIndex, gameObjectTypes))
+                if (scan.IsInsideGameObjectReturningMethod(constructionIndex))
                 {
                     return true;
                 }
             }
 
-            if (
-                Regex.IsMatch(
-                    statement,
-                    @"\bFunc\s*<\s*(?:(?:global::)?UnityEngine\.)?GameObject\s*>[^;]*=>[^;]*$"
-                )
-            )
+            if (GameObjectFactoryLambda.IsMatch(statement))
             {
                 return true;
             }
 
-            if (Regex.IsMatch(statement, @"\bget\s*{[^{}]*\breturn\b"))
+            if (GetterReturn.IsMatch(statement))
             {
-                return IsInsideGameObjectProperty(source, constructionIndex, gameObjectTypes);
+                return scan.IsInsideGameObjectProperty(constructionIndex);
             }
 
             return IsInsideExpressionBodiedGameObjectMethod(
@@ -493,10 +670,8 @@ namespace DxMessaging.Tests.Editor
             {
                 string escaped = Regex.Escape(type);
                 if (
-                    Regex.IsMatch(
-                        text,
-                        $@"(?:^|[^\w.]){escaped}\s*(?:\[\])?\s*\??\s+[A-Za-z_]\w*[^;]*="
-                    )
+                    ForPattern($@"(?:^|[^\w.]){escaped}\s*(?:\[\])?\s*\??\s+[A-Za-z_]\w*[^;]*=")
+                        .IsMatch(text)
                 )
                 {
                     return true;
@@ -514,7 +689,7 @@ namespace DxMessaging.Tests.Editor
             }
 
             string targetPrefix = statement.Substring(assignment + 1);
-            return Regex.IsMatch(targetPrefix, @"^\s*\(*\s*$");
+            return EmptyTargetPrefix.IsMatch(targetPrefix);
         }
 
         private static bool IsExplicitGameObjectArrayInitializer(
@@ -530,57 +705,9 @@ namespace DxMessaging.Tests.Editor
 
             string targetPrefix = statement.Substring(assignment + 1);
             return gameObjectTypes.Any(type =>
-                Regex.IsMatch(
-                    targetPrefix,
-                    $@"^\s*new\s+{Regex.Escape(type)}\s*\[\s*\]\s*\{{[^{{}}]*$"
-                )
+                ForPattern($@"^\s*new\s+{Regex.Escape(type)}\s*\[\s*\]\s*\{{[^{{}}]*$")
+                    .IsMatch(targetPrefix)
             );
-        }
-
-        private static bool ResolvesToGameObject(
-            string source,
-            string name,
-            int constructionIndex,
-            ISet<string> gameObjectTypes
-        )
-        {
-            Regex declaration = new(
-                $@"(?<type>[A-Za-z_][\w.:<>?\[\]]*)\s+{Regex.Escape(name)}\s*(?:[;=,\){{])"
-            );
-            Match nearest = declaration
-                .Matches(source.Substring(0, constructionIndex))
-                .Cast<Match>()
-                .Where(match => constructionIndex < FindEnclosingScopeEnd(source, match.Index))
-                .LastOrDefault();
-            return nearest != null
-                && gameObjectTypes.Contains(nearest.Groups["type"].Value.TrimEnd('?'));
-        }
-
-        private static bool IsInsideGameObjectReturningMethod(
-            string source,
-            int constructionIndex,
-            ISet<string> gameObjectTypes
-        )
-        {
-            foreach (string type in gameObjectTypes)
-            {
-                Regex method = new(
-                    $@"(?:^|[^\w.]){Regex.Escape(type)}\s+[A-Za-z_]\w*\s*\([^;{{}}]*\)\s*{{"
-                );
-                foreach (Match match in method.Matches(source))
-                {
-                    int openBrace = source.IndexOf('{', match.Index);
-                    if (
-                        openBrace >= 0
-                        && openBrace < constructionIndex
-                        && constructionIndex < FindMatchingBrace(source, openBrace)
-                    )
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
         }
 
         private static bool IsInsideExpressionBodiedGameObjectMethod(
@@ -598,47 +725,9 @@ namespace DxMessaging.Tests.Editor
 
             string signature = source.Substring(semicolon + 1, arrow - semicolon - 1);
             return gameObjectTypes.Any(type =>
-                Regex.IsMatch(
-                    signature,
-                    $@"(?:^|[^\w.]){Regex.Escape(type)}\s+[A-Za-z_]\w*\s*\([^)]*\)\s*$"
-                )
+                ForPattern($@"(?:^|[^\w.]){Regex.Escape(type)}\s+[A-Za-z_]\w*\s*\([^)]*\)\s*$")
+                    .IsMatch(signature)
             );
-        }
-
-        private static int FindEnclosingScopeEnd(string source, int declarationIndex)
-        {
-            Stack<int> openBraces = new();
-            for (int index = 0; index < declarationIndex; index++)
-            {
-                if (source[index] == '{')
-                {
-                    openBraces.Push(index);
-                }
-                else if (source[index] == '}' && openBraces.Count > 0)
-                {
-                    openBraces.Pop();
-                }
-            }
-            return openBraces.Count == 0
-                ? source.Length
-                : FindMatchingBrace(source, openBraces.Peek());
-        }
-
-        private static int FindMatchingBrace(string source, int openBrace)
-        {
-            int depth = 0;
-            for (int index = openBrace; index < source.Length; index++)
-            {
-                if (source[index] == '{')
-                {
-                    depth++;
-                }
-                else if (source[index] == '}' && --depth == 0)
-                {
-                    return index;
-                }
-            }
-            return source.Length;
         }
 
         private static int FindMatchingParenthesis(string source, int openParenthesis)
@@ -680,31 +769,6 @@ namespace DxMessaging.Tests.Editor
                 }
             }
             return depth == 0;
-        }
-
-        private static bool IsInsideGameObjectProperty(
-            string source,
-            int constructionIndex,
-            ISet<string> gameObjectTypes
-        )
-        {
-            foreach (string type in gameObjectTypes)
-            {
-                Regex property = new($@"(?:^|[^\w.]){Regex.Escape(type)}\s+[A-Za-z_]\w*\s*{{");
-                foreach (Match match in property.Matches(source))
-                {
-                    int openBrace = source.IndexOf('{', match.Index);
-                    if (
-                        openBrace >= 0
-                        && openBrace < constructionIndex
-                        && constructionIndex < FindMatchingBrace(source, openBrace)
-                    )
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
         }
 
         private static IReadOnlyList<string> SplitTopLevelArguments(string arguments)
@@ -750,7 +814,7 @@ namespace DxMessaging.Tests.Editor
             }
 
             string id = trimmed.Substring(ExemptionPrefix.Length).Trim();
-            return Regex.IsMatch(id, @"^[a-z0-9]+(?:-[a-z0-9]+)*$") ? id : string.Empty;
+            return ExemptionIdFormat.IsMatch(id) ? id : string.Empty;
         }
 
         private static LexedSource Lex(string source)
@@ -975,6 +1039,236 @@ namespace DxMessaging.Tests.Editor
 
             internal string Sanitized { get; }
             internal IReadOnlyDictionary<int, string> LineComments { get; }
+        }
+
+        private readonly struct BraceSpan
+        {
+            internal BraceSpan(int open, int close)
+            {
+                Open = open;
+                Close = close;
+            }
+
+            internal int Open { get; }
+            internal int Close { get; }
+
+            internal bool Contains(int index)
+            {
+                return Open < index && index < Close;
+            }
+        }
+
+        private readonly struct TypedDeclaration
+        {
+            internal TypedDeclaration(int start, int end, string type)
+            {
+                Start = start;
+                End = end;
+                Type = type;
+            }
+
+            internal int Start { get; }
+            internal int End { get; }
+            internal string Type { get; }
+        }
+
+        /// <summary>
+        /// Whole-file lookups computed once per <see cref="Find"/> call. Every query the scanner
+        /// used to answer by re-scanning the source per construction -- line numbers, brace
+        /// matching, enclosing scope ends, declarations by name, and GameObject-returning method
+        /// and property bodies -- resolves here against a prebuilt index instead, which is what
+        /// keeps the scan linear in file length rather than quadratic.
+        /// </summary>
+        private sealed class ScanIndex
+        {
+            private readonly int[] _lineStarts;
+            private readonly Dictionary<int, int> _closeByOpenBrace;
+            private readonly int[] _scopeChangeAt;
+            private readonly int[] _scopeChangeEnd;
+            private Dictionary<string, List<TypedDeclaration>> _declarationsByName;
+            private List<BraceSpan> _gameObjectMethodBodies;
+            private List<BraceSpan> _gameObjectPropertyBodies;
+
+            internal ScanIndex(string source, ISet<string> gameObjectTypes)
+            {
+                Source = source;
+                GameObjectTypes = gameObjectTypes;
+
+                List<int> lineStarts = new() { 0 };
+                List<int> scopeChangeAt = new() { 0 };
+                List<int> scopeChangeOpenBrace = new() { -1 };
+                Stack<int> openBraces = new();
+                _closeByOpenBrace = new Dictionary<int, int>();
+
+                for (int index = 0; index < source.Length; index++)
+                {
+                    char current = source[index];
+                    if (current == '\n')
+                    {
+                        lineStarts.Add(index + 1);
+                    }
+                    else if (current == '{')
+                    {
+                        openBraces.Push(index);
+                        scopeChangeAt.Add(index + 1);
+                        scopeChangeOpenBrace.Add(index);
+                    }
+                    else if (current == '}' && openBraces.Count > 0)
+                    {
+                        _closeByOpenBrace[openBraces.Pop()] = index;
+                        scopeChangeAt.Add(index + 1);
+                        scopeChangeOpenBrace.Add(openBraces.Count > 0 ? openBraces.Peek() : -1);
+                    }
+                }
+
+                _lineStarts = lineStarts.ToArray();
+                _scopeChangeAt = scopeChangeAt.ToArray();
+                _scopeChangeEnd = new int[scopeChangeOpenBrace.Count];
+                for (int change = 0; change < scopeChangeOpenBrace.Count; change++)
+                {
+                    int openBrace = scopeChangeOpenBrace[change];
+                    _scopeChangeEnd[change] = MatchingBrace(openBrace);
+                }
+            }
+
+            internal string Source { get; }
+
+            internal ISet<string> GameObjectTypes { get; }
+
+            internal int LineNumberAt(int index)
+            {
+                return FloorIndex(_lineStarts, index) + 1;
+            }
+
+            /// <summary>
+            /// Matches the enclosing-scope rule the recursive scan used: the innermost brace open
+            /// before <paramref name="index"/>, resolved to its close, or the end of the source
+            /// when nothing encloses it.
+            /// </summary>
+            internal int EnclosingScopeEnd(int index)
+            {
+                return _scopeChangeEnd[FloorIndex(_scopeChangeAt, index)];
+            }
+
+            internal bool ResolvesToGameObject(string name, int constructionIndex)
+            {
+                EnsureDeclarations();
+                if (!_declarationsByName.TryGetValue(name, out List<TypedDeclaration> declarations))
+                {
+                    return false;
+                }
+
+                for (int index = declarations.Count - 1; index >= 0; index--)
+                {
+                    TypedDeclaration declaration = declarations[index];
+                    if (declaration.End > constructionIndex)
+                    {
+                        continue;
+                    }
+                    if (constructionIndex >= EnclosingScopeEnd(declaration.Start))
+                    {
+                        continue;
+                    }
+                    return GameObjectTypes.Contains(declaration.Type.TrimEnd('?'));
+                }
+
+                return false;
+            }
+
+            internal bool IsInsideGameObjectReturningMethod(int constructionIndex)
+            {
+                _gameObjectMethodBodies ??= FindBodies(type =>
+                    $@"(?:^|[^\w.]){Regex.Escape(type)}\s+[A-Za-z_]\w*\s*\([^;{{}}]*\)\s*{{"
+                );
+                return IsInsideAny(_gameObjectMethodBodies, constructionIndex);
+            }
+
+            internal bool IsInsideGameObjectProperty(int constructionIndex)
+            {
+                _gameObjectPropertyBodies ??= FindBodies(type =>
+                    $@"(?:^|[^\w.]){Regex.Escape(type)}\s+[A-Za-z_]\w*\s*{{"
+                );
+                return IsInsideAny(_gameObjectPropertyBodies, constructionIndex);
+            }
+
+            private int MatchingBrace(int openBrace)
+            {
+                return openBrace >= 0 && _closeByOpenBrace.TryGetValue(openBrace, out int close)
+                    ? close
+                    : Source.Length;
+            }
+
+            private void EnsureDeclarations()
+            {
+                if (_declarationsByName != null)
+                {
+                    return;
+                }
+
+                _declarationsByName = new Dictionary<string, List<TypedDeclaration>>(
+                    StringComparer.Ordinal
+                );
+                foreach (Match match in Declaration.Matches(Source))
+                {
+                    string name = match.Groups["name"].Value;
+                    if (
+                        !_declarationsByName.TryGetValue(
+                            name,
+                            out List<TypedDeclaration> declarations
+                        )
+                    )
+                    {
+                        declarations = new List<TypedDeclaration>();
+                        _declarationsByName[name] = declarations;
+                    }
+                    declarations.Add(
+                        new TypedDeclaration(
+                            match.Index,
+                            match.Index + match.Length,
+                            match.Groups["type"].Value
+                        )
+                    );
+                }
+            }
+
+            private List<BraceSpan> FindBodies(Func<string, string> patternForType)
+            {
+                List<BraceSpan> bodies = new();
+                foreach (string type in GameObjectTypes)
+                {
+                    foreach (Match match in ForPattern(patternForType(type)).Matches(Source))
+                    {
+                        int openBrace = Source.IndexOf('{', match.Index);
+                        if (openBrace >= 0)
+                        {
+                            bodies.Add(new BraceSpan(openBrace, MatchingBrace(openBrace)));
+                        }
+                    }
+                }
+                return bodies;
+            }
+
+            private static bool IsInsideAny(List<BraceSpan> bodies, int index)
+            {
+                foreach (BraceSpan body in bodies)
+                {
+                    if (body.Contains(index))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            private static int FloorIndex(int[] sortedPositions, int index)
+            {
+                int position = Array.BinarySearch(sortedPositions, index);
+                if (position < 0)
+                {
+                    position = ~position - 1;
+                }
+                return Math.Max(0, position);
+            }
         }
     }
 


### PR DESCRIPTION
Closes #407.

## What was wrong

`EditModeGameObjectConstructionScanner.Find` answered every question by re-scanning the file for each candidate construction, so its cost grew with the square of file length. `EditModeFixturesDoNotConstructGameObjectsInDeveloperScenes` blew its 180s timeout under full-suite load while passing in isolation, and the two largest editor-window fixtures were still growing.

## Where the cost actually was

The scanner is pure .NET, so it was extracted into a throwaway harness that runs the shipped and the `HEAD` implementation side by side over the real corpus. Ablation on the 508 KB flow-graph fixture:

| Configuration | Elapsed |
| --- | --- |
| Unmodified | 7958 ms |
| `IsInsideGameObjectReturningMethod` stubbed | 8091 ms |
| `ResolvesToGameObject` stubbed | **16 ms** |

`ResolvesToGameObject` is 99.8% of the run. The issue named three suspects; only one mattered, and it was not the one it led with. Splitting it further, removing the `FindEnclosingScopeEnd` call only drops 7958 ms to 7045 ms, so the dominant term is the per-construction `source.Substring(0, constructionIndex)` plus a full regex scan of that prefix -- 266 constructions against a ~250 KB average prefix -- with a pattern interpolated from the assigned identifier, and therefore recompiled every call because interpolated patterns evict each other from .NET's 15-entry regex cache.

## The fix

Every positional question resolves against a `ScanIndex` built once per `Find` call: line numbers from a line-start table, matching braces and enclosing scope ends from one stack sweep recorded as binary-searchable change points, declarations from one name-agnostic pass grouped by name, GameObject-returning method and property bodies collected once and lazily, and type-interpolated patterns cached instead of recompiled.

## Findings are unchanged, and that is measured rather than argued

| Corpus | Result |
| --- | --- |
| All 534 C# files in the repository (9.5 MB) | byte-identical findings |
| All 32 scanner cases | byte-identical findings |
| 4000 fuzzed inputs (synthetic fragments, random corpus slices) | 0 divergences |

## Effect

| Scope | Before | After |
| --- | --- | --- |
| Corpus scan, 534 files | 20 650 ms | **184 ms** |
| Cost curve (4x input) | 11.7x time | **3.7x time** |
| `EditModeSceneSafetyContractTests` | 36 tests, 58.5 s | **68 tests, 4.2 s** |
| `WallstopStudios.DxMessaging.Tests.Editor` | 746 pass, **1 fail**, 432 s | **779 pass, 0 fail**, **107 s** |

The whole EditMode assembly is 4x faster while running 32 more tests.

That time is spent inside the organization lock window on every editor leg, and CI confirms it. Across the last 24 green `Unity Tests` runs on `master` (52 successful editor legs), split at the #394 merge that introduced this scanner:

| Step | Before (n=24) | After (n=28) | Delta |
| --- | --- | --- | --- |
| `Run Unity Test Runner` (EditMode) | 35.8s | **113.8s** | **+78.0s** |
| `Run Unity PlayMode tests` | 50.7s | 48.2s | -2.5s |
| `Run Unity standalone tests` | 63.3s | 57.6s | -5.7s |

The regression is isolated to EditMode. This PR's four legs run it in 37s, 37s, 27s and 44s -- mean **36.3s**, back inside the pre-#394 band, recovering ~5.2 min of licensed, lock-held time per run. Measurements posted to #337, which had concluded that the licensed section was irreducible.

## Guard

`ScannerResultsDoNotDependOnSurroundingFileSize` runs every scanner case alone and again after unrelated but structurally busy code, asserting identical findings and line numbers offset by exactly the filler's line count. The isolated cases are single-scope one-liners, so they cannot catch an index that resolves the wrong entry once a file is large; this one can. `EditModeFixturesDoNotConstructGameObjectsInDeveloperScenes` stays the scale guard, since it scans the real corpus and is what caught this.

The first version sized that filler to blow the per-test timeout on a quadratic re-regression. It worked and it was wrong: the fixture measured 136.9 s. Buying a canary with 78 s of every EditMode leg, in a change whose whole purpose is CI margin, is a bad trade, and it duplicated a guard that already exists. The filler is now 200 methods and the fixture is 4.2 s.

The 32 cases moved from stacked `[TestCase]` attributes to a shared `[TestCaseSource]` so both tests run the same data.

## The issue's two open questions

- **The 8 inconclusive EditMode tests are not silently skipping coverage.** All 8 are `SampleQualityContractTests` cases gated on `TryGetImportedSamplesRoot`, which asserts `fixtureExists || !IsContinuousIntegration()` before going inconclusive. The gate fails closed: in CI a missing `Assets/DxmCiSamples` is a failure, not a skip. Locally that fixture is not imported, so inconclusive is the honest result.
- **Class sweep.** Six test files under `Tests/` scan repository sources; only the scene-safety scanner re-scanned inside a per-candidate loop. The rest are single-pass with hoisted static patterns, and the only other in-method `new Regex(...)` in the tree is a one-shot `LogAssert.Expect` argument. Confirmed empirically too: the whole EditMode assembly now runs in 107 s with nothing near a timeout.

`.llm/skills/unity-test-execution/SKILL.md` records the rule as a sixth speed lever, since its levers all covered hosting and play-mode reload and none covered the tests' own algorithmic cost.

## Verification

- Host editor 6000.4.6f1 over `unity-mcp-remote`. Preflight `SAFE_TO_RUN=True`, `Assets/Refresh` run because this is C#, and assembly freshness proved by resolving the new test method and checking the assembly write time before trusting any run. Editor left with one clean scene, main stage, idle.
- `TestAttributeContractTests`, `InstanceIdSourceTests` and `PublicSurfaceContractTests` pass 21/21.
- `npm test` 421 pass; `validate:all`, `check:spelling`, `markdownlint-cli2`, `csharpier` and the pre-commit hook set all pass.
- No `CHANGELOG.md` entry: test-only code, no user-facing behavior change.
