### PR TITLE
Fix post-processor snapshot consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Make initially empty and interceptor-rewritten post routes obey frozen snapshots: additions wait
+  until the next emission, while removals finish the current post phase
+  ([#413](https://github.com/Ambiguous-Interactive/DxMessaging/issues/413)).
 - Fix an interceptor registered or removed at a different priority than the running interceptor
   taking effect during that same emission; interceptor changes now wait for the next emission, as
   the snapshot semantics documentation already described

--- a/Runtime/Core/MessageBus/MessageBus.cs
+++ b/Runtime/Core/MessageBus/MessageBus.cs
@@ -399,6 +399,114 @@ namespace DxMessaging.Core.MessageBus
         }
 
         /// <summary>
+        /// Captures one context-keyed post route immediately before a registration mutation.
+        /// The first mutation after an emission began owns the exact route snapshot that emission
+        /// must observe if an interceptor later rewrites the target/source to this context.
+        /// Entries live only until the outermost dispatch lease exits.
+        /// </summary>
+        private readonly struct PostRouteSnapshotHistoryEntry
+        {
+            public PostRouteSnapshotHistoryEntry(
+                long resetGeneration,
+                int messageTypeIndex,
+                SlotKey slotKey,
+                InstanceId context,
+                long captureEmissionId,
+                int captureDispatchDepth,
+                long mutationTick,
+                DispatchSnapshot snapshot
+            )
+            {
+                this.resetGeneration = resetGeneration;
+                this.messageTypeIndex = messageTypeIndex;
+                this.slotKey = slotKey;
+                this.context = context;
+                this.captureEmissionId = captureEmissionId;
+                this.captureDispatchDepth = captureDispatchDepth;
+                this.mutationTick = mutationTick;
+                this.snapshot = snapshot;
+            }
+
+            public readonly long resetGeneration;
+            public readonly int messageTypeIndex;
+            public readonly SlotKey slotKey;
+            public readonly InstanceId context;
+            public readonly long captureEmissionId;
+            public readonly int captureDispatchDepth;
+            public readonly long mutationTick;
+            public readonly DispatchSnapshot snapshot;
+
+            public PostRouteSnapshotHistoryEntry ReassignCapture(long emissionId, int dispatchDepth)
+            {
+                return new PostRouteSnapshotHistoryEntry(
+                    resetGeneration,
+                    messageTypeIndex,
+                    slotKey,
+                    context,
+                    emissionId,
+                    dispatchDepth,
+                    mutationTick,
+                    snapshot
+                );
+            }
+        }
+
+        private readonly struct PostRouteKey : IEquatable<PostRouteKey>
+        {
+            private readonly int _messageTypeIndex;
+            private readonly SlotKey _slotKey;
+            private readonly InstanceId _context;
+            private readonly int _hash;
+
+            public PostRouteKey(int messageTypeIndex, SlotKey slotKey, InstanceId context)
+            {
+                _messageTypeIndex = messageTypeIndex;
+                _slotKey = slotKey;
+                _context = context;
+                unchecked
+                {
+                    int hash = 17;
+                    hash = (hash * 31) + messageTypeIndex;
+                    hash = (hash * 31) + slotKey.GetHashCode();
+                    hash = (hash * 31) + context.GetHashCode();
+                    _hash = hash;
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool Equals(PostRouteKey other)
+            {
+                return _hash == other._hash
+                    && _messageTypeIndex == other._messageTypeIndex
+                    && _slotKey == other._slotKey
+                    && _context == other._context;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is PostRouteKey other && Equals(other);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public override int GetHashCode()
+            {
+                return _hash;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool operator ==(PostRouteKey left, PostRouteKey right)
+            {
+                return left.Equals(right);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool operator !=(PostRouteKey left, PostRouteKey right)
+            {
+                return !left.Equals(right);
+            }
+        }
+
+        /// <summary>
         /// Per-(bus, message-type, dispatch-kind) emit-preamble plan: caches
         /// the sink-slot references the emit shells would otherwise resolve
         /// with multiple <see cref="MessageCache{TValue}"/> lookups per
@@ -653,9 +761,19 @@ namespace DxMessaging.Core.MessageBus
                 bus._scopedEmissionId = _previousScopedEmissionId;
                 int depth = bus._dispatchDepth - 1;
                 bus._dispatchDepth = depth;
-                if (depth == 0 && bus._hasDeferredResetTeardown)
+                if (depth == 0)
                 {
-                    bus.FlushDeferredResetTeardown();
+                    if (bus._hasDeferredResetTeardown)
+                    {
+                        bus.FlushDeferredResetTeardown();
+                    }
+
+                    return;
+                }
+
+                if (bus._postRouteSnapshotHistory != null)
+                {
+                    bus.CompactPostRouteSnapshotHistoryForParent(_previousScopedEmissionId, depth);
                 }
             }
         }
@@ -1718,9 +1836,10 @@ namespace DxMessaging.Core.MessageBus
         // loop is still iterating them. Instead, the caches/states are queued
         // here and torn down when the outermost dispatch lease exits --
         // mirroring how Trim/sweep defer eviction via HasActiveDispatchSnapshot
-        // and the _dispatchDepth gate in SweepDirtyTypedHandlerSlots. These
-        // lists allocate only on the rare reset-during-dispatch path; the
-        // steady-state dispatch path pays a single flag check on lease exit.
+        // and the _dispatchDepth gate in SweepDirtyTypedHandlerSlots. The
+        // deferred reset lists allocate only on the rare reset-during-dispatch
+        // path; the steady-state dispatch path pays a single flag check on
+        // lease exit.
         //
         // _deferredDisplacedSnapshots extends the same machinery to dispatch
         // snapshots DISPLACED out of DispatchState.active by a nested
@@ -1736,10 +1855,15 @@ namespace DxMessaging.Core.MessageBus
         // removed from its DispatchState field at the moment it is queued,
         // snapshot instances are never shared between state fields, and
         // Release() is additionally idempotent via its _pooled guard.
+        // _postRouteSnapshotHistory uses the same lease lifetime for standalone
+        // pre-mutation snapshots of rewritten target/source post routes. It
+        // allocates only when a keyed post route mutates during dispatch.
         private bool _hasDeferredResetTeardown;
         private List<HandlerCache<int, HandlerCache>> _deferredResetHandlerCaches;
         private List<DispatchState> _deferredResetDispatchStates;
         private List<DispatchSnapshot> _deferredDisplacedSnapshots;
+        private List<PostRouteSnapshotHistoryEntry> _postRouteSnapshotHistory;
+        private HashSet<PostRouteKey> _postRouteCompactionRoutes;
 
         // Bumped by ResetState. Deregister closures captured before the bump
         // compare their captured generation to this field and silently skip
@@ -1973,6 +2097,21 @@ namespace DxMessaging.Core.MessageBus
             pooledCollectionsEvicted += ContextHandlerByTargetDicts.Trim(
                 force ? 0 : ContextHandlerByTargetDicts.MaxRetained
             );
+            if (
+                force
+                && _dispatchDepth == 0
+                && _postRouteSnapshotHistory != null
+                && _postRouteSnapshotHistory.Count == 0
+            )
+            {
+                _postRouteSnapshotHistory = null;
+                pooledCollectionsEvicted++;
+            }
+            if (force && _dispatchDepth == 0 && _postRouteCompactionRoutes != null)
+            {
+                _postRouteCompactionRoutes = null;
+                pooledCollectionsEvicted++;
+            }
             _lastSweepSeconds = _clock.NowSeconds;
 
             return new TrimResult(
@@ -2721,15 +2860,39 @@ namespace DxMessaging.Core.MessageBus
         private void FlushDeferredResetTeardown()
         {
             _hasDeferredResetTeardown = false;
-            // Displaced snapshots are released FIRST: they are standalone
-            // (queued only after being unlinked from their DispatchState
-            // field, and snapshot instances are never shared between state
-            // fields), so releasing them cannot interact with the cache
-            // clears / state resets below, which release *different* snapshot
-            // objects still referenced by their states. Releasing them ahead
-            // of the clears keeps the pools warm for any rebuilds those
-            // clears trigger later, and Release() stays idempotent via
-            // _pooled should both paths ever observe the same instance.
+            List<PostRouteSnapshotHistoryEntry> routeHistory = _postRouteSnapshotHistory;
+            if (routeHistory != null)
+            {
+                for (int i = 0; i < routeHistory.Count; ++i)
+                {
+                    routeHistory[i].snapshot.Release();
+                }
+
+                // List.Clear clears the DispatchSnapshot references held by
+                // each entry. Retain only a bounded backing array so an
+                // adversarial mutation burst cannot permanently raise this
+                // bus's idle footprint.
+                routeHistory.Clear();
+                if (routeHistory.Capacity > ContextHandlerByTargetDicts.MaxRetained)
+                {
+                    _postRouteSnapshotHistory = null;
+                }
+            }
+
+            HashSet<PostRouteKey> compactionRoutes = _postRouteCompactionRoutes;
+            if (
+                compactionRoutes != null
+                && compactionRoutes.EnsureCapacity(0) > ContextHandlerByTargetDicts.MaxRetained
+            )
+            {
+                _postRouteCompactionRoutes = null;
+            }
+
+            // Displaced snapshots are standalone (queued only after being
+            // unlinked from DispatchState.active), just like the historical
+            // route snapshots released above. Releasing both groups ahead of
+            // cache clears keeps the pools warm and cannot overlap snapshots
+            // still referenced by those states.
             List<DispatchSnapshot> displacedSnapshots = _deferredDisplacedSnapshots;
             if (displacedSnapshots != null)
             {
@@ -3730,9 +3893,8 @@ namespace DxMessaging.Core.MessageBus
             {
                 // No interceptors, no global accept-all, no post-processors
                 // existed when the plan was validated (i.e. at emission
-                // start): handle phase only. Mutations performed BY handlers
-                // bump the plan version; the re-compare below reruns the live
-                // post-phase re-check exactly like the featured path would.
+                // start): handle phase only. A post-processor added by a
+                // handler waits until the next emission.
                 bool fastFound = false;
                 HandlerCache<int, HandlerCache> fastHandlers = plan.scalarHandle;
                 if (fastHandlers != null && 0 < fastHandlers.handlers.Count)
@@ -3747,20 +3909,6 @@ namespace DxMessaging.Core.MessageBus
                     fastFound = DispatchFlatSnapshot(fastSnapshot, ref typedMessage);
                 }
 
-                if (
-                    planVersion != _dispatchPlanVersion
-                    && RunUntargetedPostPhase<TMessage>(
-                        ref typedMessage,
-                        planVersion,
-                        DispatchSnapshot.Empty,
-                        emissionId,
-                        touchTick
-                    )
-                )
-                {
-                    fastFound = true;
-                }
-
                 if (!fastFound && MessagingDebug.enabled)
                 {
                     MessagingDebug.Log(
@@ -3772,6 +3920,8 @@ namespace DxMessaging.Core.MessageBus
 
                 return;
             }
+
+            long emissionResetGeneration = _resetGeneration;
 
             // Pre-freeze the post-processing snapshot for this emission so
             // mutations during handlers/post-processors are not observed
@@ -3822,10 +3972,8 @@ namespace DxMessaging.Core.MessageBus
             if (
                 RunUntargetedPostPhase<TMessage>(
                     ref typedMessage,
-                    planVersion,
                     untargetedPostSnapshot,
-                    emissionId,
-                    touchTick
+                    emissionResetGeneration
                 )
             )
             {
@@ -3844,54 +3992,22 @@ namespace DxMessaging.Core.MessageBus
 
         /// <summary>
         /// Post-processing phase for untargeted emissions, shared by the
-        /// featured emit path and the fast lane's mid-emission-mutation
-        /// fallback. When <paramref name="planVersion"/> still matches the bus
-        /// stamp, no registration mutation ran during this emission, so the
-        /// snapshot frozen at emission start is exactly what a live re-check
-        /// would produce and the typed sink lookup is skipped. Once the stamp
-        /// has moved, the sink is re-checked LIVE (a post-processor registered
-        /// into a previously-snapshotless sink mid-emission is observed here,
-        /// matching the legacy lazy-freeze placement).
+        /// featured emit path. It dispatches only the snapshot frozen at
+        /// emission start, so a first post-processor registered by an
+        /// interceptor or handler waits until the next emission just like one
+        /// added to an already populated sink.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool RunUntargetedPostPhase<TMessage>(
             ref TMessage typedMessage,
-            long planVersion,
             DispatchSnapshot prefrozenSnapshot,
-            long emissionId,
-            long touchTick
+            long emissionResetGeneration
         )
             where TMessage : IUntargetedMessage
         {
-            if (planVersion == _dispatchPlanVersion)
-            {
-                return prefrozenSnapshot.IsInitialized
-                    && DispatchFlatSnapshot(prefrozenSnapshot, ref typedMessage);
-            }
-
-            if (
-                !_scalarSinks[BusSinkIndex.UntargetedPostProcessDefault]
-                    .TryGetValue<TMessage>(out HandlerCache<int, HandlerCache> sortedHandlers)
-                || sortedHandlers.handlers.Count == 0
-            )
-            {
-                return false;
-            }
-
-            Touch(sortedHandlers, touchTick);
-            DispatchSnapshot snapshot = !prefrozenSnapshot.IsInitialized
-                ? AcquireDispatchSnapshotFast<TMessage>(
-                    this,
-                    sortedHandlers,
-                    UntargetedPostSlot,
-                    emissionId,
-                    default
-                )
-                : prefrozenSnapshot;
-            // Flat dispatch; see DispatchFlatSnapshot for the frozen-array
-            // semantics that replace prefreeze stamping and for the
-            // reset-generation guard rationale.
-            return DispatchFlatSnapshot(snapshot, ref typedMessage);
+            return emissionResetGeneration == _resetGeneration
+                && prefrozenSnapshot.IsInitialized
+                && DispatchFlatSnapshot(prefrozenSnapshot, ref typedMessage);
         }
 
         /// <summary>
@@ -4079,26 +4195,6 @@ namespace DxMessaging.Core.MessageBus
                     fastFound = true;
                 }
 
-                // Post phases: nothing existed at emission start; only a
-                // mid-emission mutation can have created live post sinks.
-                // The target cannot have been rewritten (no interceptors
-                // ran), so the pre-interceptor target equals the final one.
-                if (
-                    planVersion != _dispatchPlanVersion
-                    && RunTargetedPostPhases<TMessage>(
-                        ref target,
-                        target,
-                        ref typedMessage,
-                        planVersion,
-                        DispatchSnapshot.Empty,
-                        DispatchSnapshot.Empty,
-                        emissionId
-                    )
-                )
-                {
-                    fastFound = true;
-                }
-
                 if (!fastFound && MessagingDebug.enabled)
                 {
                     MessagingDebug.Log(
@@ -4111,6 +4207,8 @@ namespace DxMessaging.Core.MessageBus
 
                 return;
             }
+
+            long emissionResetGeneration = _resetGeneration;
 
             // Pre-freeze targeted post-processing for this emission
             // (target-specific and without targeting). Acquiring the snapshot
@@ -4459,10 +4557,11 @@ namespace DxMessaging.Core.MessageBus
                     ref target,
                     preInterceptorTarget,
                     ref typedMessage,
-                    planVersion,
                     targetedPostSnapshot,
                     targetedWithoutTargetingPostSnapshot,
-                    emissionId
+                    emissionId,
+                    touchTick,
+                    emissionResetGeneration
                 )
             )
             {
@@ -4482,28 +4581,32 @@ namespace DxMessaging.Core.MessageBus
 
         /// <summary>
         /// Post-processing phases for targeted emissions (target-keyed then
-        /// without-targeting), shared by the featured emit path and the fast
-        /// lane's mid-emission-mutation fallback. While
-        /// <paramref name="planVersion"/> still matches the bus stamp and no
-        /// interceptor rewrote the target, the snapshots frozen at emission
-        /// start are exactly what a live re-check would produce and both typed
-        /// sink lookups are skipped. Once either changed, both sinks are
-        /// re-checked LIVE, matching the legacy lazy-freeze placement.
+        /// without-targeting). An unchanged target dispatches only the
+        /// snapshots frozen at emission start. A rewritten target resolves
+        /// its final route through the pre-mutation history captured during
+        /// this dispatch, retaining removed processors without admitting ones
+        /// added after the emission began.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool RunTargetedPostPhases<TMessage>(
             ref InstanceId target,
             InstanceId preInterceptorTarget,
             ref TMessage typedMessage,
-            long planVersion,
             DispatchSnapshot targetedPostSnapshot,
             DispatchSnapshot targetedWithoutTargetingPostSnapshot,
-            long emissionId
+            long emissionId,
+            long emissionStartTick,
+            long emissionResetGeneration
         )
             where TMessage : ITargetedMessage
         {
             bool foundAnyHandlers = false;
-            if (planVersion == _dispatchPlanVersion && target == preInterceptorTarget)
+            if (emissionResetGeneration != _resetGeneration)
+            {
+                return false;
+            }
+
+            if (target == preInterceptorTarget)
             {
                 if (
                     targetedPostSnapshot.IsInitialized
@@ -4511,6 +4614,11 @@ namespace DxMessaging.Core.MessageBus
                 )
                 {
                     foundAnyHandlers = true;
+                }
+
+                if (emissionResetGeneration != _resetGeneration)
+                {
+                    return foundAnyHandlers;
                 }
 
                 if (
@@ -4528,27 +4636,27 @@ namespace DxMessaging.Core.MessageBus
                 return foundAnyHandlers;
             }
 
+            DispatchSnapshot snapshot;
             if (
-                _contextSinks[BusContextIndex.TargetedPostProcessDefault]
-                    .TryGetValue<TMessage>(out ContextHandlerMap targetedHandlers)
-                && targetedHandlers.TryGetValue(
+                !TryGetContextPostRouteAtEmissionStart<TMessage>(
+                    TargetedPostSlot,
                     target,
-                    out HandlerCache<int, HandlerCache> sortedHandlers
+                    emissionStartTick,
+                    emissionResetGeneration,
+                    out snapshot
                 )
-                && sortedHandlers.handlers.Count > 0
             )
             {
-                // Post-processors follow the FINAL (post-interceptor) target. When an
-                // interceptor rewrote the id, the pre-frozen snapshot is keyed by the
-                // ORIGINAL target and must not be dispatched against the new one;
-                // re-resolve for the rewritten target instead, mirroring the
-                // handle-phase re-resolution above. Like that path, this exposes
-                // registrations made mid-emission for the REWRITTEN id (its cache
-                // had no snapshot pinned at emission start); the pre-frozen
-                // snapshot - and its mid-emission registration gating - is
-                // preferred only when the target is unchanged.
-                DispatchSnapshot snapshot;
-                if (target != preInterceptorTarget)
+                snapshot = DispatchSnapshot.Empty;
+                if (
+                    _contextSinks[BusContextIndex.TargetedPostProcessDefault]
+                        .TryGetValue<TMessage>(out ContextHandlerMap targetedHandlers)
+                    && targetedHandlers.TryGetValue(
+                        target,
+                        out HandlerCache<int, HandlerCache> sortedHandlers
+                    )
+                    && sortedHandlers.handlers.Count > 0
+                )
                 {
                     snapshot = AcquireDispatchSnapshotFast<TMessage>(
                         this,
@@ -4557,43 +4665,28 @@ namespace DxMessaging.Core.MessageBus
                         emissionId,
                         target
                     );
-                }
-                else if (!targetedPostSnapshot.IsInitialized)
-                {
-                    snapshot = AcquireDispatchSnapshotFast<TMessage>(
-                        this,
-                        sortedHandlers,
-                        TargetedPostSlot,
-                        emissionId,
-                        target
-                    );
-                }
-                else
-                {
-                    snapshot = targetedPostSnapshot;
-                }
-                if (DispatchFlatSnapshot(snapshot, ref typedMessage))
-                {
-                    foundAnyHandlers = true;
                 }
             }
 
-            if (
-                _scalarSinks[BusSinkIndex.TargetedPostProcessWithoutContext]
-                    .TryGetValue<TMessage>(out HandlerCache<int, HandlerCache> postTwt)
-                && postTwt.handlers.Count > 0
-            )
+            if (snapshot.IsInitialized && DispatchFlatSnapshot(snapshot, ref typedMessage))
             {
-                DispatchSnapshot snapshot = !targetedWithoutTargetingPostSnapshot.IsInitialized
-                    ? AcquireDispatchSnapshotFast<TMessage>(
-                        this,
-                        postTwt,
-                        TargetedWithoutContextPostSlot,
-                        emissionId,
-                        default
+                foundAnyHandlers = true;
+            }
+
+            if (emissionResetGeneration != _resetGeneration)
+            {
+                return foundAnyHandlers;
+            }
+
+            if (targetedWithoutTargetingPostSnapshot.IsInitialized)
+            {
+                if (
+                    DispatchContextFlatSnapshot(
+                        targetedWithoutTargetingPostSnapshot,
+                        ref target,
+                        ref typedMessage
                     )
-                    : targetedWithoutTargetingPostSnapshot;
-                if (DispatchContextFlatSnapshot(snapshot, ref target, ref typedMessage))
+                )
                 {
                     foundAnyHandlers = true;
                 }
@@ -4804,6 +4897,8 @@ namespace DxMessaging.Core.MessageBus
                 return;
             }
 
+            long emissionResetGeneration = _resetGeneration;
+
             // Pre-freeze broadcast post-processing for this emission
             // (source-specific and without source). Acquiring the snapshot
             // here (before interceptors and handlers run) is sufficient: the
@@ -4943,31 +5038,42 @@ namespace DxMessaging.Core.MessageBus
                 emissionId
             );
 
-            // Post-processors follow the FINAL (post-interceptor) source. The
-            // pre-frozen snapshot above is keyed by the ORIGINAL source; when an
-            // interceptor rewrote it, re-resolve the snapshot for the new source,
-            // mirroring the targeted post-phase re-resolution. Like that path,
-            // this exposes registrations made mid-emission for the REWRITTEN id
-            // (its cache had no snapshot pinned at emission start); the
-            // pre-frozen snapshot - and its mid-emission registration gating -
-            // applies only when the source is unchanged.
+            if (emissionResetGeneration != _resetGeneration)
+            {
+                return;
+            }
+
+            // Post-processors follow the FINAL source. If that route changed
+            // after this emission began, its first pre-mutation snapshot is
+            // the exact frozen view for this emission.
             if (source != preInterceptorSource)
             {
                 broadcastPostSnapshot = DispatchSnapshot.Empty;
                 if (
-                    _contextSinks[BusContextIndex.BroadcastPostProcessDefault]
-                        .TryGetValue<TMessage>(out broadcastPostHandlers)
-                    && broadcastPostHandlers.TryGetValue(source, out broadcastPostByPriority)
-                    && broadcastPostByPriority.handlers.Count > 0
+                    !TryGetContextPostRouteAtEmissionStart<TMessage>(
+                        BroadcastPostSlot,
+                        source,
+                        touchTick,
+                        emissionResetGeneration,
+                        out broadcastPostSnapshot
+                    )
                 )
                 {
-                    broadcastPostSnapshot = AcquireDispatchSnapshotFast<TMessage>(
-                        this,
-                        broadcastPostByPriority,
-                        BroadcastPostSlot,
-                        emissionId,
-                        source
-                    );
+                    if (
+                        _contextSinks[BusContextIndex.BroadcastPostProcessDefault]
+                            .TryGetValue<TMessage>(out broadcastPostHandlers)
+                        && broadcastPostHandlers.TryGetValue(source, out broadcastPostByPriority)
+                        && broadcastPostByPriority.handlers.Count > 0
+                    )
+                    {
+                        broadcastPostSnapshot = AcquireDispatchSnapshotFast<TMessage>(
+                            this,
+                            broadcastPostByPriority,
+                            BroadcastPostSlot,
+                            emissionId,
+                            source
+                        );
+                    }
                 }
             }
 
@@ -4977,6 +5083,11 @@ namespace DxMessaging.Core.MessageBus
                 // "found" even when it owns zero resolved delegates.
                 foundAnyHandlers = true;
                 _ = DispatchFlatSnapshot(broadcastPostSnapshot, ref typedMessage);
+            }
+
+            if (emissionResetGeneration != _resetGeneration)
+            {
+                return;
             }
 
             if (broadcastWithoutSourcePostSnapshot.IsInitialized)
@@ -5732,6 +5843,7 @@ namespace DxMessaging.Core.MessageBus
             }
             Touch(handlers, touchTick);
             HandlerCache<int, HandlerCache> capturedHandlers = handlers;
+            CaptureContextPostRouteBeforeMutation<T>(handlers, slotKey, context, touchTick);
 
             if (!handlers.handlers.TryGetValue(priority, out HandlerCache cache))
             {
@@ -5826,6 +5938,12 @@ namespace DxMessaging.Core.MessageBus
                 && cache.handlers.TryGetValue(messageHandler, out int count)
             )
             {
+                CaptureContextPostRouteBeforeMutation<T>(
+                    capturedHandlers,
+                    slotKey,
+                    context,
+                    deregisterTouchTick
+                );
                 _log?.Log(
                     new MessagingRegistration(
                         context,
@@ -6134,6 +6252,215 @@ namespace DxMessaging.Core.MessageBus
                     )
                     || !ReferenceEquals(currentHandlers, capturedHandlers)
                 );
+        }
+
+        private void CaptureContextPostRouteBeforeMutation<TMessage>(
+            HandlerCache<int, HandlerCache> handlers,
+            SlotKey slotKey,
+            InstanceId context,
+            long mutationTick
+        )
+            where TMessage : IMessage
+        {
+            if (
+                _dispatchDepth == 0
+                || slotKey == SlotKey.None
+                || slotKey.Phase != DispatchPhase.PostProcess
+                || slotKey.Variant != DispatchVariant.Default
+            )
+            {
+                return;
+            }
+
+            List<PostRouteSnapshotHistoryEntry> history = _postRouteSnapshotHistory ??=
+                new List<PostRouteSnapshotHistoryEntry>();
+            int messageTypeIndex = MessageHelperIndexer<TMessage>.SequentialId;
+            for (int i = history.Count - 1; 0 <= i; --i)
+            {
+                PostRouteSnapshotHistoryEntry entry = history[i];
+                if (
+                    entry.resetGeneration == _resetGeneration
+                    && entry.messageTypeIndex == messageTypeIndex
+                    && entry.slotKey == slotKey
+                    && entry.context == context
+                )
+                {
+                    if (
+                        entry.captureEmissionId == _scopedEmissionId
+                        && entry.captureDispatchDepth == _dispatchDepth
+                    )
+                    {
+                        return;
+                    }
+
+                    break;
+                }
+            }
+
+            int entryIndex = history.Count;
+
+            // Reserve the history slot before renting/building snapshot
+            // storage. If list growth fails, the registration mutation has
+            // not started and there is no standalone snapshot to release.
+            history.Add(default);
+            try
+            {
+                DispatchSnapshot snapshot = BuildDispatchSnapshot<TMessage>(
+                    this,
+                    handlers,
+                    slotKey,
+                    context
+                );
+                history[entryIndex] = new PostRouteSnapshotHistoryEntry(
+                    _resetGeneration,
+                    messageTypeIndex,
+                    slotKey,
+                    context,
+                    _scopedEmissionId,
+                    _dispatchDepth,
+                    mutationTick,
+                    snapshot
+                );
+                _hasDeferredResetTeardown = true;
+            }
+            catch
+            {
+                history.RemoveAt(entryIndex);
+                throw;
+            }
+        }
+
+        private bool TryGetContextPostRouteAtEmissionStart<TMessage>(
+            SlotKey slotKey,
+            InstanceId context,
+            long emissionStartTick,
+            long emissionResetGeneration,
+            out DispatchSnapshot snapshot
+        )
+            where TMessage : IMessage
+        {
+            snapshot = DispatchSnapshot.Empty;
+            if (emissionResetGeneration != _resetGeneration)
+            {
+                // Reset invalidates the in-flight message. Treat the route as
+                // historically empty so post-reset registrations cannot leak
+                // into the old emission.
+                return true;
+            }
+
+            List<PostRouteSnapshotHistoryEntry> history = _postRouteSnapshotHistory;
+            if (history == null)
+            {
+                return false;
+            }
+
+            int messageTypeIndex = MessageHelperIndexer<TMessage>.SequentialId;
+            int count = history.Count;
+            for (int i = 0; i < count; ++i)
+            {
+                PostRouteSnapshotHistoryEntry entry = history[i];
+                if (
+                    entry.resetGeneration == emissionResetGeneration
+                    && entry.messageTypeIndex == messageTypeIndex
+                    && entry.slotKey == slotKey
+                    && entry.context == context
+                    && unchecked(entry.mutationTick - emissionStartTick) > 0
+                )
+                {
+                    snapshot = entry.snapshot;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void CompactPostRouteSnapshotHistoryForParent(
+            long parentEmissionId,
+            int parentDispatchDepth
+        )
+        {
+            List<PostRouteSnapshotHistoryEntry> history = _postRouteSnapshotHistory;
+            int count = history.Count;
+            if (count == 0 || history[count - 1].captureDispatchDepth <= parentDispatchDepth)
+            {
+                return;
+            }
+
+            HashSet<PostRouteKey> parentRoutes = _postRouteCompactionRoutes;
+            if (parentRoutes == null)
+            {
+                parentRoutes = new HashSet<PostRouteKey>();
+                parentRoutes.EnsureCapacity(count);
+                _postRouteCompactionRoutes = parentRoutes;
+            }
+            else
+            {
+                parentRoutes.Clear();
+                parentRoutes.EnsureCapacity(count);
+            }
+
+            try
+            {
+                int retainedCount = 0;
+                for (int i = 0; i < count; ++i)
+                {
+                    PostRouteSnapshotHistoryEntry entry = history[i];
+                    if (entry.resetGeneration != _resetGeneration)
+                    {
+                        entry.snapshot.Release();
+                        continue;
+                    }
+
+                    if (entry.captureDispatchDepth < parentDispatchDepth)
+                    {
+                        history[retainedCount++] = entry;
+                        continue;
+                    }
+
+                    PostRouteKey route = new PostRouteKey(
+                        entry.messageTypeIndex,
+                        entry.slotKey,
+                        entry.context
+                    );
+                    if (
+                        entry.captureDispatchDepth == parentDispatchDepth
+                        && entry.captureEmissionId == parentEmissionId
+                    )
+                    {
+                        if (parentRoutes.Add(route))
+                        {
+                            history[retainedCount++] = entry;
+                        }
+                        else
+                        {
+                            entry.snapshot.Release();
+                        }
+
+                        continue;
+                    }
+
+                    if (!parentRoutes.Add(route))
+                    {
+                        entry.snapshot.Release();
+                        continue;
+                    }
+
+                    history[retainedCount++] = entry.ReassignCapture(
+                        parentEmissionId,
+                        parentDispatchDepth
+                    );
+                }
+
+                if (retainedCount < count)
+                {
+                    history.RemoveRange(retainedCount, count - retainedCount);
+                }
+            }
+            finally
+            {
+                parentRoutes.Clear();
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Tests/Editor/Allocations/AllocationMatrixTests.cs
+++ b/Tests/Editor/Allocations/AllocationMatrixTests.cs
@@ -167,6 +167,8 @@ namespace DxMessaging.Tests.Editor.Allocations
         // possible.
         private static readonly InstanceId StableTarget = new InstanceId(0x5757_5757);
         private static readonly InstanceId StableSource = new InstanceId(0x4242_4242);
+        private static readonly InstanceId RewrittenTarget = new InstanceId(0x5757_5758);
+        private static readonly InstanceId RewrittenSource = new InstanceId(0x4242_4243);
         private static readonly InstanceId HandlerOwner = new InstanceId(0x6363_6363);
 
         private DiagnosticsScope _diagnosticsScope;
@@ -523,6 +525,88 @@ namespace DxMessaging.Tests.Editor.Allocations
                             + "the bus-wide plan stamp again, so ordinary spawn/despawn churn "
                             + "reallocates it on every emit.",
                         scenario.Kind
+                    );
+                }
+            );
+        }
+
+        /// <summary>
+        /// Pins the zero-allocation path that resolves a context-specific post
+        /// sink after an interceptor rewrites the target or source. This route
+        /// differs from the ordinary interceptor rows because the post phase
+        /// must resolve the rewritten destination while preserving the
+        /// emission-start listener set.
+        /// </summary>
+        [Test]
+        [Category("Allocation")]
+        public void EmitWithRewrittenContextPostProcessorIsZeroAlloc(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.KindsWithComponentTarget)
+            )]
+                MessageScenario scenario
+        )
+        {
+            RunWithFreshHarness(
+                scenario,
+                (token, bus) =>
+                {
+                    Action emit = BuildEmitClosure(scenario, bus);
+                    switch (scenario.Kind)
+                    {
+                        case MessageKind.Targeted:
+                        {
+                            ScenarioHarness.RegisterTargeted<SimpleTargetedMessage>(
+                                scenario,
+                                token,
+                                RewrittenTarget,
+                                NoOpTargeted
+                            );
+                            ScenarioHarness.RegisterTargetedPostProcessor<SimpleTargetedMessage>(
+                                scenario,
+                                token,
+                                RewrittenTarget,
+                                NoOpTargeted
+                            );
+                            ScenarioHarness.RegisterTargetedInterceptor<SimpleTargetedMessage>(
+                                scenario,
+                                token,
+                                RewriteTarget
+                            );
+                            break;
+                        }
+                        case MessageKind.Broadcast:
+                        {
+                            ScenarioHarness.RegisterBroadcast<SimpleBroadcastMessage>(
+                                scenario,
+                                token,
+                                RewrittenSource,
+                                NoOpBroadcast
+                            );
+                            ScenarioHarness.RegisterBroadcastPostProcessor<SimpleBroadcastMessage>(
+                                scenario,
+                                token,
+                                RewrittenSource,
+                                NoOpBroadcast
+                            );
+                            ScenarioHarness.RegisterBroadcastInterceptor<SimpleBroadcastMessage>(
+                                scenario,
+                                token,
+                                RewriteSource
+                            );
+                            break;
+                        }
+                        default:
+                        {
+                            throw new InvalidOperationException(
+                                $"Unhandled MessageKind {scenario.Kind}."
+                            );
+                        }
+                    }
+
+                    AllocationAssertions.AssertNoAllocations(
+                        $"Emit+RewrittenContextPost-{scenario.Kind}",
+                        emit
                     );
                 }
             );
@@ -1484,6 +1568,18 @@ namespace DxMessaging.Tests.Editor.Allocations
             ref SimpleBroadcastMessage message
         )
         {
+            return true;
+        }
+
+        private static bool RewriteTarget(ref InstanceId target, ref SimpleTargetedMessage message)
+        {
+            target = RewrittenTarget;
+            return true;
+        }
+
+        private static bool RewriteSource(ref InstanceId source, ref SimpleBroadcastMessage message)
+        {
+            source = RewrittenSource;
             return true;
         }
 

--- a/Tests/Runtime/Core/InterceptorRetargetingTests.cs
+++ b/Tests/Runtime/Core/InterceptorRetargetingTests.cs
@@ -27,6 +27,12 @@ namespace DxMessaging.Tests.Runtime.Core
     /// </summary>
     public sealed class InterceptorRetargetingTests : MessagingTestBase
     {
+        public enum PostProcessorDelegateShape
+        {
+            Fast,
+            Action,
+        }
+
         [Test]
         public void RewrittenContextRoutesHandlersToNewId(
             [ValueSource(
@@ -395,6 +401,970 @@ namespace DxMessaging.Tests.Runtime.Core
             );
         }
 
+        [Test]
+        public void PostProcessorAddedForRewrittenContextWaitsUntilNextEmission(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.KindsWithComponentTarget)
+            )]
+                MessageScenario scenario,
+            [Values] PostProcessorDelegateShape delegateShape,
+            [Values] bool hasExistingProcessor
+        )
+        {
+            GameObject originalHost = new(
+                nameof(PostProcessorAddedForRewrittenContextWaitsUntilNextEmission)
+                    + "_Original_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(originalHost);
+            GameObject redirectedHost = new(
+                nameof(PostProcessorAddedForRewrittenContextWaitsUntilNextEmission)
+                    + "_Redirected_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(redirectedHost);
+
+            MessageRegistrationToken token = GetToken(
+                originalHost.GetComponent<EmptyMessageAwareComponent>()
+            );
+            InstanceId originalId = originalHost;
+            InstanceId redirectedId = redirectedHost;
+            int existingPostCount = 0;
+            int latePostCount = 0;
+            bool added = false;
+            List<MessageRegistrationHandle> handles = new();
+            int firstExistingPostCount = 0;
+            int firstLatePostCount = 0;
+            int historyCountAfterFirstEmission = -1;
+
+            using (
+                LeakWatcher watcher = LeakWatcher.Watch(
+                    label: scenario.Kind + "/" + delegateShape + "/existing=" + hasExistingProcessor
+                )
+            )
+            {
+                if (hasExistingProcessor)
+                {
+                    handles.Add(
+                        RegisterCountingPostProcessor(
+                            scenario,
+                            token,
+                            redirectedId,
+                            () => ++existingPostCount,
+                            delegateShape
+                        )
+                    );
+                }
+                handles.Add(
+                    RegisterRewritingInterceptor(
+                        scenario,
+                        token,
+                        originalId,
+                        redirectedId,
+                        () =>
+                        {
+                            if (!added)
+                            {
+                                added = true;
+                                handles.Add(
+                                    RegisterCountingPostProcessor(
+                                        scenario,
+                                        token,
+                                        redirectedId,
+                                        () => ++latePostCount,
+                                        delegateShape
+                                    )
+                                );
+                            }
+                        }
+                    )
+                );
+
+                EmitForScenario(scenario, originalId);
+                firstExistingPostCount = existingPostCount;
+                firstLatePostCount = latePostCount;
+                historyCountAfterFirstEmission = GetPostRouteSnapshotHistoryCount();
+
+                EmitForScenario(scenario, originalId);
+                RemoveAll(token, handles);
+
+                Assert.AreEqual(
+                    hasExistingProcessor ? 1 : 0,
+                    firstExistingPostCount,
+                    "[{0}] A processor already registered for the rewritten context must run "
+                        + "on the first emission. firstExistingPostCount={1}, "
+                        + "firstLatePostCount={2}.",
+                    scenario.Kind + "/" + delegateShape + "/existing=" + hasExistingProcessor,
+                    firstExistingPostCount,
+                    firstLatePostCount
+                );
+                Assert.AreEqual(
+                    0,
+                    firstLatePostCount,
+                    "[{0}] A processor registered during the interceptor must wait until the "
+                        + "next emission. firstExistingPostCount={1}, "
+                        + "firstLatePostCount={2}.",
+                    scenario.Kind + "/" + delegateShape + "/existing=" + hasExistingProcessor,
+                    firstExistingPostCount,
+                    firstLatePostCount
+                );
+                Assert.AreEqual(
+                    hasExistingProcessor ? 2 : 0,
+                    existingPostCount,
+                    "[{0}] The existing processor must run once per emission. "
+                        + "existingPostCount={1}, latePostCount={2}.",
+                    scenario.Kind + "/" + delegateShape + "/existing=" + hasExistingProcessor,
+                    existingPostCount,
+                    latePostCount
+                );
+                Assert.AreEqual(
+                    1,
+                    latePostCount,
+                    "[{0}] The late processor must start on the next emission. "
+                        + "existingPostCount={1}, latePostCount={2}.",
+                    scenario.Kind + "/" + delegateShape + "/existing=" + hasExistingProcessor,
+                    existingPostCount,
+                    latePostCount
+                );
+            }
+
+            Assert.AreEqual(
+                0,
+                historyCountAfterFirstEmission,
+                "[{0}] The outermost dispatch lease must release and clear every pre-mutation "
+                    + "route snapshot. Retaining entries would keep handlers alive between "
+                    + "emissions.",
+                scenario.Kind + "/" + delegateShape + "/existing=" + hasExistingProcessor
+            );
+        }
+
+        [Test]
+        public void PostProcessorRemovedForRewrittenContextFinishesCurrentEmission(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.KindsWithComponentTarget)
+            )]
+                MessageScenario scenario,
+            [Values] PostProcessorDelegateShape delegateShape
+        )
+        {
+            GameObject originalHost = new(
+                nameof(PostProcessorRemovedForRewrittenContextFinishesCurrentEmission)
+                    + "_Original_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(originalHost);
+            GameObject redirectedHost = new(
+                nameof(PostProcessorRemovedForRewrittenContextFinishesCurrentEmission)
+                    + "_Redirected_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(redirectedHost);
+
+            MessageRegistrationToken token = GetToken(
+                originalHost.GetComponent<EmptyMessageAwareComponent>()
+            );
+            InstanceId originalId = originalHost;
+            InstanceId redirectedId = redirectedHost;
+            int postCount = 0;
+            bool removed = false;
+            List<MessageRegistrationHandle> handles = new();
+
+            using (
+                LeakWatcher watcher = LeakWatcher.Watch(label: scenario.Kind + "/" + delegateShape)
+            )
+            {
+                MessageRegistrationHandle postHandle = RegisterCountingPostProcessor(
+                    scenario,
+                    token,
+                    redirectedId,
+                    () => ++postCount,
+                    delegateShape
+                );
+                handles.Add(postHandle);
+                handles.Add(
+                    RegisterRewritingInterceptor(
+                        scenario,
+                        token,
+                        originalId,
+                        redirectedId,
+                        () =>
+                        {
+                            if (removed)
+                            {
+                                return;
+                            }
+
+                            removed = true;
+                            token.RemoveRegistration(postHandle);
+                            _ = handles.Remove(postHandle);
+                        }
+                    )
+                );
+
+                EmitForScenario(scenario, originalId);
+                int firstEmissionCount = postCount;
+                EmitForScenario(scenario, originalId);
+                RemoveAll(token, handles);
+
+                Assert.AreEqual(
+                    1,
+                    firstEmissionCount,
+                    "[{0}, {1}] A final-route processor removed by the rewriting interceptor "
+                        + "must finish the frozen emission. firstEmissionCount={2}, totalCount={3}.",
+                    scenario.Kind,
+                    delegateShape,
+                    firstEmissionCount,
+                    postCount
+                );
+                Assert.AreEqual(
+                    1,
+                    postCount,
+                    "[{0}, {1}] The removed final-route processor must disappear on the next "
+                        + "emission. firstEmissionCount={2}, totalCount={3}.",
+                    scenario.Kind,
+                    delegateShape,
+                    firstEmissionCount,
+                    postCount
+                );
+            }
+        }
+
+        [Test]
+        public void NestedRewriteUsesEachEmissionsDestinationSnapshot(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.KindsWithComponentTarget)
+            )]
+                MessageScenario scenario
+        )
+        {
+            GameObject originalHost = new(
+                nameof(NestedRewriteUsesEachEmissionsDestinationSnapshot)
+                    + "_Original_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(originalHost);
+            GameObject redirectedHost = new(
+                nameof(NestedRewriteUsesEachEmissionsDestinationSnapshot)
+                    + "_Redirected_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(redirectedHost);
+
+            MessageRegistrationToken token = GetToken(
+                originalHost.GetComponent<EmptyMessageAwareComponent>()
+            );
+            InstanceId originalId = originalHost;
+            InstanceId redirectedId = redirectedHost;
+            int postCount = 0;
+            bool inNestedEmission = false;
+            MessageRegistrationHandle nestedPostHandle = default;
+            List<MessageRegistrationHandle> handles = new();
+
+            using (LeakWatcher watcher = LeakWatcher.Watch(label: scenario.DisplayName))
+            {
+                handles.Add(
+                    RegisterRewritingInterceptor(
+                        scenario,
+                        token,
+                        originalId,
+                        redirectedId,
+                        () =>
+                        {
+                            if (!inNestedEmission)
+                            {
+                                nestedPostHandle = RegisterCountingPostProcessor(
+                                    scenario,
+                                    token,
+                                    redirectedId,
+                                    () => ++postCount
+                                );
+                                handles.Add(nestedPostHandle);
+                                inNestedEmission = true;
+                                EmitForScenario(scenario, originalId);
+                                inNestedEmission = false;
+                                return;
+                            }
+
+                            token.RemoveRegistration(nestedPostHandle);
+                            _ = handles.Remove(nestedPostHandle);
+                        }
+                    )
+                );
+
+                EmitForScenario(scenario, originalId);
+                RemoveAll(token, handles);
+
+                Assert.AreEqual(
+                    1,
+                    postCount,
+                    "[{0}] The nested emission starts after registration and must see the final-"
+                        + "route processor once; the outer emission started before registration "
+                        + "and must not see it. postCount={1}.",
+                    scenario.Kind,
+                    postCount
+                );
+            }
+        }
+
+        [Test]
+        public void RepeatedRouteMutationsRetainOneSnapshotPerRouteAndDropOversizedHistory(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.KindsWithComponentTarget)
+            )]
+                MessageScenario scenario
+        )
+        {
+            GameObject originalHost = new(
+                nameof(RepeatedRouteMutationsRetainOneSnapshotPerRouteAndDropOversizedHistory)
+                    + "_Original_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(originalHost);
+            GameObject redirectedHost = new(
+                nameof(RepeatedRouteMutationsRetainOneSnapshotPerRouteAndDropOversizedHistory)
+                    + "_Redirected_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(redirectedHost);
+
+            MessageRegistrationToken token = GetToken(
+                originalHost.GetComponent<EmptyMessageAwareComponent>()
+            );
+            InstanceId originalId = originalHost;
+            InstanceId redirectedId = redirectedHost;
+            List<MessageRegistrationHandle> handles = new();
+            using IDisposable poolCapScope = new ContextMapPoolCapScope(16);
+            int maxRetained = DxMessaging
+                .Core.MessageBus.MessageBus.ObserveContextMapPoolForBenchmark()
+                .MaxRetained;
+            int distinctRouteCount = checked(maxRetained + 1);
+            const int sameRouteMutationCount = 64;
+            int historyCountDuringMutation = -1;
+            bool historyRetainedAfterEmission = true;
+
+            using (LeakWatcher watcher = LeakWatcher.Watch(label: scenario.DisplayName))
+            {
+                handles.Add(
+                    RegisterRewritingInterceptor(
+                        scenario,
+                        token,
+                        originalId,
+                        redirectedId,
+                        () =>
+                        {
+                            for (int i = 0; i < sameRouteMutationCount; ++i)
+                            {
+                                handles.Add(
+                                    RegisterCountingPostProcessor(
+                                        scenario,
+                                        token,
+                                        redirectedId,
+                                        () => { }
+                                    )
+                                );
+                            }
+
+                            for (int i = 0; i < distinctRouteCount; ++i)
+                            {
+                                handles.Add(
+                                    RegisterCountingPostProcessor(
+                                        scenario,
+                                        token,
+                                        new InstanceId(0x6000_0000 + i),
+                                        () => { }
+                                    )
+                                );
+                            }
+
+                            historyCountDuringMutation = GetPostRouteSnapshotHistoryCount();
+                        }
+                    )
+                );
+
+                EmitForScenario(scenario, originalId);
+                historyRetainedAfterEmission = GetPostRouteSnapshotHistory() != null;
+                RemoveAll(token, handles);
+            }
+
+            Assert.AreEqual(
+                distinctRouteCount + 1,
+                historyCountDuringMutation,
+                "[{0}] Repeated mutations of one route need one pre-mutation snapshot; each "
+                    + "distinct route needs one. sameRouteMutations={1}, distinctRoutes={2}.",
+                scenario.Kind,
+                sameRouteMutationCount,
+                distinctRouteCount
+            );
+            Assert.IsFalse(
+                historyRetainedAfterEmission,
+                "[{0}] A history whose capacity crossed the configured retention cap must be "
+                    + "dropped when the outermost lease exits. maxRetained={1}.",
+                scenario.Kind,
+                maxRetained
+            );
+        }
+
+        [Test]
+        public void SequentialNestedSiblingMutationsReleaseSupersededRouteSnapshots(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.KindsWithComponentTarget)
+            )]
+                MessageScenario scenario
+        )
+        {
+            GameObject originalHost = new(
+                nameof(SequentialNestedSiblingMutationsReleaseSupersededRouteSnapshots)
+                    + "_Original_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(originalHost);
+            GameObject redirectedHost = new(
+                nameof(SequentialNestedSiblingMutationsReleaseSupersededRouteSnapshots)
+                    + "_Redirected_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(redirectedHost);
+
+            MessageRegistrationToken token = GetToken(
+                originalHost.GetComponent<EmptyMessageAwareComponent>()
+            );
+            InstanceId originalId = originalHost;
+            InstanceId redirectedId = redirectedHost;
+            List<MessageRegistrationHandle> handles = new();
+            const int siblingCount = 32;
+            bool emittingNestedSibling = false;
+            int maximumHistoryCount = 0;
+            int maximumRetainedEntryCount = 0;
+            bool supersededSnapshotsReleased = true;
+            bool allSnapshotsReleasedAfterEmission = false;
+            bool compactionIndexRetainedBeforeForceTrim = false;
+            bool historyRetainedBeforeForceTrim = false;
+            bool compactionIndexReused = true;
+            object firstCompactionIndex = null;
+            List<object> capturedSnapshots = new();
+
+            using (LeakWatcher watcher = LeakWatcher.Watch(label: scenario.DisplayName))
+            {
+                handles.Add(
+                    RegisterRewritingInterceptor(
+                        scenario,
+                        token,
+                        originalId,
+                        redirectedId,
+                        () =>
+                        {
+                            if (emittingNestedSibling)
+                            {
+                                handles.Add(
+                                    RegisterCountingPostProcessor(
+                                        scenario,
+                                        token,
+                                        redirectedId,
+                                        () => { }
+                                    )
+                                );
+                                maximumHistoryCount = Math.Max(
+                                    maximumHistoryCount,
+                                    GetPostRouteSnapshotHistoryCount()
+                                );
+                                maximumRetainedEntryCount = Math.Max(
+                                    maximumRetainedEntryCount,
+                                    GetPostRouteSnapshotHistoryResolvedEntryCount()
+                                );
+                                capturedSnapshots.Add(GetLatestPostRouteSnapshot());
+                                return;
+                            }
+
+                            for (int i = 0; i < siblingCount; ++i)
+                            {
+                                emittingNestedSibling = true;
+                                try
+                                {
+                                    EmitForScenario(scenario, originalId);
+                                }
+                                finally
+                                {
+                                    emittingNestedSibling = false;
+                                }
+
+                                if (
+                                    i > 0
+                                    && (
+                                        capturedSnapshots.Count <= i
+                                        || !IsDispatchSnapshotReleased(capturedSnapshots[i])
+                                    )
+                                )
+                                {
+                                    supersededSnapshotsReleased = false;
+                                }
+
+                                object currentCompactionIndex = GetPostRouteCompactionIndex();
+                                if (i == 0)
+                                {
+                                    firstCompactionIndex = currentCompactionIndex;
+                                }
+                                else if (
+                                    !ReferenceEquals(firstCompactionIndex, currentCompactionIndex)
+                                )
+                                {
+                                    compactionIndexReused = false;
+                                }
+                            }
+                        }
+                    )
+                );
+
+                try
+                {
+                    EmitForScenario(scenario, originalId);
+                    allSnapshotsReleasedAfterEmission = capturedSnapshots.TrueForAll(
+                        IsDispatchSnapshotReleased
+                    );
+                    compactionIndexRetainedBeforeForceTrim = GetPostRouteCompactionIndex() != null;
+                    historyRetainedBeforeForceTrim = GetPostRouteSnapshotHistory() != null;
+                }
+                finally
+                {
+                    RemoveAll(token, handles);
+                }
+            }
+
+            _ = MessageHandler.MessageBus.Trim(force: true);
+            bool compactionIndexRetainedAfterForceTrim = GetPostRouteCompactionIndex() != null;
+            bool historyRetainedAfterForceTrim = GetPostRouteSnapshotHistory() != null;
+
+            Assert.LessOrEqual(
+                maximumHistoryCount,
+                2,
+                "[{0}] Each nested sibling may add one working snapshot beside the parent's "
+                    + "earliest snapshot, but completed siblings must not accumulate. siblings={1}.",
+                scenario.Kind,
+                siblingCount
+            );
+            Assert.LessOrEqual(
+                maximumRetainedEntryCount,
+                siblingCount,
+                "[{0}] Sequential siblings must retain O(n), not triangular O(n^2), resolved "
+                    + "route entries. siblings={1}.",
+                scenario.Kind,
+                siblingCount
+            );
+            Assert.AreEqual(
+                siblingCount,
+                capturedSnapshots.Count,
+                "[{0}] Every nested sibling must capture one pre-mutation route snapshot.",
+                scenario.Kind
+            );
+            Assert.IsTrue(
+                supersededSnapshotsReleased,
+                "[{0}] Each completed sibling after the first must release its superseded flat "
+                    + "snapshot immediately.",
+                scenario.Kind
+            );
+            Assert.IsTrue(
+                allSnapshotsReleasedAfterEmission,
+                "[{0}] The outermost lease must release the first snapshot promoted to its frame.",
+                scenario.Kind
+            );
+            Assert.IsTrue(
+                compactionIndexReused,
+                "[{0}] Sequential siblings must reuse the same bus-owned compaction index.",
+                scenario.Kind
+            );
+            Assert.IsTrue(
+                compactionIndexRetainedBeforeForceTrim,
+                "[{0}] A small compaction index should remain available for reuse until trimmed.",
+                scenario.Kind
+            );
+            Assert.IsTrue(
+                historyRetainedBeforeForceTrim,
+                "[{0}] A small cleared route-history list should remain available until trimmed.",
+                scenario.Kind
+            );
+            Assert.IsFalse(
+                compactionIndexRetainedAfterForceTrim,
+                "[{0}] Force trim must reclaim the bus-owned compaction index.",
+                scenario.Kind
+            );
+            Assert.IsFalse(
+                historyRetainedAfterForceTrim,
+                "[{0}] Force trim must reclaim the cleared route-history list.",
+                scenario.Kind
+            );
+        }
+
+        [Test]
+        public void ManyDistinctNestedRoutesUseBoundedCompactionIndex(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.KindsWithComponentTarget)
+            )]
+                MessageScenario scenario
+        )
+        {
+            GameObject originalHost = new(
+                nameof(ManyDistinctNestedRoutesUseBoundedCompactionIndex)
+                    + "_Original_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(originalHost);
+            GameObject redirectedHost = new(
+                nameof(ManyDistinctNestedRoutesUseBoundedCompactionIndex)
+                    + "_Redirected_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(redirectedHost);
+
+            MessageRegistrationToken token = GetToken(
+                originalHost.GetComponent<EmptyMessageAwareComponent>()
+            );
+            InstanceId originalId = originalHost;
+            InstanceId redirectedId = redirectedHost;
+            List<MessageRegistrationHandle> handles = new();
+            using IDisposable poolCapScope = new ContextMapPoolCapScope(16);
+            int maxRetained = DxMessaging
+                .Core.MessageBus.MessageBus.ObserveContextMapPoolForBenchmark()
+                .MaxRetained;
+            int distinctRouteCount = checked(maxRetained + 1);
+            bool emittingNested = false;
+            int historyCountAfterNested = -1;
+            bool compactionIndexRetainedAfterNested = false;
+            bool compactionIndexReused = true;
+            bool compactionIndexRetainedAfterEmission = true;
+            bool historyRetainedAfterEmission = true;
+            object firstCompactionIndex = null;
+
+            using (LeakWatcher watcher = LeakWatcher.Watch(label: scenario.DisplayName))
+            {
+                handles.Add(
+                    RegisterRewritingInterceptor(
+                        scenario,
+                        token,
+                        originalId,
+                        redirectedId,
+                        () =>
+                        {
+                            if (emittingNested)
+                            {
+                                for (int i = 0; i < distinctRouteCount; ++i)
+                                {
+                                    handles.Add(
+                                        RegisterCountingPostProcessor(
+                                            scenario,
+                                            token,
+                                            new InstanceId(0x7000_0000 + i),
+                                            () => { }
+                                        )
+                                    );
+                                }
+
+                                return;
+                            }
+
+                            for (int sibling = 0; sibling < 2; ++sibling)
+                            {
+                                emittingNested = true;
+                                try
+                                {
+                                    EmitForScenario(scenario, originalId);
+                                }
+                                finally
+                                {
+                                    emittingNested = false;
+                                }
+
+                                object currentCompactionIndex = GetPostRouteCompactionIndex();
+                                if (sibling == 0)
+                                {
+                                    firstCompactionIndex = currentCompactionIndex;
+                                }
+                                else if (
+                                    !ReferenceEquals(firstCompactionIndex, currentCompactionIndex)
+                                )
+                                {
+                                    compactionIndexReused = false;
+                                }
+                            }
+
+                            historyCountAfterNested = GetPostRouteSnapshotHistoryCount();
+                            compactionIndexRetainedAfterNested =
+                                GetPostRouteCompactionIndex() != null;
+                        }
+                    )
+                );
+
+                try
+                {
+                    EmitForScenario(scenario, originalId);
+                    compactionIndexRetainedAfterEmission = GetPostRouteCompactionIndex() != null;
+                    historyRetainedAfterEmission = GetPostRouteSnapshotHistory() != null;
+                }
+                finally
+                {
+                    RemoveAll(token, handles);
+                }
+            }
+
+            Assert.AreEqual(
+                distinctRouteCount,
+                historyCountAfterNested,
+                "[{0}] A nested child must promote the earliest snapshot for every distinct "
+                    + "route to its parent. distinctRoutes={1}.",
+                scenario.Kind,
+                distinctRouteCount
+            );
+            Assert.IsTrue(
+                compactionIndexRetainedAfterNested,
+                "[{0}] An oversized compaction index must remain reusable while its outer "
+                    + "dispatch is active. maxRetained={1}.",
+                scenario.Kind,
+                maxRetained
+            );
+            Assert.IsTrue(
+                compactionIndexReused,
+                "[{0}] Oversized sequential siblings must reuse one compaction index.",
+                scenario.Kind
+            );
+            Assert.IsFalse(
+                compactionIndexRetainedAfterEmission,
+                "[{0}] The outermost lease must drop an oversized compaction index.",
+                scenario.Kind
+            );
+            Assert.IsFalse(
+                historyRetainedAfterEmission,
+                "[{0}] The outermost lease must drop an oversized history list.",
+                scenario.Kind
+            );
+        }
+
+        [Test]
+        public void ExceptionalRewrittenRouteMutationReleasesSnapshotHistory(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.KindsWithComponentTarget)
+            )]
+                MessageScenario scenario
+        )
+        {
+            GameObject originalHost = new(
+                nameof(ExceptionalRewrittenRouteMutationReleasesSnapshotHistory)
+                    + "_Original_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(originalHost);
+            GameObject redirectedHost = new(
+                nameof(ExceptionalRewrittenRouteMutationReleasesSnapshotHistory)
+                    + "_Redirected_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(redirectedHost);
+
+            MessageRegistrationToken token = GetToken(
+                originalHost.GetComponent<EmptyMessageAwareComponent>()
+            );
+            InstanceId originalId = originalHost;
+            InstanceId redirectedId = redirectedHost;
+            List<MessageRegistrationHandle> handles = new();
+            int historyCountAfterException = -1;
+            Exception thrown = null;
+
+            using (LeakWatcher watcher = LeakWatcher.Watch(label: scenario.DisplayName))
+            {
+                handles.Add(
+                    RegisterRewritingInterceptor(
+                        scenario,
+                        token,
+                        originalId,
+                        redirectedId,
+                        () =>
+                        {
+                            handles.Add(
+                                RegisterCountingPostProcessor(
+                                    scenario,
+                                    token,
+                                    redirectedId,
+                                    () => { }
+                                )
+                            );
+                            throw new InvalidOperationException("expected route mutation failure");
+                        }
+                    )
+                );
+
+                try
+                {
+                    EmitForScenario(scenario, originalId);
+                }
+                catch (Exception exception)
+                {
+                    thrown = exception;
+                }
+                finally
+                {
+                    historyCountAfterException = GetPostRouteSnapshotHistoryCount();
+                    RemoveAll(token, handles);
+                }
+            }
+
+            Assert.IsInstanceOf<InvalidOperationException>(
+                thrown,
+                "[{0}] The interceptor must propagate its expected exception after mutating the "
+                    + "rewritten route.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                "expected route mutation failure",
+                thrown.Message,
+                "[{0}] The propagated exception must be the interceptor's sentinel.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                0,
+                historyCountAfterException,
+                "[{0}] DispatchLease.Dispose must clear the route history while unwinding an "
+                    + "exceptional interceptor.",
+                scenario.Kind
+            );
+        }
+
+        [Test]
+        public void PostResetNestedEmissionDoesNotReuseStaleOuterCaptureIdentity(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.KindsWithComponentTarget)
+            )]
+                MessageScenario scenario
+        )
+        {
+            GameObject originalHost = new(
+                nameof(PostResetNestedEmissionDoesNotReuseStaleOuterCaptureIdentity)
+                    + "_Original_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(originalHost);
+            GameObject redirectedHost = new(
+                nameof(PostResetNestedEmissionDoesNotReuseStaleOuterCaptureIdentity)
+                    + "_Redirected_"
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(redirectedHost);
+
+            MessageRegistrationToken originalToken = GetToken(
+                originalHost.GetComponent<EmptyMessageAwareComponent>()
+            );
+            InstanceId originalId = originalHost;
+            InstanceId redirectedId = redirectedHost;
+            MessageRegistrationToken postResetToken = null;
+            int stage = 0;
+            int existingPostCount = 0;
+            int latePostCount = 0;
+            bool latePostAdded = false;
+
+            _ = RegisterRewritingInterceptor(
+                scenario,
+                originalToken,
+                originalId,
+                redirectedId,
+                () =>
+                {
+                    if (stage == 1)
+                    {
+                        DxMessagingStaticState.Reset();
+                        return;
+                    }
+
+                    if (stage != 0)
+                    {
+                        return;
+                    }
+
+                    stage = 1;
+                    EmitForScenario(scenario, originalId);
+
+                    GameObject postResetHost = new(
+                        nameof(PostResetNestedEmissionDoesNotReuseStaleOuterCaptureIdentity)
+                            + "_PostReset_"
+                            + scenario.Kind,
+                        typeof(EmptyMessageAwareComponent)
+                    );
+                    _spawned.Add(postResetHost);
+                    postResetToken = GetToken(
+                        postResetHost.GetComponent<EmptyMessageAwareComponent>()
+                    );
+                    _ = RegisterCountingPostProcessor(
+                        scenario,
+                        postResetToken,
+                        redirectedId,
+                        () => ++existingPostCount
+                    );
+                    _ = RegisterRewritingInterceptor(
+                        scenario,
+                        postResetToken,
+                        originalId,
+                        redirectedId,
+                        () =>
+                        {
+                            if (latePostAdded)
+                            {
+                                return;
+                            }
+
+                            latePostAdded = true;
+                            _ = RegisterCountingPostProcessor(
+                                scenario,
+                                postResetToken,
+                                redirectedId,
+                                () => ++latePostCount
+                            );
+                        }
+                    );
+
+                    stage = 2;
+                    EmitForScenario(scenario, originalId);
+                    stage = 3;
+                }
+            );
+
+            Assert.DoesNotThrow(() => EmitForScenario(scenario, originalId));
+            postResetToken?.UnregisterAll();
+
+            Assert.AreEqual(
+                1,
+                existingPostCount,
+                "[{0}] The valid post-reset nested emission must dispatch the processor that "
+                    + "existed when it began.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                0,
+                latePostCount,
+                "[{0}] The first processor added by the valid post-reset nested emission must "
+                    + "wait. A stale outer capture identity must not deduplicate its snapshot.",
+                scenario.Kind
+            );
+        }
+
         private static void RemoveAll(
             MessageRegistrationToken token,
             List<MessageRegistrationHandle> handles
@@ -408,11 +1378,195 @@ namespace DxMessaging.Tests.Runtime.Core
             handles.Clear();
         }
 
+        private static int GetPostRouteSnapshotHistoryCount()
+        {
+            return GetPostRouteSnapshotHistory()?.Count ?? 0;
+        }
+
+        private static int GetPostRouteSnapshotHistoryResolvedEntryCount()
+        {
+            System.Collections.ICollection history = GetPostRouteSnapshotHistory();
+            if (history == null)
+            {
+                return 0;
+            }
+
+            int entryCount = 0;
+            foreach (object historyEntry in history)
+            {
+                System.Reflection.FieldInfo snapshotField = historyEntry
+                    .GetType()
+                    .GetField(
+                        "snapshot",
+                        System.Reflection.BindingFlags.Instance
+                            | System.Reflection.BindingFlags.Public
+                    );
+                Assert.IsNotNull(
+                    snapshotField,
+                    "Each route history entry must expose its frozen snapshot."
+                );
+
+                object snapshot = snapshotField.GetValue(historyEntry);
+                Assert.IsNotNull(snapshot, "A route history entry must own a snapshot instance.");
+                System.Reflection.FieldInfo entryCountField = snapshot
+                    .GetType()
+                    .GetField(
+                        "entryCount",
+                        System.Reflection.BindingFlags.Instance
+                            | System.Reflection.BindingFlags.Public
+                    );
+                Assert.IsNotNull(
+                    entryCountField,
+                    "Each frozen snapshot must expose its resolved dispatch entry count."
+                );
+                object value = entryCountField.GetValue(snapshot);
+                Assert.IsInstanceOf<int>(
+                    value,
+                    "A frozen snapshot's resolved dispatch entry count must be an integer."
+                );
+                entryCount += (int)value;
+            }
+
+            return entryCount;
+        }
+
+        private static object GetLatestPostRouteSnapshot()
+        {
+            System.Collections.ICollection history = GetPostRouteSnapshotHistory();
+            Assert.IsNotNull(history, "A route mutation during dispatch must create history.");
+            Assert.Greater(history.Count, 0, "Route history must contain the current mutation.");
+
+            object latestEntry = null;
+            foreach (object historyEntry in history)
+            {
+                latestEntry = historyEntry;
+            }
+
+            System.Reflection.FieldInfo snapshotField = latestEntry
+                .GetType()
+                .GetField(
+                    "snapshot",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public
+                );
+            Assert.IsNotNull(snapshotField, "A route history entry must expose its snapshot.");
+            object snapshot = snapshotField.GetValue(latestEntry);
+            Assert.IsNotNull(snapshot, "A route history entry must own a snapshot instance.");
+            return snapshot;
+        }
+
+        private static bool IsDispatchSnapshotReleased(object snapshot)
+        {
+            System.Type snapshotType = snapshot.GetType();
+            System.Reflection.FieldInfo entryCountField = snapshotType.GetField(
+                "entryCount",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public
+            );
+            System.Reflection.FieldInfo flatField = snapshotType.GetField(
+                "flat",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public
+            );
+            Assert.IsNotNull(entryCountField, "A frozen snapshot must expose its entry count.");
+            Assert.IsNotNull(flatField, "A frozen snapshot must expose its flat dispatch holder.");
+            object value = entryCountField.GetValue(snapshot);
+            Assert.IsInstanceOf<int>(value, "A frozen snapshot entry count must be an integer.");
+            return (int)value == 0 && flatField.GetValue(snapshot) == null;
+        }
+
+        private static object GetPostRouteCompactionIndex()
+        {
+            System.Reflection.FieldInfo indexField =
+                typeof(DxMessaging.Core.MessageBus.MessageBus).GetField(
+                    "_postRouteCompactionRoutes",
+                    System.Reflection.BindingFlags.Instance
+                        | System.Reflection.BindingFlags.NonPublic
+                );
+            Assert.IsNotNull(
+                indexField,
+                "MessageBus must expose the transient route compaction index to structural tests."
+            );
+            return indexField.GetValue(MessageHandler.MessageBus);
+        }
+
+        private sealed class ContextMapPoolCapScope : IDisposable
+        {
+            private readonly DxMessaging.Core.MessageBus.MessageBus.ContextMapPoolBenchmarkObservation _baseline;
+            private readonly IDisposable _isolation;
+            private bool _disposed;
+
+            public ContextMapPoolCapScope(int maxRetained)
+            {
+                _baseline =
+                    DxMessaging.Core.MessageBus.MessageBus.ObserveContextMapPoolForBenchmark();
+                _isolation =
+                    DxMessaging.Core.MessageBus.MessageBus.IsolateContextMapPoolForBenchmark();
+                try
+                {
+                    DxMessaging.Core.MessageBus.MessageBus.ConfigureContextMapPoolForBenchmark(
+                        _baseline.UseLru,
+                        maxRetained
+                    );
+                }
+                catch
+                {
+                    _isolation.Dispose();
+                    throw;
+                }
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                try
+                {
+                    DxMessaging.Core.MessageBus.MessageBus.ConfigureContextMapPoolForBenchmark(
+                        _baseline.UseLru,
+                        _baseline.MaxRetained
+                    );
+                }
+                finally
+                {
+                    _isolation.Dispose();
+                }
+            }
+        }
+
+        private static System.Collections.ICollection GetPostRouteSnapshotHistory()
+        {
+            System.Reflection.FieldInfo historyField =
+                typeof(DxMessaging.Core.MessageBus.MessageBus).GetField(
+                    "_postRouteSnapshotHistory",
+                    System.Reflection.BindingFlags.Instance
+                        | System.Reflection.BindingFlags.NonPublic
+                );
+            Assert.IsNotNull(
+                historyField,
+                "MessageBus must retain the pre-mutation route history field."
+            );
+
+            object value = historyField.GetValue(MessageHandler.MessageBus);
+            if (value == null)
+            {
+                return null;
+            }
+
+            Assert.IsInstanceOf<System.Collections.ICollection>(
+                value,
+                "The route history must expose collection count semantics for structural tests."
+            );
+            return (System.Collections.ICollection)value;
+        }
+
         private static MessageRegistrationHandle RegisterRewritingInterceptor(
             MessageScenario scenario,
             MessageRegistrationToken token,
             InstanceId from,
-            InstanceId to
+            InstanceId to,
+            Action onRewritten = null
         )
         {
             switch (scenario.Kind)
@@ -427,6 +1581,7 @@ namespace DxMessaging.Tests.Runtime.Core
                             if (target == from)
                             {
                                 target = to;
+                                onRewritten?.Invoke();
                             }
 
                             return true;
@@ -443,6 +1598,7 @@ namespace DxMessaging.Tests.Runtime.Core
                             if (source == from)
                             {
                                 source = to;
+                                onRewritten?.Invoke();
                             }
 
                             return true;
@@ -502,13 +1658,22 @@ namespace DxMessaging.Tests.Runtime.Core
             MessageScenario scenario,
             MessageRegistrationToken token,
             InstanceId context,
-            Action onInvoked
+            Action onInvoked,
+            PostProcessorDelegateShape delegateShape = PostProcessorDelegateShape.Fast
         )
         {
             switch (scenario.Kind)
             {
                 case MessageKind.Targeted:
                 {
+                    if (delegateShape == PostProcessorDelegateShape.Action)
+                    {
+                        return token.RegisterTargetedPostProcessor<SimpleTargetedMessage>(
+                            context,
+                            (SimpleTargetedMessage _) => onInvoked()
+                        );
+                    }
+
                     return ScenarioHarness.RegisterTargetedPostProcessor<SimpleTargetedMessage>(
                         scenario,
                         token,
@@ -518,6 +1683,14 @@ namespace DxMessaging.Tests.Runtime.Core
                 }
                 case MessageKind.Broadcast:
                 {
+                    if (delegateShape == PostProcessorDelegateShape.Action)
+                    {
+                        return token.RegisterBroadcastPostProcessor<SimpleBroadcastMessage>(
+                            context,
+                            (SimpleBroadcastMessage _) => onInvoked()
+                        );
+                    }
+
                     return ScenarioHarness.RegisterBroadcastPostProcessor<SimpleBroadcastMessage>(
                         scenario,
                         token,

--- a/Tests/Runtime/Core/MutationDuringEmissionTests.cs
+++ b/Tests/Runtime/Core/MutationDuringEmissionTests.cs
@@ -1540,9 +1540,9 @@ namespace DxMessaging.Tests.Runtime.Core
         /// featured lane can reuse the emission's dispatch plan when no
         /// registration mutated during the emission -- so a plan-validity
         /// check captured too early silently skips the new listener on one
-        /// lane only. This asserts parity rather than a specific count, so it
-        /// stays correct if the freeze semantics are deliberately changed
-        /// later (see issue #413) while still catching lane divergence.
+        /// lane only. Issue #413 made post-processor additions consistently
+        /// defer, without changing this handler-listener path; this assertion
+        /// keeps the two lanes aligned on that existing behavior.
         /// </para>
         /// </summary>
         [Test]

--- a/Tests/Runtime/Core/MutationPostProcessorMoreTests.cs
+++ b/Tests/Runtime/Core/MutationPostProcessorMoreTests.cs
@@ -21,6 +21,12 @@ namespace DxMessaging.Tests.Runtime.Core
             BroadcastWithoutSource,
         }
 
+        public enum PostProcessorDelegateShape
+        {
+            Fast,
+            Action,
+        }
+
         public static IEnumerable<PostProcessorVariant> AllVariants
         {
             get
@@ -39,6 +45,28 @@ namespace DxMessaging.Tests.Runtime.Core
             {
                 yield return PostProcessorVariant.Targeted;
                 yield return PostProcessorVariant.Broadcast;
+            }
+        }
+
+        public static IEnumerable<TestCaseData> FirstPostProcessorCases
+        {
+            get
+            {
+                foreach (PostProcessorVariant variant in AllVariants)
+                {
+                    yield return new TestCaseData(variant, PostProcessorDelegateShape.Fast).SetName(
+                        $"{nameof(AddFirstPostProcessorDuringInterceptorDoesNotRunInSameEmission)}({variant},Fast)"
+                    );
+                    if (variant != PostProcessorVariant.Untargeted)
+                    {
+                        yield return new TestCaseData(
+                            variant,
+                            PostProcessorDelegateShape.Action
+                        ).SetName(
+                            $"{nameof(AddFirstPostProcessorDuringInterceptorDoesNotRunInSameEmission)}({variant},Action)"
+                        );
+                    }
+                }
             }
         }
 
@@ -157,6 +185,85 @@ namespace DxMessaging.Tests.Runtime.Core
                 originalPpCount,
                 newPpCount
             );
+        }
+
+        [TestCaseSource(nameof(FirstPostProcessorCases))]
+        public void AddFirstPostProcessorDuringInterceptorDoesNotRunInSameEmission(
+            PostProcessorVariant variant,
+            PostProcessorDelegateShape delegateShape
+        )
+        {
+            GameObject host = new(
+                nameof(AddFirstPostProcessorDuringInterceptorDoesNotRunInSameEmission)
+                    + "_"
+                    + variant,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(host);
+            MessageRegistrationToken token = GetToken(
+                host.GetComponent<EmptyMessageAwareComponent>()
+            );
+            InstanceId hostId = host;
+            int latePostCount = 0;
+            bool added = false;
+            List<MessageRegistrationHandle> handles = new();
+
+            using (LeakWatcher watcher = LeakWatcher.Watch(label: variant + "/" + delegateShape))
+            {
+                handles.Add(
+                    RegisterInterceptor(
+                        variant,
+                        token,
+                        () =>
+                        {
+                            if (!added)
+                            {
+                                added = true;
+                                handles.Add(
+                                    RegisterPostProcessor(
+                                        variant,
+                                        token,
+                                        hostId,
+                                        () => ++latePostCount,
+                                        delegateShape: delegateShape
+                                    )
+                                );
+                            }
+                        }
+                    )
+                );
+                handles.Add(RegisterHandler(variant, token, hostId, () => { }));
+
+                Emit(variant, host);
+                int firstEmissionCount = latePostCount;
+
+                Emit(variant, host);
+                foreach (MessageRegistrationHandle handle in handles)
+                {
+                    token.RemoveRegistration(handle);
+                }
+
+                Assert.AreEqual(
+                    0,
+                    firstEmissionCount,
+                    "[{0}, {1}] The first post-processor registered during an interceptor must "
+                        + "wait until the next emission. firstEmissionCount={2}, totalCount={3}.",
+                    variant,
+                    delegateShape,
+                    firstEmissionCount,
+                    latePostCount
+                );
+                Assert.AreEqual(
+                    1,
+                    latePostCount,
+                    "[{0}, {1}] The post-processor registered during the previous emission must "
+                        + "run once on the next emission. firstEmissionCount={2}, totalCount={3}.",
+                    variant,
+                    delegateShape,
+                    firstEmissionCount,
+                    latePostCount
+                );
+            }
         }
 
         [Test]
@@ -533,7 +640,8 @@ namespace DxMessaging.Tests.Runtime.Core
             MessageRegistrationToken token,
             InstanceId source,
             Action onInvoked,
-            int priority = 0
+            int priority = 0,
+            PostProcessorDelegateShape delegateShape = PostProcessorDelegateShape.Fast
         )
         {
             switch (variant)
@@ -547,6 +655,15 @@ namespace DxMessaging.Tests.Runtime.Core
                 }
                 case PostProcessorVariant.Targeted:
                 {
+                    if (delegateShape == PostProcessorDelegateShape.Action)
+                    {
+                        return token.RegisterTargetedPostProcessor<SimpleTargetedMessage>(
+                            source,
+                            (SimpleTargetedMessage _) => onInvoked(),
+                            priority: priority
+                        );
+                    }
+
                     return token.RegisterTargetedPostProcessor<SimpleTargetedMessage>(
                         source,
                         (ref SimpleTargetedMessage _) => onInvoked(),
@@ -555,6 +672,15 @@ namespace DxMessaging.Tests.Runtime.Core
                 }
                 case PostProcessorVariant.Broadcast:
                 {
+                    if (delegateShape == PostProcessorDelegateShape.Action)
+                    {
+                        return token.RegisterBroadcastPostProcessor<SimpleBroadcastMessage>(
+                            source,
+                            (SimpleBroadcastMessage _) => onInvoked(),
+                            priority: priority
+                        );
+                    }
+
                     return token.RegisterBroadcastPostProcessor<SimpleBroadcastMessage>(
                         source,
                         (ref SimpleBroadcastMessage _) => onInvoked(),
@@ -563,6 +689,14 @@ namespace DxMessaging.Tests.Runtime.Core
                 }
                 case PostProcessorVariant.TargetedWithoutTargeting:
                 {
+                    if (delegateShape == PostProcessorDelegateShape.Action)
+                    {
+                        return token.RegisterTargetedWithoutTargetingPostProcessor<SimpleTargetedMessage>(
+                            (InstanceId _, SimpleTargetedMessage __) => onInvoked(),
+                            priority: priority
+                        );
+                    }
+
                     return token.RegisterTargetedWithoutTargetingPostProcessor<SimpleTargetedMessage>(
                         (ref InstanceId _, ref SimpleTargetedMessage __) => onInvoked(),
                         priority: priority
@@ -570,9 +704,68 @@ namespace DxMessaging.Tests.Runtime.Core
                 }
                 case PostProcessorVariant.BroadcastWithoutSource:
                 {
+                    if (delegateShape == PostProcessorDelegateShape.Action)
+                    {
+                        return token.RegisterBroadcastWithoutSourcePostProcessor<SimpleBroadcastMessage>(
+                            (InstanceId _, SimpleBroadcastMessage __) => onInvoked(),
+                            priority: priority
+                        );
+                    }
+
                     return token.RegisterBroadcastWithoutSourcePostProcessor<SimpleBroadcastMessage>(
                         (ref InstanceId _, ref SimpleBroadcastMessage __) => onInvoked(),
                         priority: priority
+                    );
+                }
+                default:
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(variant),
+                        variant,
+                        "Unsupported post-processor variant."
+                    );
+                }
+            }
+        }
+
+        private static MessageRegistrationHandle RegisterInterceptor(
+            PostProcessorVariant variant,
+            MessageRegistrationToken token,
+            Action onInvoked
+        )
+        {
+            switch (variant)
+            {
+                case PostProcessorVariant.Untargeted:
+                {
+                    return token.RegisterUntargetedInterceptor<SimpleUntargetedMessage>(
+                        (ref SimpleUntargetedMessage _) =>
+                        {
+                            onInvoked();
+                            return true;
+                        }
+                    );
+                }
+                case PostProcessorVariant.Targeted:
+                case PostProcessorVariant.TargetedWithoutTargeting:
+                {
+                    return token.RegisterTargetedInterceptor<SimpleTargetedMessage>(
+                        (ref InstanceId _, ref SimpleTargetedMessage __) =>
+                        {
+                            onInvoked();
+                            return true;
+                        }
+                    );
+                }
+                case PostProcessorVariant.Broadcast:
+                case PostProcessorVariant.BroadcastWithoutSource:
+                {
+                    return token.RegisterBroadcastInterceptor<SimpleBroadcastMessage>(
+                        (ref InstanceId _, ref SimpleBroadcastMessage __) =>
+                        {
+                            onInvoked();
+                            return true;
+                        }
                     );
                 }
                 default:

--- a/Tests/Runtime/Core/ResetMidDispatchTests.cs
+++ b/Tests/Runtime/Core/ResetMidDispatchTests.cs
@@ -32,6 +32,129 @@ namespace DxMessaging.Tests.Runtime.Core
     /// </remarks>
     public sealed class ResetMidDispatchTests : MessagingTestBase
     {
+        [Test]
+        public void ResetFromHandlerSuppressesEveryPrefrozenPostPhase(
+            [ValueSource(typeof(MessageScenarios), nameof(MessageScenarios.AllKinds))]
+                MessageScenario scenario
+        )
+        {
+            GameObject host = new(
+                nameof(ResetFromHandlerSuppressesEveryPrefrozenPostPhase) + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(host);
+            MessageRegistrationToken token = GetToken(
+                host.GetComponent<EmptyMessageAwareComponent>()
+            );
+            InstanceId hostId = host;
+            int resettingCount = 0;
+            int postCount = 0;
+
+            _ = ScenarioCallbacks.RegisterCountingHandler(
+                scenario,
+                token,
+                hostId,
+                () =>
+                {
+                    ++resettingCount;
+                    DxMessagingStaticState.Reset();
+                }
+            );
+            _ = ScenarioCallbacks.RegisterCountingPostProcessor(
+                scenario,
+                token,
+                hostId,
+                () => ++postCount
+            );
+
+            Assert.DoesNotThrow(() => ScenarioCallbacks.EmitForKind(scenario, hostId));
+            Assert.AreEqual(
+                1,
+                resettingCount,
+                "[{0}] The resetting handler must run once.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                0,
+                postCount,
+                "[{0}] A post snapshot frozen before Reset must not start a new dispatch "
+                    + "phase after the reset generation changes.",
+                scenario.Kind
+            );
+        }
+
+        [Test]
+        public void ResetFromKeyedPostProcessorSuppressesWithoutContextPostPhase(
+            [ValueSource(
+                typeof(MessageScenarios),
+                nameof(MessageScenarios.KindsWithComponentTarget)
+            )]
+                MessageScenario scenario
+        )
+        {
+            GameObject host = new(
+                nameof(ResetFromKeyedPostProcessorSuppressesWithoutContextPostPhase)
+                    + scenario.Kind,
+                typeof(EmptyMessageAwareComponent)
+            );
+            _spawned.Add(host);
+            MessageRegistrationToken token = GetToken(
+                host.GetComponent<EmptyMessageAwareComponent>()
+            );
+            InstanceId hostId = host;
+            int keyedPostCount = 0;
+            int withoutContextPostCount = 0;
+
+            _ = ScenarioCallbacks.RegisterCountingPostProcessor(
+                scenario,
+                token,
+                hostId,
+                () =>
+                {
+                    ++keyedPostCount;
+                    DxMessagingStaticState.Reset();
+                }
+            );
+            switch (scenario.Kind)
+            {
+                case MessageKind.Targeted:
+                {
+                    _ = token.RegisterTargetedWithoutTargetingPostProcessor<SimpleTargetedMessage>(
+                        (ref InstanceId _, ref SimpleTargetedMessage __) =>
+                            ++withoutContextPostCount
+                    );
+                    break;
+                }
+                case MessageKind.Broadcast:
+                {
+                    _ = token.RegisterBroadcastWithoutSourcePostProcessor<SimpleBroadcastMessage>(
+                        (ref InstanceId _, ref SimpleBroadcastMessage __) =>
+                            ++withoutContextPostCount
+                    );
+                    break;
+                }
+                default:
+                {
+                    throw new InvalidOperationException($"Unhandled MessageKind {scenario.Kind}.");
+                }
+            }
+
+            Assert.DoesNotThrow(() => ScenarioCallbacks.EmitForKind(scenario, hostId));
+            Assert.AreEqual(
+                1,
+                keyedPostCount,
+                "[{0}] The keyed post-processor must run once and reset the bus.",
+                scenario.Kind
+            );
+            Assert.AreEqual(
+                0,
+                withoutContextPostCount,
+                "[{0}] Reset in the keyed post phase must suppress the later without-context "
+                    + "post phase.",
+                scenario.Kind
+            );
+        }
+
         /// <summary>
         /// Reset mid-dispatch with the resetting handler and a trailing peer
         /// at DIFFERENT priorities (separate dispatch buckets). The emission

--- a/Tests/Runtime/Core/UntargetedPrefreezeTests.cs
+++ b/Tests/Runtime/Core/UntargetedPrefreezeTests.cs
@@ -196,58 +196,71 @@ namespace DxMessaging.Tests.Runtime.Core
         }
 
         /// <summary>
-        /// Edge pin (pre-existing public behavior, preserved by the
-        /// flattening redesign): when the ONLY remaining untargeted
-        /// post-processor for a message type is deregistered during the
-        /// handler phase, the post-process phase is skipped for that
-        /// emission entirely. The bus re-reads the live post-process sink
-        /// count after the handler phase, and the sink is empty by then, so
-        /// the frozen snapshot is never consulted. This differs from the
-        /// peer-remains case above, where the frozen snapshot still fires
-        /// the deregistered entry.
+        /// The final post-processor follows the same frozen-snapshot rule as
+        /// a removed processor that still has a peer: deregistration during
+        /// the handler phase takes effect on the next emission.
         /// </summary>
         [Test]
-        public void LastPostProcessorDeregisteredDuringHandlerSkipsPostPhaseThatEmission()
+        public void LastPostProcessorDeregisteredDuringHandlerStillFiresSameEmission()
         {
             MessageHandler handler = new(new InstanceId(127)) { active = true };
             MessageBus messageBus = new();
             MessageRegistrationToken token = MessageRegistrationToken.Create(handler, messageBus);
 
             int postProcessCount = 0;
-            MessageRegistrationHandle postHandle = token.RegisterUntargetedPostProcessor(
-                (ref SimpleUntargetedMessage _) => postProcessCount++,
-                priority: 0
-            );
+            int firstEmissionCount;
+            int secondEmissionCount;
+            using (
+                LeakWatcher watcher = new LeakWatcher(
+                    messageBus,
+                    label: nameof(SimpleUntargetedMessage)
+                )
+            )
+            {
+                MessageRegistrationHandle postHandle = token.RegisterUntargetedPostProcessor(
+                    (ref SimpleUntargetedMessage _) => postProcessCount++,
+                    priority: 0
+                );
 
-            bool removed = false;
-            _ = token.RegisterUntargeted(
-                (ref SimpleUntargetedMessage _) =>
-                {
-                    if (!removed)
+                bool removed = false;
+                _ = token.RegisterUntargeted(
+                    (ref SimpleUntargetedMessage _) =>
                     {
-                        removed = true;
-                        token.RemoveRegistration(postHandle);
+                        if (!removed)
+                        {
+                            removed = true;
+                            token.RemoveRegistration(postHandle);
+                        }
                     }
-                }
-            );
+                );
 
-            token.Enable();
+                token.Enable();
 
-            SimpleUntargetedMessage message = new();
-            messageBus.UntargetedBroadcast(ref message);
+                SimpleUntargetedMessage message = new();
+                messageBus.UntargetedBroadcast(ref message);
+                firstEmissionCount = postProcessCount;
+                messageBus.UntargetedBroadcast(ref message);
+                secondEmissionCount = postProcessCount;
+                token.Disable();
+            }
+
             Assert.AreEqual(
-                0,
-                postProcessCount,
-                "Deregistering the LAST untargeted post-processor during the handler "
-                    + "phase empties the live post-process sink, so the post phase is "
-                    + "skipped for that emission (live count gate runs before the frozen "
-                    + "snapshot is consulted)."
+                1,
+                firstEmissionCount,
+                "Deregistering the final untargeted post-processor during the handler "
+                    + "phase must not change the frozen post-process snapshot. "
+                    + "firstEmissionCount={0}, secondEmissionCount={1}.",
+                firstEmissionCount,
+                secondEmissionCount
             );
-
-            messageBus.UntargetedBroadcast(ref message);
-            Assert.AreEqual(0, postProcessCount);
-
-            token.Disable();
+            Assert.AreEqual(
+                1,
+                secondEmissionCount,
+                "The final post-processor removed during the previous emission must not run "
+                    + "again. firstEmissionCount={0}, secondEmissionCount={1}.",
+                firstEmissionCount,
+                secondEmissionCount
+            );
         }
 
         [Test]

--- a/docs/concepts/interceptors-and-ordering.md
+++ b/docs/concepts/interceptors-and-ordering.md
@@ -20,6 +20,11 @@ the frozen rule above; deregistering a handler from an interceptor takes effect
 immediately. Post-processor snapshots are taken before interceptors run, so they
 follow the frozen rule in every case.
 
+In 3.2.3 and later, this rule also covers the first post-processor registered
+for a message type and one registered for a target or source that an interceptor
+selects during the emission. Both start on the next emission. A processor removed
+from an interceptor-selected route still finishes the current emission.
+
 #### Example
 
 ```csharp

--- a/docs/runbooks/test-suite-performance.md
+++ b/docs/runbooks/test-suite-performance.md
@@ -131,10 +131,12 @@ SECOND, persistent run).
   unless the file is on the `pendingMigration` allowlist -- now empty, so the rule
   covers the whole tree and a new synchronous test cannot regress back into a
   coroutine costume.
-- `SuiteWallClockBudgetTest` (Runtime) is the pre-existing speed backstop: it fails
-  the default correctness suite when its wall clock exceeds a per-version hard
-  ceiling (300 s on 2021.3, 180 s on 2022.3 / 6000.x) and warns past a 60 s soft
-  budget, so a slowdown is unmissable regardless of which lever regressed.
+- `SuiteWallClockBudgetTest` covers the Runtime assembly. It fails that assembly
+  when its wall clock exceeds a per-version hard ceiling (300 s on 2021.3, 180 s
+  on 2022.3 / 6000.x) and warns past a 60 s soft budget. It does not cover
+  EditMode regressions or identify which Unity test step slowed down; compare the
+  `Run Unity Test Runner`, `Run Unity PlayMode tests`, and `Run Unity standalone
+tests` step durations when the full workflow gets slower.
 
 ## Status and follow-ups
 


### PR DESCRIPTION
Closes #413

## Summary

- Freeze post-processor membership at emission start even when a route was initially empty.
- Preserve the emission-start post snapshot when an interceptor rewrites a target or source, including processors removed during the emission.
- Keep transient rewritten-route history bounded across nested emissions, release superseded pooled snapshots, reuse the compaction index, and reclaim idle holders through force trim.
- Add targeted, broadcast, untargeted, reset, nesting, exception, allocation, and reclamation coverage.
- Correct the test-suite performance runbook so it does not overstate the runtime-only wall-clock guard.

## Root cause

Initially empty post sinks were looked up live after interceptors and handlers ran, while populated sinks used a prefrozen snapshot. Rewritten target/source routes were also resolved from live caches. That made late registrations visible only for some route shapes and made live-cache reconstruction unable to retain a processor removed during the current emission.

## Impact

All post-processor surfaces now follow one rule: additions made during an emission wait until the next emission, while removals still finish the current frozen post phase.

## Validation

- Three-way adversarial semantics, performance/memory, and tests/docs review: clean consensus
- Unity 6000.4.6f1 focused retargeting fixture: 34/34 twice
- Full PlayMode runtime: 1091/1091 twice, with 1 expected skip
- Rewritten target/source allocation rows: 2/2
- Full EditMode editor + allocation assemblies: 1024 passed, 1 skipped, 8 established inconclusive probes
- Node tests: 421/421
- Source-generator tests: 246/246
- Documentation tests: 583/583
- `npm run validate:all`, analyzer reproducibility, CSharpier, Prettier, markdownlint, cspell, and diff checks: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core `MessageBus` dispatch semantics for all post-processor surfaces (empty routes, fast path, interceptor retargeting, reset), with behavior shifts users may rely on; mitigated by extensive regression tests.
> 
> **Overview**
> Fixes **#413** by making **post-processor dispatch** follow one frozen-snapshot rule everywhere: membership is fixed at **emission start**, so **additions during an emission wait until the next one**, while **removals still run for the current post phase**.
> 
> **`MessageBus`** stops **live post-sink lookups** after handlers/interceptors (including the **fast-path** fallback when the dispatch plan changes mid-emission). **Untargeted** and **featured** paths only dispatch **prefrozen** post snapshots, gated by **reset generation** so `Reset()` mid-dispatch does not run stale post work.
> 
> When an **interceptor rewrites** target or source, rewritten **context post routes** resolve through **pre-mutation snapshot history** (`CaptureContextPostRouteBeforeMutation` / `TryGetContextPostRouteAtEmissionStart`) instead of live caches—so a processor **removed during the emission** still runs, and one **added** does not. History is **compacted on nested dispatch exit**, **released on outermost lease teardown**, and **trimmed** when oversized.
> 
> **CHANGELOG**, **interceptors-and-ordering** docs, a **test-suite performance runbook** correction, and **tests** (retargeting, mutations, reset, allocations, nesting/memory) lock in the new behavior—including reversing the old “last post-processor deregistered skips same emission” edge case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b3b4c824c5ee91df7cfe9c44c8feace1f945c98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->