### PR TITLE
Speed up interceptor and post-processing dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   policy ([#367](https://github.com/Ambiguous-Interactive/DxMessaging/issues/367)).
 - Point the Package Manager **Changelog** link at the rendered changelog instead of raw Markdown
   ([#362](https://github.com/Ambiguous-Interactive/DxMessaging/issues/362)).
+- Dispatch faster when a message type has interceptors or post-processors: interceptors are
+  resolved once when registrations change instead of being re-collected on every emission, and
+  emissions no longer repeat handler and post-processor lookups the bus already resolved. One
+  interceptor costs roughly half what it did, and four cost roughly a quarter
+  ([#408](https://github.com/Ambiguous-Interactive/DxMessaging/issues/408)).
 
 ### Fixed
 
+- Fix an interceptor registered or removed at a different priority than the running interceptor
+  taking effect during that same emission; interceptor changes now wait for the next emission, as
+  the snapshot semantics documentation already described
+  ([#408](https://github.com/Ambiguous-Interactive/DxMessaging/issues/408)).
 - Fix `DxMessagingStaticState.Reset()` from inside an interceptor so it stops the rest of the
   dispatch instead of invoking callbacks against reset bus state
   ([#395](https://github.com/Ambiguous-Interactive/DxMessaging/issues/395)).

--- a/Runtime/Core/MessageBus/MessageBus.cs
+++ b/Runtime/Core/MessageBus/MessageBus.cs
@@ -429,6 +429,28 @@ namespace DxMessaging.Core.MessageBus
             public ContextHandlerMap contextPost;
 
             /// <summary>
+            /// Interceptors for this message type, flattened into one
+            /// priority-ordered array at plan-refresh time (ascending priority
+            /// group, then registration order within a group - the same order
+            /// the per-emit walk over
+            /// <see cref="InterceptorCache{TValue}.handlers"/> produced). The
+            /// interceptor phase iterates this array directly, so it costs one
+            /// array read plus the delegate call per interceptor instead of a
+            /// typed cache lookup, a scratch-list rent, and a defensive
+            /// <see cref="List{T}"/> copy per priority group per emission.
+            /// <para>
+            /// <see cref="RefreshInterceptorPlan{TValue}"/> always assigns a
+            /// NEW array rather than mutating in place, so an emission already
+            /// iterating the previous array keeps a stable, frozen view: a
+            /// mutation performed by an interceptor or handler is observed by
+            /// the NEXT emission, matching the handler path's snapshot freeze
+            /// (see <see cref="DispatchSnapshot"/>).
+            /// </para>
+            /// </summary>
+            public object[] interceptors = Array.Empty<object>();
+            public int interceptorCount;
+
+            /// <summary>
             /// Drops every cached sink reference and forces a refresh on the
             /// next emission. Called by the sweep registry so evicted sink
             /// slots are not kept alive by plan references, and by
@@ -442,6 +464,8 @@ namespace DxMessaging.Core.MessageBus
                 scalarPost = null;
                 contextHandle = null;
                 contextPost = null;
+                interceptors = Array.Empty<object>();
+                interceptorCount = 0;
             }
         }
 
@@ -1567,7 +1591,6 @@ namespace DxMessaging.Core.MessageBus
             Type,
             Action<InstanceId, IBroadcastMessage>
         > _sourcedBroadcastMethodsByType = new();
-        private readonly Stack<List<object>> _innerInterceptorsStack = new();
 
         private readonly Dictionary<
             Type,
@@ -2918,7 +2941,6 @@ namespace DxMessaging.Core.MessageBus
             _untargetedBroadcastMethodsByType.Clear();
             _targetedBroadcastMethodsByType.Clear();
             _sourcedBroadcastMethodsByType.Clear();
-            _innerInterceptorsStack.Clear();
             _methodCache.Clear();
             _dirtyTypes.Clear();
             ReturnAllDirtyTargetCollections();
@@ -3649,6 +3671,7 @@ namespace DxMessaging.Core.MessageBus
                     planVersion != _dispatchPlanVersion
                     && RunUntargetedPostPhase<TMessage>(
                         ref typedMessage,
+                        planVersion,
                         DispatchSnapshot.Empty,
                         emissionId,
                         touchTick
@@ -3693,7 +3716,7 @@ namespace DxMessaging.Core.MessageBus
                 );
             }
 
-            if (!RunUntargetedInterceptors(ref typedMessage))
+            if (0 < plan.interceptorCount && !RunUntargetedInterceptors(ref typedMessage, plan))
             {
                 return;
             }
@@ -3704,11 +3727,18 @@ namespace DxMessaging.Core.MessageBus
                 BroadcastGlobalUntargeted(ref untargetedMessage, emissionId);
             }
 
-            bool foundAnyHandlers = InternalUntargetedBroadcast(ref typedMessage, emissionId);
+            // While the plan stamp still matches, no registration mutation has
+            // run since the plan was validated, so plan.scalarHandle IS what a
+            // live sink lookup returns. Only the mutated case pays the lookup.
+            bool foundAnyHandlers =
+                planVersion == _dispatchPlanVersion
+                    ? DispatchUntargetedHandlePhase(plan.scalarHandle, ref typedMessage, emissionId)
+                    : InternalUntargetedBroadcast(ref typedMessage, emissionId);
 
             if (
                 RunUntargetedPostPhase<TMessage>(
                     ref typedMessage,
+                    planVersion,
                     untargetedPostSnapshot,
                     emissionId,
                     touchTick
@@ -3729,23 +3759,32 @@ namespace DxMessaging.Core.MessageBus
         }
 
         /// <summary>
-        /// Live post-processing phase for untargeted emissions, shared by
-        /// the featured emit path and the fast lane's mid-emission-mutation
-        /// fallback. Re-checks the post sink LIVE (a post-processor
-        /// registered into a previously-snapshotless sink mid-emission is
-        /// observed here, matching the legacy lazy-freeze placement) and
-        /// dispatches the pre-frozen snapshot when one was acquired at
-        /// emission start.
+        /// Post-processing phase for untargeted emissions, shared by the
+        /// featured emit path and the fast lane's mid-emission-mutation
+        /// fallback. When <paramref name="planVersion"/> still matches the bus
+        /// stamp, no registration mutation ran during this emission, so the
+        /// snapshot frozen at emission start is exactly what a live re-check
+        /// would produce and the typed sink lookup is skipped. Once the stamp
+        /// has moved, the sink is re-checked LIVE (a post-processor registered
+        /// into a previously-snapshotless sink mid-emission is observed here,
+        /// matching the legacy lazy-freeze placement).
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool RunUntargetedPostPhase<TMessage>(
             ref TMessage typedMessage,
+            long planVersion,
             DispatchSnapshot prefrozenSnapshot,
             long emissionId,
             long touchTick
         )
             where TMessage : IUntargetedMessage
         {
+            if (planVersion == _dispatchPlanVersion)
+            {
+                return prefrozenSnapshot.IsInitialized
+                    && DispatchFlatSnapshot(prefrozenSnapshot, ref typedMessage);
+            }
+
             if (
                 !_scalarSinks[BusSinkIndex.UntargetedPostProcessDefault]
                     .TryGetValue<TMessage>(out HandlerCache<int, HandlerCache> sortedHandlers)
@@ -3788,15 +3827,71 @@ namespace DxMessaging.Core.MessageBus
             plan.scalarPost = post;
             plan.contextHandle = null;
             plan.contextPost = null;
-            bool hasInterceptors =
-                _untargetedInterceptsByType.TryGetValue<TMessage>(
-                    out InterceptorCache<object> interceptors
-                )
-                && interceptors.handlers.Count != 0;
+            _ = _untargetedInterceptsByType.TryGetValue<TMessage>(
+                out InterceptorCache<object> interceptors
+            );
+            bool hasInterceptors = RefreshInterceptorPlan(plan, interceptors);
             bool hasGlobal = 0 < _globalSlots.sharedHandlers.Count;
             bool hasPost = post != null && 0 < post.handlers.Count;
             plan.fastPath = !hasInterceptors && !hasGlobal && !hasPost;
             plan.version = _dispatchPlanVersion;
+        }
+
+        /// <summary>
+        /// Flattens an interceptor store's priority groups into the plan's
+        /// frozen, priority-ordered array and reports whether any interceptor
+        /// remains. Runs only on plan refresh (registration churn, sweep,
+        /// reset, settings reload), never per emission.
+        /// </summary>
+        /// <remarks>
+        /// The rebuilt array is always a fresh allocation. An emission that is
+        /// mid-iteration over the previous array therefore keeps walking a
+        /// stable, complete view even when an interceptor it invokes registers
+        /// or deregisters interceptors; the mutation lands in the array the
+        /// NEXT emission builds. That is the same freeze the handler phase
+        /// gets from <see cref="DispatchSnapshot"/>, applied to the
+        /// interceptor phase.
+        /// </remarks>
+        /// <returns><c>true</c> when at least one interceptor is registered.</returns>
+        private static bool RefreshInterceptorPlan(
+            DispatchPlan plan,
+            InterceptorCache<object> interceptors
+        )
+        {
+            SortedList<int, List<object>> groupsByPriority = interceptors?.handlers;
+            if (groupsByPriority == null || groupsByPriority.Count == 0)
+            {
+                plan.interceptors = Array.Empty<object>();
+                plan.interceptorCount = 0;
+                return false;
+            }
+
+            IList<List<object>> groups = groupsByPriority.Values;
+            int total = 0;
+            for (int index = 0; index < groups.Count; ++index)
+            {
+                total += groups[index].Count;
+            }
+
+            if (total == 0)
+            {
+                plan.interceptors = Array.Empty<object>();
+                plan.interceptorCount = 0;
+                return false;
+            }
+
+            object[] flattened = new object[total];
+            int next = 0;
+            for (int index = 0; index < groups.Count; ++index)
+            {
+                List<object> group = groups[index];
+                group.CopyTo(flattened, next);
+                next += group.Count;
+            }
+
+            plan.interceptors = flattened;
+            plan.interceptorCount = next;
+            return true;
         }
 
         /// <inheritdoc />
@@ -3921,7 +4016,9 @@ namespace DxMessaging.Core.MessageBus
                     }
                 }
                 else if (
-                    InternalTargetedWithoutTargetingBroadcast(
+                    DispatchTargetedWithoutTargetingPhase(
+                        null,
+                        false,
                         ref target,
                         ref typedMessage,
                         emissionId
@@ -3941,6 +4038,7 @@ namespace DxMessaging.Core.MessageBus
                         ref target,
                         target,
                         ref typedMessage,
+                        planVersion,
                         DispatchSnapshot.Empty,
                         DispatchSnapshot.Empty,
                         emissionId
@@ -4012,7 +4110,10 @@ namespace DxMessaging.Core.MessageBus
             // Capture the pre-interceptor target so post-processing can detect a
             // rewritten id and re-resolve its snapshot against the final target.
             InstanceId preInterceptorTarget = target;
-            if (!RunTargetedInterceptors(ref typedMessage, ref target))
+            if (
+                0 < plan.interceptorCount
+                && !RunTargetedInterceptors(ref typedMessage, ref target, plan)
+            )
             {
                 return;
             }
@@ -4241,9 +4342,24 @@ namespace DxMessaging.Core.MessageBus
 #endif
             }
 
+            // The target-keyed handle sink is re-resolved LIVE only once the
+            // plan stamp has moved; while it still matches, no interceptor or
+            // global handler mutated registrations and plan.contextHandle IS
+            // what a live lookup returns.
+            bool planStillValid = planVersion == _dispatchPlanVersion;
+            ContextHandlerMap targetedHandlers;
+            if (planStillValid)
+            {
+                targetedHandlers = plan.contextHandle;
+            }
+            else
+            {
+                _ = _contextSinks[BusContextIndex.TargetedHandleDefault]
+                    .TryGetValue<TMessage>(out targetedHandlers);
+            }
+
             if (
-                _contextSinks[BusContextIndex.TargetedHandleDefault]
-                    .TryGetValue<TMessage>(out ContextHandlerMap targetedHandlers)
+                targetedHandlers != null
                 && targetedHandlers.TryGetValue(
                     target,
                     out HandlerCache<int, HandlerCache> sortedHandlers
@@ -4268,7 +4384,15 @@ namespace DxMessaging.Core.MessageBus
                 }
             }
 
-            if (InternalTargetedWithoutTargetingBroadcast(ref target, ref typedMessage, emissionId))
+            if (
+                DispatchTargetedWithoutTargetingPhase(
+                    planStillValid ? plan.scalarHandle : null,
+                    planStillValid,
+                    ref target,
+                    ref typedMessage,
+                    emissionId
+                )
+            )
             {
                 foundAnyHandlers = true;
             }
@@ -4278,6 +4402,7 @@ namespace DxMessaging.Core.MessageBus
                     ref target,
                     preInterceptorTarget,
                     ref typedMessage,
+                    planVersion,
                     targetedPostSnapshot,
                     targetedWithoutTargetingPostSnapshot,
                     emissionId
@@ -4299,9 +4424,13 @@ namespace DxMessaging.Core.MessageBus
         }
 
         /// <summary>
-        /// Live post-processing phases for targeted emissions (target-keyed
-        /// then without-targeting), shared by the featured emit path and the
-        /// fast lane's mid-emission-mutation fallback. Both sinks are
+        /// Post-processing phases for targeted emissions (target-keyed then
+        /// without-targeting), shared by the featured emit path and the fast
+        /// lane's mid-emission-mutation fallback. While
+        /// <paramref name="planVersion"/> still matches the bus stamp and no
+        /// interceptor rewrote the target, the snapshots frozen at emission
+        /// start are exactly what a live re-check would produce and both typed
+        /// sink lookups are skipped. Once either changed, both sinks are
         /// re-checked LIVE, matching the legacy lazy-freeze placement.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -4309,6 +4438,7 @@ namespace DxMessaging.Core.MessageBus
             ref InstanceId target,
             InstanceId preInterceptorTarget,
             ref TMessage typedMessage,
+            long planVersion,
             DispatchSnapshot targetedPostSnapshot,
             DispatchSnapshot targetedWithoutTargetingPostSnapshot,
             long emissionId
@@ -4316,6 +4446,31 @@ namespace DxMessaging.Core.MessageBus
             where TMessage : ITargetedMessage
         {
             bool foundAnyHandlers = false;
+            if (planVersion == _dispatchPlanVersion && target == preInterceptorTarget)
+            {
+                if (
+                    targetedPostSnapshot.IsInitialized
+                    && DispatchFlatSnapshot(targetedPostSnapshot, ref typedMessage)
+                )
+                {
+                    foundAnyHandlers = true;
+                }
+
+                if (
+                    targetedWithoutTargetingPostSnapshot.IsInitialized
+                    && DispatchContextFlatSnapshot(
+                        targetedWithoutTargetingPostSnapshot,
+                        ref target,
+                        ref typedMessage
+                    )
+                )
+                {
+                    foundAnyHandlers = true;
+                }
+
+                return foundAnyHandlers;
+            }
+
             if (
                 _contextSinks[BusContextIndex.TargetedPostProcessDefault]
                     .TryGetValue<TMessage>(out ContextHandlerMap targetedHandlers)
@@ -4413,11 +4568,10 @@ namespace DxMessaging.Core.MessageBus
             plan.contextPost = contextPost;
             plan.scalarHandle = scalarHandle;
             plan.scalarPost = scalarPost;
-            bool hasInterceptors =
-                _targetedInterceptsByType.TryGetValue<TMessage>(
-                    out InterceptorCache<object> interceptors
-                )
-                && interceptors.handlers.Count != 0;
+            _ = _targetedInterceptsByType.TryGetValue<TMessage>(
+                out InterceptorCache<object> interceptors
+            );
+            bool hasInterceptors = RefreshInterceptorPlan(plan, interceptors);
             bool hasGlobal = 0 < _globalSlots.sharedHandlers.Count;
             bool hasPost =
                 (contextPost != null && 0 < contextPost.Count)
@@ -4642,7 +4796,10 @@ namespace DxMessaging.Core.MessageBus
             // Capture the pre-interceptor source so post-processing can detect a
             // rewritten id and re-resolve its snapshot against the final source.
             InstanceId preInterceptorSource = source;
-            if (!RunBroadcastInterceptors(ref typedMessage, ref source))
+            if (
+                0 < plan.interceptorCount
+                && !RunBroadcastInterceptors(ref typedMessage, ref source, plan)
+            )
             {
                 return;
             }
@@ -4658,14 +4815,29 @@ namespace DxMessaging.Core.MessageBus
             // interceptors and the global walk, before the source-keyed
             // handle phase), so registrations made by a source-keyed handler
             // this emission are not observed - acquisition alone freezes the
-            // fully-resolved flat array. LIVE lookup: interceptors and
-            // global handlers (user code) ran above.
+            // fully-resolved flat array. The sinks are re-resolved LIVE only
+            // once the plan stamp has moved: interceptors and global handlers
+            // (user code) run above, but while the stamp still matches, none
+            // of them mutated registrations and the plan's cached sinks ARE
+            // what a live lookup returns.
+            bool planStillValid = planVersion == _dispatchPlanVersion;
+            HandlerCache<int, HandlerCache> bwsHandlers;
+            ContextHandlerMap broadcastHandlers;
+            if (planStillValid)
+            {
+                bwsHandlers = plan.scalarHandle;
+                broadcastHandlers = plan.contextHandle;
+            }
+            else
+            {
+                _ = _scalarSinks[BusSinkIndex.BroadcastHandleWithoutContext]
+                    .TryGetValue<TMessage>(out bwsHandlers);
+                _ = _contextSinks[BusContextIndex.BroadcastHandleDefault]
+                    .TryGetValue<TMessage>(out broadcastHandlers);
+            }
+
             DispatchSnapshot broadcastWithoutSourceHandleSnapshot = DispatchSnapshot.Empty;
-            if (
-                _scalarSinks[BusSinkIndex.BroadcastHandleWithoutContext]
-                    .TryGetValue<TMessage>(out HandlerCache<int, HandlerCache> bwsHandlers)
-                && bwsHandlers.handlers.Count > 0
-            )
+            if (bwsHandlers != null && bwsHandlers.handlers.Count > 0)
             {
                 Touch(bwsHandlers, touchTick);
                 broadcastWithoutSourceHandleSnapshot = AcquireDispatchSnapshotFast<TMessage>(
@@ -4678,8 +4850,6 @@ namespace DxMessaging.Core.MessageBus
             }
 
             bool foundAnyHandlers = false;
-            _ = _contextSinks[BusContextIndex.BroadcastHandleDefault]
-                .TryGetValue<TMessage>(out ContextHandlerMap broadcastHandlers);
             if (
                 broadcastHandlers != null
                 && broadcastHandlers.TryGetValue(
@@ -4797,11 +4967,10 @@ namespace DxMessaging.Core.MessageBus
             plan.contextPost = contextPost;
             plan.scalarHandle = scalarHandle;
             plan.scalarPost = scalarPost;
-            bool hasInterceptors =
-                _broadcastInterceptsByType.TryGetValue<TMessage>(
-                    out InterceptorCache<object> interceptors
-                )
-                && interceptors.handlers.Count != 0;
+            _ = _broadcastInterceptsByType.TryGetValue<TMessage>(
+                out InterceptorCache<object> interceptors
+            );
+            bool hasInterceptors = RefreshInterceptorPlan(plan, interceptors);
             bool hasGlobal = 0 < _globalSlots.sharedHandlers.Count;
             bool hasPost =
                 (contextPost != null && 0 < contextPost.Count)
@@ -5041,228 +5210,108 @@ namespace DxMessaging.Core.MessageBus
             }
         }
 
-        private bool TryGetUntargetedInterceptorCaches<TMessage>(
-            out SortedList<int, List<object>> interceptorHandlers,
-            out List<object> interceptorObjects
-        )
-            where TMessage : IUntargetedMessage
-        {
-            if (
-                !_untargetedInterceptsByType.TryGetValue<TMessage>(
-                    out InterceptorCache<object> interceptors
-                )
-                || interceptors.handlers.Count == 0
-            )
-            {
-                interceptorHandlers = default;
-                interceptorObjects = default;
-                return false;
-            }
-
-            interceptorHandlers = interceptors.handlers;
-
-            if (!_innerInterceptorsStack.TryPop(out interceptorObjects))
-            {
-                interceptorObjects = new List<object>();
-            }
-
-            return true;
-        }
-
-        private bool TryGetTargetedInterceptorCaches<TMessage>(
-            out SortedList<int, List<object>> interceptorHandlers,
-            out List<object> interceptorObjects
-        )
-            where TMessage : ITargetedMessage
-        {
-            if (
-                !_targetedInterceptsByType.TryGetValue<TMessage>(
-                    out InterceptorCache<object> interceptors
-                )
-                || interceptors.handlers.Count == 0
-            )
-            {
-                interceptorHandlers = default;
-                interceptorObjects = default;
-                return false;
-            }
-
-            interceptorHandlers = interceptors.handlers;
-
-            if (!_innerInterceptorsStack.TryPop(out interceptorObjects))
-            {
-                interceptorObjects = new List<object>();
-            }
-
-            return true;
-        }
-
-        private bool TryGetBroadcastInterceptorCaches<TMessage>(
-            out SortedList<int, List<object>> interceptorHandlers,
-            out List<object> interceptorObjects
-        )
-            where TMessage : IBroadcastMessage
-        {
-            if (
-                !_broadcastInterceptsByType.TryGetValue<TMessage>(
-                    out InterceptorCache<object> interceptors
-                )
-                || interceptors.handlers.Count == 0
-            )
-            {
-                interceptorHandlers = default;
-                interceptorObjects = default;
-                return false;
-            }
-
-            interceptorHandlers = interceptors.handlers;
-
-            if (!_innerInterceptorsStack.TryPop(out interceptorObjects))
-            {
-                interceptorObjects = new List<object>();
-            }
-
-            return true;
-        }
-
-        private bool RunUntargetedInterceptors<T>(ref T message)
+        /// <summary>
+        /// Runs the untargeted interceptor phase over the plan's frozen,
+        /// priority-ordered interceptor array. Callers gate on
+        /// <see cref="DispatchPlan.interceptorCount"/>, so this method is
+        /// entered only when at least one interceptor was registered when the
+        /// plan was refreshed.
+        /// </summary>
+        /// <remarks>
+        /// The array is never mutated in place (see
+        /// <see cref="RefreshInterceptorPlan"/>), so an interceptor that
+        /// registers or deregisters interceptors cannot shorten, lengthen, or
+        /// reorder the walk in progress; its mutation is observed by the next
+        /// emission. The <see cref="_resetGeneration"/> guard still aborts the
+        /// phase mid-walk, because a reset invalidates the message itself, not
+        /// just the interceptor set.
+        /// </remarks>
+        // IL2CPP check elision on the frozen array walk: entries are non-null
+        // by plan construction and the loop bound is the plan's own count.
+        [Il2CppSetOption(Option.NullChecks, false)]
+        [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
+        private bool RunUntargetedInterceptors<T>(ref T message, DispatchPlan plan)
             where T : IUntargetedMessage
         {
-            if (
-                !TryGetUntargetedInterceptorCaches<T>(
-                    out SortedList<int, List<object>> interceptorHandlers,
-                    out List<object> interceptorObjects
-                )
-            )
-            {
-                return true;
-            }
-
+            object[] interceptors = plan.interceptors;
+            int count = plan.interceptorCount;
             long resetGeneration = _resetGeneration;
-            try
+            for (int index = 0; index < count; ++index)
             {
-                IList<List<object>> prioritizedInterceptors = interceptorHandlers.Values;
-                for (int s = 0; s < prioritizedInterceptors.Count; ++s)
+                UntargetedInterceptor<T> typedTransformer = DxUnsafe.As<UntargetedInterceptor<T>>(
+                    interceptors[index]
+                );
+                if (!typedTransformer(ref message) || _resetGeneration != resetGeneration)
                 {
-                    interceptorObjects.Clear();
-                    List<object> interceptors = prioritizedInterceptors[s];
-                    interceptorObjects.AddRange(interceptors);
-
-                    for (int i = 0; i < interceptorObjects.Count; ++i)
-                    {
-                        UntargetedInterceptor<T> typedTransformer = DxUnsafe.As<
-                            UntargetedInterceptor<T>
-                        >(interceptorObjects[i]);
-                        if (!typedTransformer(ref message) || _resetGeneration != resetGeneration)
-                        {
-                            return false;
-                        }
-                    }
-                }
-            }
-            finally
-            {
-                if (_resetGeneration == resetGeneration)
-                {
-                    _innerInterceptorsStack.Push(interceptorObjects);
+                    return false;
                 }
             }
 
             return true;
         }
 
-        private bool RunTargetedInterceptors<T>(ref T message, ref InstanceId target)
+        /// <summary>
+        /// Targeted counterpart of
+        /// <see cref="RunUntargetedInterceptors{T}"/>; see that method for the
+        /// frozen-array semantics.
+        /// </summary>
+        [Il2CppSetOption(Option.NullChecks, false)]
+        [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
+        private bool RunTargetedInterceptors<T>(
+            ref T message,
+            ref InstanceId target,
+            DispatchPlan plan
+        )
             where T : ITargetedMessage
         {
-            if (
-                !TryGetTargetedInterceptorCaches<T>(
-                    out SortedList<int, List<object>> interceptorHandlers,
-                    out List<object> interceptorObjects
-                )
-            )
-            {
-                return true;
-            }
-
+            object[] interceptors = plan.interceptors;
+            int count = plan.interceptorCount;
             long resetGeneration = _resetGeneration;
-            try
+            for (int index = 0; index < count; ++index)
             {
-                IList<List<object>> prioritizedInterceptors = interceptorHandlers.Values;
-                for (int s = 0; s < prioritizedInterceptors.Count; ++s)
+                TargetedInterceptor<T> typedTransformer = DxUnsafe.As<TargetedInterceptor<T>>(
+                    interceptors[index]
+                );
+                if (
+                    !typedTransformer(ref target, ref message)
+                    || _resetGeneration != resetGeneration
+                )
                 {
-                    interceptorObjects.Clear();
-                    List<object> interceptors = prioritizedInterceptors[s];
-                    interceptorObjects.AddRange(interceptors);
-
-                    for (int i = 0; i < interceptorObjects.Count; ++i)
-                    {
-                        TargetedInterceptor<T> typedTransformer = DxUnsafe.As<
-                            TargetedInterceptor<T>
-                        >(interceptorObjects[i]);
-                        if (
-                            !typedTransformer(ref target, ref message)
-                            || _resetGeneration != resetGeneration
-                        )
-                        {
-                            return false;
-                        }
-                    }
-                }
-            }
-            finally
-            {
-                if (_resetGeneration == resetGeneration)
-                {
-                    _innerInterceptorsStack.Push(interceptorObjects);
+                    return false;
                 }
             }
 
             return true;
         }
 
-        private bool RunBroadcastInterceptors<T>(ref T message, ref InstanceId source)
+        /// <summary>
+        /// Broadcast counterpart of
+        /// <see cref="RunUntargetedInterceptors{T}"/>; see that method for the
+        /// frozen-array semantics.
+        /// </summary>
+        [Il2CppSetOption(Option.NullChecks, false)]
+        [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
+        private bool RunBroadcastInterceptors<T>(
+            ref T message,
+            ref InstanceId source,
+            DispatchPlan plan
+        )
             where T : IBroadcastMessage
         {
-            if (
-                !TryGetBroadcastInterceptorCaches<T>(
-                    out SortedList<int, List<object>> interceptorHandlers,
-                    out List<object> interceptorObjects
-                )
-            )
-            {
-                return true;
-            }
-
+            object[] interceptors = plan.interceptors;
+            int count = plan.interceptorCount;
             long resetGeneration = _resetGeneration;
-            try
+            for (int index = 0; index < count; ++index)
             {
-                IList<List<object>> prioritizedInterceptors = interceptorHandlers.Values;
-                for (int s = 0; s < prioritizedInterceptors.Count; ++s)
+                BroadcastInterceptor<T> typedTransformer = DxUnsafe.As<BroadcastInterceptor<T>>(
+                    interceptors[index]
+                );
+                if (
+                    !typedTransformer(ref source, ref message)
+                    || _resetGeneration != resetGeneration
+                )
                 {
-                    interceptorObjects.Clear();
-                    List<object> interceptors = prioritizedInterceptors[s];
-                    interceptorObjects.AddRange(interceptors);
-
-                    for (int i = 0; i < interceptorObjects.Count; ++i)
-                    {
-                        BroadcastInterceptor<T> typedTransformer = DxUnsafe.As<
-                            BroadcastInterceptor<T>
-                        >(interceptorObjects[i]);
-                        if (
-                            !typedTransformer(ref source, ref message)
-                            || _resetGeneration != resetGeneration
-                        )
-                        {
-                            return false;
-                        }
-                    }
-                }
-            }
-            finally
-            {
-                if (_resetGeneration == resetGeneration)
-                {
-                    _innerInterceptorsStack.Push(interceptorObjects);
+                    return false;
                 }
             }
 
@@ -5272,11 +5321,26 @@ namespace DxMessaging.Core.MessageBus
         private bool InternalUntargetedBroadcast<TMessage>(ref TMessage message, long emissionId)
             where TMessage : IUntargetedMessage
         {
-            if (
-                !_scalarSinks[BusSinkIndex.UntargetedHandleDefault]
-                    .TryGetValue<TMessage>(out HandlerCache<int, HandlerCache> sortedHandlers)
-                || sortedHandlers.handlers.Count == 0
-            )
+            _ = _scalarSinks[BusSinkIndex.UntargetedHandleDefault]
+                .TryGetValue<TMessage>(out HandlerCache<int, HandlerCache> sortedHandlers);
+            return DispatchUntargetedHandlePhase(sortedHandlers, ref message, emissionId);
+        }
+
+        /// <summary>
+        /// Untargeted handle phase over an already-resolved sink. Callers that
+        /// still hold a valid dispatch plan pass its cached sink directly;
+        /// callers whose plan may have been invalidated mid-emission re-resolve
+        /// the sink first (see <see cref="InternalUntargetedBroadcast{TMessage}"/>).
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool DispatchUntargetedHandlePhase<TMessage>(
+            HandlerCache<int, HandlerCache> sortedHandlers,
+            ref TMessage message,
+            long emissionId
+        )
+            where TMessage : IUntargetedMessage
+        {
+            if (sortedHandlers == null || sortedHandlers.handlers.Count == 0)
             {
                 return false;
             }
@@ -5297,18 +5361,30 @@ namespace DxMessaging.Core.MessageBus
             return DispatchFlatSnapshot(snapshot, ref message);
         }
 
-        private bool InternalTargetedWithoutTargetingBroadcast<TMessage>(
+        /// <summary>
+        /// Targeted without-targeting handle phase. When
+        /// <paramref name="sinkResolved"/> is true the caller's dispatch plan
+        /// was still valid, so <paramref name="sortedHandlers"/> is the live
+        /// sink and the typed lookup is skipped; otherwise the sink is
+        /// re-resolved here.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool DispatchTargetedWithoutTargetingPhase<TMessage>(
+            HandlerCache<int, HandlerCache> sortedHandlers,
+            bool sinkResolved,
             ref InstanceId target,
             ref TMessage message,
             long emissionId
         )
             where TMessage : ITargetedMessage
         {
-            if (
-                !_scalarSinks[BusSinkIndex.TargetedHandleWithoutContext]
-                    .TryGetValue<TMessage>(out HandlerCache<int, HandlerCache> sortedHandlers)
-                || sortedHandlers.handlers.Count == 0
-            )
+            if (!sinkResolved)
+            {
+                _ = _scalarSinks[BusSinkIndex.TargetedHandleWithoutContext]
+                    .TryGetValue<TMessage>(out sortedHandlers);
+            }
+
+            if (sortedHandlers == null || sortedHandlers.handlers.Count == 0)
             {
                 return false;
             }

--- a/Runtime/Core/MessageBus/MessageBus.cs
+++ b/Runtime/Core/MessageBus/MessageBus.cs
@@ -4384,10 +4384,15 @@ namespace DxMessaging.Core.MessageBus
                 }
             }
 
+            // Re-compare rather than reusing planStillValid: the target-keyed
+            // handle phase above ran user code, and a handler that mutated
+            // registrations must be observed here exactly as the live lookup
+            // this replaces would have observed it.
+            bool planValidAfterHandlers = planVersion == _dispatchPlanVersion;
             if (
                 DispatchTargetedWithoutTargetingPhase(
-                    planStillValid ? plan.scalarHandle : null,
-                    planStillValid,
+                    planValidAfterHandlers ? plan.scalarHandle : null,
+                    planValidAfterHandlers,
                     ref target,
                     ref typedMessage,
                     emissionId

--- a/Runtime/Core/MessageBus/MessageBus.cs
+++ b/Runtime/Core/MessageBus/MessageBus.cs
@@ -429,26 +429,17 @@ namespace DxMessaging.Core.MessageBus
             public ContextHandlerMap contextPost;
 
             /// <summary>
-            /// Interceptors for this message type, flattened into one
-            /// priority-ordered array at plan-refresh time (ascending priority
-            /// group, then registration order within a group - the same order
-            /// the per-emit walk over
-            /// <see cref="InterceptorCache{TValue}.handlers"/> produced). The
-            /// interceptor phase iterates this array directly, so it costs one
-            /// array read plus the delegate call per interceptor instead of a
-            /// typed cache lookup, a scratch-list rent, and a defensive
-            /// <see cref="List{T}"/> copy per priority group per emission.
-            /// <para>
-            /// <see cref="RefreshInterceptorPlan{TValue}"/> always assigns a
-            /// NEW array rather than mutating in place, so an emission already
-            /// iterating the previous array keeps a stable, frozen view: a
-            /// mutation performed by an interceptor or handler is observed by
-            /// the NEXT emission, matching the handler path's snapshot freeze
-            /// (see <see cref="DispatchSnapshot"/>).
-            /// </para>
+            /// Interceptor store for this message type, or <c>null</c> when
+            /// none were registered at refresh time (which is also the
+            /// emit-path gate). The flattened, priority-ordered array lives on
+            /// the store rather than here on purpose: this plan is invalidated
+            /// by ANY registration anywhere on the bus and by every idle
+            /// sweep, so caching the array here would rebuild - and therefore
+            /// allocate - on the next emission after unrelated churn. Keyed to
+            /// the store's own dirty flag, the array survives everything
+            /// except an actual interceptor mutation.
             /// </summary>
-            public object[] interceptors = Array.Empty<object>();
-            public int interceptorCount;
+            public InterceptorCache<object> interceptorCache;
 
             /// <summary>
             /// Drops every cached sink reference and forces a refresh on the
@@ -464,8 +455,7 @@ namespace DxMessaging.Core.MessageBus
                 scalarPost = null;
                 contextHandle = null;
                 contextPost = null;
-                interceptors = Array.Empty<object>();
-                interceptorCount = 0;
+                interceptorCache = null;
             }
         }
 
@@ -514,10 +504,97 @@ namespace DxMessaging.Core.MessageBus
             public readonly SortedList<int, List<TValue>> handlers = new();
             public long lastTouchTicks;
 
+            /// <summary>
+            /// <see cref="handlers"/> flattened into one priority-ordered
+            /// array (ascending priority group, then registration order within
+            /// a group - the order the old per-emit walk produced). The
+            /// interceptor phase iterates this directly, so it costs one array
+            /// read plus the delegate call per interceptor instead of a
+            /// scratch-list rent and a defensive <see cref="List{T}"/> copy per
+            /// priority group per emission.
+            /// <para>
+            /// Rebuilt lazily, only after <see cref="MarkFlatDirty"/>, which
+            /// every interceptor mutation calls. It deliberately does NOT key
+            /// off the bus-wide dispatch-plan stamp: that stamp moves on any
+            /// registration anywhere and on every idle sweep, which would make
+            /// steady-state emission allocate a fresh array after unrelated
+            /// churn.
+            /// </para>
+            /// </summary>
+            private TValue[] _flat = Array.Empty<TValue>();
+            private int _flatCount;
+            private bool _flatDirty = true;
+
+            /// <summary>
+            /// Invalidates the flattened view AND drops its references, so a
+            /// deregistered interceptor is not kept alive by this cache until
+            /// the next emission or sweep. Assigning a fresh empty array rather
+            /// than clearing in place preserves the frozen view any emission
+            /// currently walking the old array still holds.
+            /// </summary>
+            public void MarkFlatDirty()
+            {
+                _flat = Array.Empty<TValue>();
+                _flatCount = 0;
+                _flatDirty = true;
+            }
+
+            /// <summary>
+            /// Returns the flattened, priority-ordered interceptors, rebuilding
+            /// first when dirty. A rebuild always ALLOCATES a new array rather
+            /// than writing into the existing one, so an emission already
+            /// iterating the previous array keeps a stable, complete view: a
+            /// mutation performed by an interceptor or handler is observed by
+            /// the NEXT emission, matching the handler path's snapshot freeze
+            /// (see <see cref="DispatchSnapshot"/>).
+            /// </summary>
+            public TValue[] EnsureFlat(out int count)
+            {
+                if (_flatDirty)
+                {
+                    RebuildFlat();
+                }
+
+                count = _flatCount;
+                return _flat;
+            }
+
+            private void RebuildFlat()
+            {
+                IList<List<TValue>> groups = handlers.Values;
+                int total = 0;
+                for (int index = 0; index < groups.Count; ++index)
+                {
+                    total += groups[index].Count;
+                }
+
+                if (total == 0)
+                {
+                    _flat = Array.Empty<TValue>();
+                    _flatCount = 0;
+                    _flatDirty = false;
+                    return;
+                }
+
+                TValue[] flattened = new TValue[total];
+                int next = 0;
+                for (int index = 0; index < groups.Count; ++index)
+                {
+                    List<TValue> group = groups[index];
+                    group.CopyTo(flattened, next);
+                    next += group.Count;
+                }
+
+                _flat = flattened;
+                _flatCount = next;
+                _flatDirty = false;
+            }
+
             public void Clear()
             {
                 handlers.Clear();
                 lastTouchTicks = 0;
+                MarkFlatDirty();
             }
         }
 
@@ -3299,6 +3376,7 @@ namespace DxMessaging.Core.MessageBus
             {
                 count = 0;
                 interceptors.Add(interceptor);
+                prioritizedInterceptors.MarkFlatDirty();
             }
 
             priorityCount[priority] = count + 1;
@@ -3370,6 +3448,7 @@ namespace DxMessaging.Core.MessageBus
             {
                 count = 0;
                 interceptors.Add(interceptor);
+                prioritizedInterceptors.MarkFlatDirty();
             }
 
             priorityCount[priority] = count + 1;
@@ -3441,6 +3520,7 @@ namespace DxMessaging.Core.MessageBus
             {
                 count = 0;
                 interceptors.Add(interceptor);
+                prioritizedInterceptors.MarkFlatDirty();
             }
 
             priorityCount[priority] = count + 1;
@@ -3716,7 +3796,11 @@ namespace DxMessaging.Core.MessageBus
                 );
             }
 
-            if (0 < plan.interceptorCount && !RunUntargetedInterceptors(ref typedMessage, plan))
+            InterceptorCache<object> untargetedInterceptors = plan.interceptorCache;
+            if (
+                untargetedInterceptors != null
+                && !RunUntargetedInterceptors(ref typedMessage, untargetedInterceptors)
+            )
             {
                 return;
             }
@@ -3838,59 +3922,26 @@ namespace DxMessaging.Core.MessageBus
         }
 
         /// <summary>
-        /// Flattens an interceptor store's priority groups into the plan's
-        /// frozen, priority-ordered array and reports whether any interceptor
-        /// remains. Runs only on plan refresh (registration churn, sweep,
-        /// reset, settings reload), never per emission.
+        /// Caches the interceptor store for this message type on the plan and
+        /// reports whether any interceptor is registered. The store owns the
+        /// flattened array (see <see cref="InterceptorCache{TValue}.EnsureFlat"/>);
+        /// the plan only caches the reference, so an unrelated registration or
+        /// an idle sweep invalidating the plan does not discard the flattened
+        /// view and force a reallocation.
         /// </summary>
-        /// <remarks>
-        /// The rebuilt array is always a fresh allocation. An emission that is
-        /// mid-iteration over the previous array therefore keeps walking a
-        /// stable, complete view even when an interceptor it invokes registers
-        /// or deregisters interceptors; the mutation lands in the array the
-        /// NEXT emission builds. That is the same freeze the handler phase
-        /// gets from <see cref="DispatchSnapshot"/>, applied to the
-        /// interceptor phase.
-        /// </remarks>
         /// <returns><c>true</c> when at least one interceptor is registered.</returns>
         private static bool RefreshInterceptorPlan(
             DispatchPlan plan,
             InterceptorCache<object> interceptors
         )
         {
-            SortedList<int, List<object>> groupsByPriority = interceptors?.handlers;
-            if (groupsByPriority == null || groupsByPriority.Count == 0)
+            if (interceptors == null || interceptors.handlers.Count == 0)
             {
-                plan.interceptors = Array.Empty<object>();
-                plan.interceptorCount = 0;
+                plan.interceptorCache = null;
                 return false;
             }
 
-            IList<List<object>> groups = groupsByPriority.Values;
-            int total = 0;
-            for (int index = 0; index < groups.Count; ++index)
-            {
-                total += groups[index].Count;
-            }
-
-            if (total == 0)
-            {
-                plan.interceptors = Array.Empty<object>();
-                plan.interceptorCount = 0;
-                return false;
-            }
-
-            object[] flattened = new object[total];
-            int next = 0;
-            for (int index = 0; index < groups.Count; ++index)
-            {
-                List<object> group = groups[index];
-                group.CopyTo(flattened, next);
-                next += group.Count;
-            }
-
-            plan.interceptors = flattened;
-            plan.interceptorCount = next;
+            plan.interceptorCache = interceptors;
             return true;
         }
 
@@ -4110,9 +4161,10 @@ namespace DxMessaging.Core.MessageBus
             // Capture the pre-interceptor target so post-processing can detect a
             // rewritten id and re-resolve its snapshot against the final target.
             InstanceId preInterceptorTarget = target;
+            InterceptorCache<object> targetedInterceptors = plan.interceptorCache;
             if (
-                0 < plan.interceptorCount
-                && !RunTargetedInterceptors(ref typedMessage, ref target, plan)
+                targetedInterceptors != null
+                && !RunTargetedInterceptors(ref typedMessage, ref target, targetedInterceptors)
             )
             {
                 return;
@@ -4801,9 +4853,10 @@ namespace DxMessaging.Core.MessageBus
             // Capture the pre-interceptor source so post-processing can detect a
             // rewritten id and re-resolve its snapshot against the final source.
             InstanceId preInterceptorSource = source;
+            InterceptorCache<object> broadcastInterceptors = plan.interceptorCache;
             if (
-                0 < plan.interceptorCount
-                && !RunBroadcastInterceptors(ref typedMessage, ref source, plan)
+                broadcastInterceptors != null
+                && !RunBroadcastInterceptors(ref typedMessage, ref source, broadcastInterceptors)
             )
             {
                 return;
@@ -5235,11 +5288,10 @@ namespace DxMessaging.Core.MessageBus
         // by plan construction and the loop bound is the plan's own count.
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
-        private bool RunUntargetedInterceptors<T>(ref T message, DispatchPlan plan)
+        private bool RunUntargetedInterceptors<T>(ref T message, InterceptorCache<object> cache)
             where T : IUntargetedMessage
         {
-            object[] interceptors = plan.interceptors;
-            int count = plan.interceptorCount;
+            object[] interceptors = cache.EnsureFlat(out int count);
             long resetGeneration = _resetGeneration;
             for (int index = 0; index < count; ++index)
             {
@@ -5265,12 +5317,11 @@ namespace DxMessaging.Core.MessageBus
         private bool RunTargetedInterceptors<T>(
             ref T message,
             ref InstanceId target,
-            DispatchPlan plan
+            InterceptorCache<object> cache
         )
             where T : ITargetedMessage
         {
-            object[] interceptors = plan.interceptors;
-            int count = plan.interceptorCount;
+            object[] interceptors = cache.EnsureFlat(out int count);
             long resetGeneration = _resetGeneration;
             for (int index = 0; index < count; ++index)
             {
@@ -5299,12 +5350,11 @@ namespace DxMessaging.Core.MessageBus
         private bool RunBroadcastInterceptors<T>(
             ref T message,
             ref InstanceId source,
-            DispatchPlan plan
+            InterceptorCache<object> cache
         )
             where T : IBroadcastMessage
         {
-            object[] interceptors = plan.interceptors;
-            int count = plan.interceptorCount;
+            object[] interceptors = cache.EnsureFlat(out int count);
             long resetGeneration = _resetGeneration;
             for (int index = 0; index < count; ++index)
             {
@@ -5977,6 +6027,11 @@ namespace DxMessaging.Core.MessageBus
                         {
                             _ = prioritizedInterceptors.handlers.Remove(priority);
                         }
+
+                        // Drops the flattened view's references too, so the
+                        // removed interceptor is not kept alive until the next
+                        // emission or sweep.
+                        prioritizedInterceptors.MarkFlatDirty();
                     }
                 }
 

--- a/Tests/Editor/Allocations/AllocationMatrixTests.cs
+++ b/Tests/Editor/Allocations/AllocationMatrixTests.cs
@@ -448,6 +448,87 @@ namespace DxMessaging.Tests.Editor.Allocations
         }
 
         /// <summary>
+        /// The interceptor phase dispatches a flattened, priority-ordered view
+        /// of the interceptor store. That view must survive registration churn
+        /// on UNRELATED message types.
+        /// <para>
+        /// <see cref="EmitIsZeroAllocAcrossInterceptorPresence"/> cannot catch a
+        /// regression here: it measures a churn-free emit loop, and
+        /// <see cref="AllocationProbe.MeasureMin"/> takes the MINIMUM across
+        /// attempts, which structurally hides an allocation that only occurs on
+        /// the first emit after an invalidation. This test puts the unrelated
+        /// registration in <c>prepare</c> -- run before each window and never
+        /// counted -- so every measured emit is the first one after the bus-wide
+        /// dispatch-plan stamp moved, which is exactly the case that regressed.
+        /// </para>
+        /// </summary>
+        [Test]
+        [Category("Allocation")]
+        public void EmitWithInterceptorIsZeroAllocAfterUnrelatedRegistrationChurn(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            RunWithFreshHarness(
+                scenario,
+                (token, bus) =>
+                {
+                    Action emit = BuildEmitClosure(scenario, bus);
+                    RegisterHandler(scenario, token);
+                    RegisterAllowingInterceptor(scenario, token);
+
+                    // A registration for a message type NO scenario emits, so it
+                    // cannot touch the sink under measurement -- SimpleUntargetedMessage
+                    // would be the emitted type on the Untargeted row and would
+                    // legitimately rebuild that sink's own dispatch snapshot. It
+                    // touches no interceptor store either, but it does bump the
+                    // bus-wide dispatch-plan stamp, which is what used to discard
+                    // the flattened interceptor view.
+                    MessageHandler.FastHandler<ComplexUntargetedMessage> churnHandler = (
+                        ref ComplexUntargetedMessage _
+                    ) => { };
+
+                    void InvalidateThePlan()
+                    {
+                        MessageRegistrationHandle churnHandle =
+                            token.RegisterUntargeted<ComplexUntargetedMessage>(churnHandler);
+                        token.RemoveRegistration(churnHandle);
+                    }
+
+                    // Warm both the emit path and the churn path.
+                    for (int i = 0; i < 8; ++i)
+                    {
+                        InvalidateThePlan();
+                        emit();
+                    }
+
+                    long delta = AllocationProbe.MeasureMin(
+                        AllocationMeasurementAttempts,
+                        prepare: InvalidateThePlan,
+                        operation: emit
+                    );
+                    if (delta == AllocationProbe.Unmeasured)
+                    {
+                        Assert.Ignore(
+                            "The GC.Alloc allocation probe is non-functional on this backend."
+                        );
+                    }
+
+                    Assert.AreEqual(
+                        0,
+                        delta,
+                        "[{0}] Emitting with an interceptor registered must allocate nothing even "
+                            + "when an unrelated registration invalidated the dispatch plan first. "
+                            + "A non-zero count means the flattened interceptor view is keyed to "
+                            + "the bus-wide plan stamp again, so ordinary spawn/despawn churn "
+                            + "reallocates it on every emit.",
+                        scenario.Kind
+                    );
+                }
+            );
+        }
+
+        /// <summary>
         /// Pins zero-allocation emission across both post-processor-present
         /// and post-processor-absent rows. The scenario flag drives whether a
         /// post-processor is registered, so this single test covers both

--- a/Tests/Runtime/Core/MutationDuringEmissionTests.cs
+++ b/Tests/Runtime/Core/MutationDuringEmissionTests.cs
@@ -1528,6 +1528,94 @@ namespace DxMessaging.Tests.Runtime.Core
                 token.RemoveRegistration(lowHandle);
             }
         }
+
+        /// <summary>
+        /// A targeted emission takes the no-feature fast lane or the featured
+        /// lane depending on whether any interceptor, global accept-all, or
+        /// post-processor exists for the type. Both lanes must report the same
+        /// thing when a target-keyed handler registers the FIRST
+        /// without-targeting listener for that type mid-emission.
+        /// <para>
+        /// The lanes resolve the without-targeting sink differently -- the
+        /// featured lane can reuse the emission's dispatch plan when no
+        /// registration mutated during the emission -- so a plan-validity
+        /// check captured too early silently skips the new listener on one
+        /// lane only. This asserts parity rather than a specific count, so it
+        /// stays correct if the freeze semantics are deliberately changed
+        /// later (see issue #413) while still catching lane divergence.
+        /// </para>
+        /// </summary>
+        [Test]
+        public void WithoutTargetingRegisteredByTargetedHandlerMatchesAcrossDispatchLanes()
+        {
+            int fastLane = CountWithoutTargetingRegisteredMidEmission(featuredLane: false);
+            int featuredLane = CountWithoutTargetingRegisteredMidEmission(featuredLane: true);
+
+            Assert.AreEqual(
+                fastLane,
+                featuredLane,
+                "The fast lane and the featured lane must agree on whether a without-targeting "
+                    + "listener registered by a target-keyed handler runs in that same emission. "
+                    + "Fast lane saw {0}, featured lane saw {1}.",
+                fastLane,
+                featuredLane
+            );
+        }
+
+        private int CountWithoutTargetingRegisteredMidEmission(bool featuredLane)
+        {
+            GameObject host = new(
+                nameof(WithoutTargetingRegisteredByTargetedHandlerMatchesAcrossDispatchLanes)
+                    + (featuredLane ? "_Featured" : "_Fast"),
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(host);
+            EmptyMessageAwareComponent component = host.GetComponent<EmptyMessageAwareComponent>();
+            MessageRegistrationToken token = GetToken(component);
+
+            int withoutTargetingCount = 0;
+            bool registered = false;
+
+            if (featuredLane)
+            {
+                // Any post-processor for the type forces the featured lane.
+                _ = token.RegisterGameObjectTargetedPostProcessor<SimpleTargetedMessage>(
+                    host,
+                    (ref SimpleTargetedMessage _) => { }
+                );
+            }
+
+            // The handler parameter is deliberately NOT named "_": a discard
+            // assignment inside the body would bind to it instead.
+            _ = token.RegisterGameObjectTargeted<SimpleTargetedMessage>(
+                host,
+                (ref SimpleTargetedMessage targeted) =>
+                {
+                    if (registered)
+                    {
+                        return;
+                    }
+
+                    registered = true;
+                    _ = token.RegisterTargetedWithoutTargeting<SimpleTargetedMessage>(
+                        (_, _) => ++withoutTargetingCount
+                    );
+                }
+            );
+
+            SimpleTargetedMessage message = new();
+            message.EmitGameObjectTargeted(host);
+
+            Assert.IsTrue(
+                registered,
+                "Precondition: the target-keyed handler must run and register the "
+                    + "without-targeting listener ({0} lane).",
+                featuredLane ? "featured" : "fast"
+            );
+
+            token.UnregisterAll();
+            return withoutTargetingCount;
+        }
     }
 }
 

--- a/Tests/Runtime/Core/MutationInterceptorTests.cs
+++ b/Tests/Runtime/Core/MutationInterceptorTests.cs
@@ -2,8 +2,6 @@
 namespace DxMessaging.Tests.Runtime.Core
 {
     using System;
-    using System.Collections.Generic;
-    using System.Reflection;
     using DxMessaging.Core;
     using DxMessaging.Core.Extensions;
     using DxMessaging.Core.MessageBus;
@@ -146,30 +144,13 @@ namespace DxMessaging.Tests.Runtime.Core
             Assert.AreEqual(
                 0,
                 trailingCount,
-                "[{0}] Reset must stop later interceptors from the copied in-flight snapshot.",
+                "[{0}] Reset must stop later interceptors from the in-flight interceptor walk.",
                 scenario.Kind
             );
             Assert.AreEqual(
                 0,
                 handlerCount,
                 "[{0}] Reset in the interceptor phase must stop the handler phase.",
-                scenario.Kind
-            );
-            FieldInfo interceptorStackField = typeof(MessageBus).GetField(
-                "_innerInterceptorsStack",
-                BindingFlags.Instance | BindingFlags.NonPublic
-            );
-            Assert.IsNotNull(
-                interceptorStackField,
-                "[{0}] The interceptor snapshot cache field must remain discoverable.",
-                scenario.Kind
-            );
-            Stack<List<object>> interceptorStack =
-                (Stack<List<object>>)interceptorStackField.GetValue(bus);
-            Assert.AreEqual(
-                0,
-                interceptorStack.Count,
-                "[{0}] Reset must not retain the in-flight interceptor snapshot in the cache.",
                 scenario.Kind
             );
             Assert.AreEqual(0, bus.RegisteredUntargeted, "[{0}] Untargeted leak.", scenario.Kind);
@@ -240,6 +221,190 @@ namespace DxMessaging.Tests.Runtime.Core
                 scenario.Kind
             );
             rebornToken.UnregisterAll();
+        }
+
+        /// <summary>
+        /// The documented snapshot contract
+        /// (docs/concepts/interceptors-and-ordering.md) says a listener added
+        /// during an emission never runs for that emission, and names
+        /// interceptors explicitly.
+        /// <see cref="MutationDuringEmissionTests.AddInterceptorDuringInterceptorDoesNotRunInSameEmission"/>
+        /// pins that for an interceptor added to the SAME priority group. This
+        /// case pins the one the group-at-a-time walk used to get wrong: an
+        /// interceptor added to a LATER priority group, whose group had not
+        /// been reached yet and so was picked up mid-emission.
+        /// </summary>
+        [Test]
+        public void InterceptorAddedToLaterPriorityGroupDoesNotRunInSameEmission(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            GameObject host = new(
+                nameof(InterceptorAddedToLaterPriorityGroupDoesNotRunInSameEmission)
+                    + "_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(host);
+            EmptyMessageAwareComponent component = host.GetComponent<EmptyMessageAwareComponent>();
+            MessageRegistrationToken token = GetToken(component);
+            InstanceId hostId = host;
+
+            // Opened after the host's own registrations exist so the baseline
+            // covers only the interceptors this test adds and removes.
+            using LeakWatcher watcher = LeakWatcher.Watch(scenario.DisplayName);
+
+            int earlyCount = 0;
+            int lateCount = 0;
+            MessageRegistrationHandle? lateHandle = null;
+
+            MessageRegistrationHandle earlyHandle = RegisterInterceptor(
+                scenario,
+                token,
+                () =>
+                {
+                    ++earlyCount;
+                    lateHandle ??= RegisterInterceptor(
+                        scenario,
+                        token,
+                        () =>
+                        {
+                            ++lateCount;
+                            return true;
+                        },
+                        priority: 10
+                    );
+                    return true;
+                },
+                priority: 0
+            );
+
+            EmitForScenario(scenario, hostId);
+            Assert.AreEqual(
+                1,
+                earlyCount,
+                "[{0}] The priority-0 interceptor must run exactly once.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                0,
+                lateCount,
+                "[{0}] An interceptor registered into a later priority group must NOT run in the "
+                    + "emission that registered it; the interceptor walk is frozen at emission start.",
+                scenario.Kind
+            );
+
+            EmitForScenario(scenario, hostId);
+            Assert.AreEqual(
+                2,
+                earlyCount,
+                "[{0}] The priority-0 interceptor must run again on the second emission.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                1,
+                lateCount,
+                "[{0}] The later-group interceptor must start running on the NEXT emission.",
+                scenario.Kind
+            );
+
+            token.RemoveRegistration(earlyHandle);
+            if (lateHandle.HasValue)
+            {
+                token.RemoveRegistration(lateHandle.Value);
+            }
+        }
+
+        /// <summary>
+        /// Removal counterpart of
+        /// <see cref="InterceptorAddedToLaterPriorityGroupDoesNotRunInSameEmission"/>: a listener
+        /// removed during an emission still completes its execution for that
+        /// message. The group-at-a-time walk honoured a same-group removal but
+        /// dropped a later-group one mid-emission; the frozen walk runs it.
+        /// </summary>
+        [Test]
+        public void InterceptorRemovedFromLaterPriorityGroupStillRunsInSameEmission(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            GameObject host = new(
+                nameof(InterceptorRemovedFromLaterPriorityGroupStillRunsInSameEmission)
+                    + "_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(host);
+            EmptyMessageAwareComponent component = host.GetComponent<EmptyMessageAwareComponent>();
+            MessageRegistrationToken token = GetToken(component);
+            InstanceId hostId = host;
+
+            // Opened after the host's own registrations exist so the baseline
+            // covers only the interceptors this test adds and removes.
+            using LeakWatcher watcher = LeakWatcher.Watch(scenario.DisplayName);
+
+            int earlyCount = 0;
+            int lateCount = 0;
+            bool removed = false;
+
+            MessageRegistrationHandle lateHandle = RegisterInterceptor(
+                scenario,
+                token,
+                () =>
+                {
+                    ++lateCount;
+                    return true;
+                },
+                priority: 10
+            );
+            MessageRegistrationHandle earlyHandle = RegisterInterceptor(
+                scenario,
+                token,
+                () =>
+                {
+                    ++earlyCount;
+                    if (!removed)
+                    {
+                        removed = true;
+                        token.RemoveRegistration(lateHandle);
+                    }
+
+                    return true;
+                },
+                priority: 0
+            );
+
+            EmitForScenario(scenario, hostId);
+            Assert.AreEqual(
+                1,
+                earlyCount,
+                "[{0}] The priority-0 interceptor must run exactly once.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                1,
+                lateCount,
+                "[{0}] An interceptor removed from a later priority group must still run for the "
+                    + "in-flight message; the interceptor walk is frozen at emission start.",
+                scenario.Kind
+            );
+
+            EmitForScenario(scenario, hostId);
+            Assert.AreEqual(
+                2,
+                earlyCount,
+                "[{0}] The priority-0 interceptor must run again on the second emission.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                1,
+                lateCount,
+                "[{0}] The removed interceptor must not run on the next emission.",
+                scenario.Kind
+            );
+
+            token.RemoveRegistration(earlyHandle);
         }
 
         private static MessageRegistrationHandle RegisterInterceptor(

--- a/docs/concepts/interceptors-and-ordering.md
+++ b/docs/concepts/interceptors-and-ordering.md
@@ -12,6 +12,13 @@
 - This behavior applies to all registration types: handlers, interceptors, and post-processors
 - This behavior applies to all message categories: Untargeted, Targeted, and Broadcast
 
+One phase boundary is deliberately not frozen. Interceptors run **before** the
+handler and post-processor snapshots are taken, so a handler that an interceptor
+deregisters is gone before those snapshots exist and does **not** run for the
+current message. Deregistering from a handler or a post-processor follows the
+frozen rule above; deregistering a handler from an interceptor takes effect
+immediately.
+
 #### Example
 
 ```csharp

--- a/docs/concepts/interceptors-and-ordering.md
+++ b/docs/concepts/interceptors-and-ordering.md
@@ -13,11 +13,12 @@
 - This behavior applies to all message categories: Untargeted, Targeted, and Broadcast
 
 One phase boundary is deliberately not frozen. Interceptors run **before** the
-handler and post-processor snapshots are taken, so a handler that an interceptor
-deregisters is gone before those snapshots exist and does **not** run for the
-current message. Deregistering from a handler or a post-processor follows the
-frozen rule above; deregistering a handler from an interceptor takes effect
-immediately.
+handler snapshot is taken, so a handler that an interceptor deregisters is gone
+before that snapshot exists and does **not** run for the current message.
+Deregistering a handler from another handler or from a post-processor follows
+the frozen rule above; deregistering a handler from an interceptor takes effect
+immediately. Post-processor snapshots are taken before interceptors run, so they
+follow the frozen rule in every case.
 
 #### Example
 


### PR DESCRIPTION
Closes #408.

## What was slow

Any emission with an interceptor, a global accept-all handler, or a post-processor leaves the
no-feature fast lane and takes the featured lane, which was rebuilding state the dispatch plan had
already resolved.

The interceptor phase rebuilt its whole working set on **every emission**: a typed `MessageCache`
lookup, a scratch-list rent off a `Stack<List<object>>` returned in a `finally`, a walk over
`SortedList.Values` as an `IList<>` (interface dispatch on every `.Count` and `[i]`), and then a
defensive `Clear()` + `AddRange()` copy per priority group. One no-op `bool (ref T)` interceptor
cost **23.4 ns** on top of an 11.0 ns emit.

Ablation on the untargeted single-interceptor case attributes it:

| Configuration | ns/emit |
| --- | --- |
| Unmodified | 34.35 |
| Interceptor phase stubbed out | 13.59 |
| Defensive `List` copy removed | 26.47 |

20.8 of the 23.4 ns was the phase around the delegate, not the delegate.

Separately, the featured lanes re-resolved handle and post sinks with
`MessageCache.TryGetValue<TMessage>()` calls whose results the `DispatchPlan` had already cached and
validated for that emission. An interceptor-only emission paid a post-sink lookup for a sink with no
post-processors in it.

## What changed

**Interceptors are flattened once into a frozen priority-ordered array** owned by the interceptor
store, and dispatch iterates it directly. This is the same treatment the handler phase already gets
from `FlatDispatch` / `DispatchSnapshot`; the interceptor phase never received it. The dispatch plan
caches the store reference, so the emit path reaches it without a typed cache lookup. See
[Where the flattened view lives](#where-the-flattened-view-lives-and-why) for why the array is keyed
to the store rather than the plan.

The array is **never mutated in place** — a rebuild allocates a new one — so an emission already
walking the previous array keeps a stable, complete view. The no-interceptor case allocates nothing.

**The redundant sink lookups now run only when `planVersion != _dispatchPlanVersion`** — that is,
only when user code mutated registrations during this emission, the only case where a live result
can differ from the plan's. Applied to the untargeted, targeted, and broadcast lanes.

`_innerInterceptorsStack` and the three `TryGet*InterceptorCaches` helpers are deleted; nothing else
used them.

## A behavior bug this exposed

`docs/concepts/interceptors-and-ordering.md` states that a listener added during an emission does not
run for that emission, that one removed still completes, and that this "applies to all registration
types: handlers, interceptors, and post-processors."

The group-at-a-time copy only delivered that **within a priority group**. Because it copied each
group lazily as the walk reached it, an interceptor registered into a *later* priority group was
picked up in the same emission, and one removed from a later group was dropped from it. Adding a new
priority key also mutated the live `SortedList.Values` view the loop was indexing.

Every existing mutating-interceptor test used priority 0 on both sides, so nothing pinned the
cross-group case. It does now, parameterized over `MessageScenarios.AllKinds`:

- `InterceptorAddedToLaterPriorityGroupDoesNotRunInSameEmission`
- `InterceptorRemovedFromLaterPriorityGroupStillRunsInSameEmission`

`ResetFromInterceptorStopsSnapshotAndAllowsFreshRegistration` no longer reflects on the deleted
`_innerInterceptorsStack` field. Its behavioral assertions are unchanged; only the
private-field probe went away, since with a frozen array there is no in-flight scratch list to
retain.

The docs page also gains the one boundary that is deliberately **not** frozen: interceptors run
before the *handler* snapshot is taken, so a handler an interceptor deregisters does not run for the
current message. The page previously stated the frozen rule without that carve-out, contradicting
`ReentrantEmissionTests.DeregisterFromInterceptorIsObservedOnCurrentEmission`. Post-processor
snapshots are taken before interceptors run, so post-processors keep the frozen rule in every case.

## Numbers

Measured against `master` on the shipped dispatch sources, one process per scenario, `min` of 7
(`min` because median still swung 25–160% on the noisy targeted rows while `min` held within 3%):

| Scenario | Before | After | Speedup |
| --- | --- | --- | --- |
| Untargeted, 4 interceptors | 77.46 ns | 22.38 ns | **3.46x** |
| Untargeted, 1 interceptor | 34.35 ns | 15.86 ns | **2.17x** |
| Interceptor + post-processor | 40.07 ns | 19.29 ns | **2.08x** |
| Broadcast, 1 interceptor | 39.19 ns | 19.94 ns | **1.97x** |
| Targeted, 1 interceptor | 44.56 ns | 23.40 ns | **1.90x** |
| Untargeted, 1 post-processor | 20.16 ns | 15.64 ns | 1.29x |
| 4 post-processors | 25.96 ns | 21.60 ns | 1.20x |
| Targeted, 1 post-processor | 31.02 ns | 26.86 ns | 1.15x |
| Broadcast, 1 post-processor | 27.27 ns | 23.89 ns | 1.14x |
| Untargeted baseline (1 handler) | 10.94 ns | 9.78 ns | 1.12x |
| Targeted baseline | 12.56 ns | 11.77 ns | 1.07x |
| Broadcast baseline | 12.58 ns | 12.23 ns | 1.03x |

No scenario regressed. The no-feature baselines are untouched code and land inside noise.

**On the measurement.** These come from a throwaway console harness that compiles `Runtime/Core`
outside Unity (everything Unity-specific is already behind `#if UNITY_2021_3_OR_NEWER`; the whole
unguarded surface is `MonoBehaviour`, `UnsafeUtility`, and `Il2CppSetOption`) and runs the **shipped
dispatch code** on CoreCLR. It is not checked in — the tooling philosophy is explicit about not
adding bespoke harnesses, and `PLAN.md` records how to rebuild it. It is trustworthy for *relative*
deltas because it reproduces the CI gap's shape (interceptor 3.1x baseline locally vs 5.2x on the
IL2CPP leg; post-processor 1.9x vs 2.8x). **The published headline still comes from the CI standalone
IL2CPP leg**, so the comparison-matrix cells in `docs/architecture/performance.md` will be
regenerated by `perf-numbers.yml` on merge, and those are the numbers to hold this to.

## Where the flattened view lives, and why

It hangs off the interceptor store (`InterceptorCache`), keyed to that store's
own dirty flag, **not** off the dispatch plan.

The first version put it on the plan. The plan is governed by one bus-wide stamp that moves on any
registration anywhere and on every idle sweep, so the array was thrown away and rebuilt far more
often than interceptors actually change: one `MessageAwareComponent` enabling or disabling made
every subsequent emit of an interceptor-carrying type allocate a fresh `object[]`, and an idle
steady state still reallocated once per type per sweep interval. Measured at 4096 bytes across 128
emits interleaved with unrelated churn -- exactly one 32-byte `object[1]` per emit. That breaks the
zero-GC contract this change exists to protect.

Keyed to the store's dirty flag, only the four real interceptor mutation sites invalidate it.
`MarkFlatDirty` also drops the array's references, so a deregistered interceptor is not kept alive
by the cache until the next emission or sweep.

`EmitWithInterceptorIsZeroAllocAfterUnrelatedRegistrationChurn` guards this across all three message
kinds. It puts the unrelated registration in `MeasureMin`'s `prepare`, which runs before each window
and is never counted, so every measured emit is the first one after the stamp moved -- the case a
min-of-attempts probe over a churn-free loop structurally cannot see, which is why
`EmitIsZeroAllocAcrossInterceptorPresence` stayed green through the regression. Verified red-green
in the editor: old design 0 pass / 3 fail, new design 3 pass / 0 fail.

## Verification

Host editor 6000.4.6f1 over `unity-mcp-remote`, after `SAFE_TO_RUN=True` preflight and an
assembly-freshness proof (new test methods resolve; assembly write time newer than source):

| Scope | Result |
| --- | --- |
| PlayMode `...Tests.Runtime` | **1053 pass, 0 fail**, 1 skip |
| EditMode `...Tests.Editor` + `...Tests.Editor.Allocations` | **1022 pass, 0 fail**, 8 inconclusive |

The previous head also went green across all four Unity CI legs (2021.3, 2022.3, 6000.3, 6000.5)
plus `Unity CI Success`, `CI Success`, `Devcontainer CI Success`, and `Performance Unity Success`.

The 8 inconclusive are the `SampleQualityContractTests` cases gated on `TryGetImportedSamplesRoot`,
which fails closed in CI and goes inconclusive locally — the same 8 recorded in the previous session.

The allocation matrix passing matters specifically here: `RefreshInterceptorPlan` allocates, so the
zero-GC dispatch contract holds only because refresh is a registration-time path and the
no-interceptor case returns `Array.Empty`. 240 rows confirm it.

A 27-check semantic verifier run against both trees makes the behavioral difference exact: **`master`
fails 4, this branch passes all 27.** The 4 are precisely the cross-priority-group add and remove
cases. Everything `master` gets right this branch also gets right, including cancellation aborting
later priority groups, a handler deregistered by an interceptor not running this emission, a
post-processor registered by an interceptor waiting for the next emission when its sink was already
frozen, and interceptor target rewriting.

Static: `npm test` 421 pass, `validate:all` clean, `check:spelling`, `markdownlint-cli2`, `prettier`,
`csharpier`, and the full pre-commit set all pass.

## Not done

- **Closing the MessagePipe gap entirely.** Interceptors now cost ~4 ns over a bare emit; the rest of
  the distance is the bus's routing model — priority buckets, per-handler `active` checks, three
  phase sinks — not waste. Chasing it means changing the model, which #408 does not authorize.
  MessagePipe's post-processing cell also measures filter middleware wrapping one subscriber, which
  is a different shape than a separate post-processor sink.
- **Pooling the flattened array.** Refresh is a registration-time path, and pooling would reintroduce
  exactly the shared-buffer aliasing copy-on-write eliminates.
- **Reconciling the post-processor visibility inconsistency.** A post-processor registered from an
  interceptor runs in the same emission when the post sink was empty at emission start and waits for
  the next one when it was not. That is longstanding, unchanged here, and now pinned in both
  variants; changing it is a deliberate behavioural decision, filed as #413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
