### PR TITLE
fix: reject null token handlers before registration mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix active `MessageRegistrationToken` registrations with null callbacks leaving partial token or
+  bus state behind after throwing ([#414](https://github.com/Ambiguous-Interactive/DxMessaging/issues/414)).
 - Make initially empty and interceptor-rewritten post routes obey frozen snapshots: additions wait
   until the next emission, while removals finish the current post phase
   ([#413](https://github.com/Ambiguous-Interactive/DxMessaging/issues/413)).

--- a/Runtime/Core/MessageRegistrationToken.cs
+++ b/Runtime/Core/MessageRegistrationToken.cs
@@ -1307,6 +1307,15 @@ namespace DxMessaging.Core
         /// <returns>A handle that allows for registration and de-registration.</returns>
         private MessageRegistrationHandle InternalRegister(Registration registration)
         {
+            // Enabled registrations are caller-visible immediately. Validate before
+            // allocating a token slot so a rejected call cannot leave inaccessible
+            // metadata behind. Disabled tokens deliberately retain lazy validation:
+            // staged registrations are validated when Enable() replays them.
+            if (_enabled)
+            {
+                registration.Validate();
+            }
+
             int slotIndex = AllocateSlot();
             MessageRegistrationHandle handle =
                 MessageRegistrationHandle.CreateMessageRegistrationHandle(slotIndex);
@@ -1334,7 +1343,8 @@ namespace DxMessaging.Core
             // (re)register on Enable().
             if (_enabled)
             {
-                MessageHandler.HandlerDeregistration actualDeregistration = registration.Register();
+                MessageHandler.HandlerDeregistration actualDeregistration =
+                    registration.RegisterValidated();
                 AddDeregistration(slotIndex, handle.Id, actualDeregistration);
             }
 
@@ -2514,7 +2524,18 @@ namespace DxMessaging.Core
             // binds to the active bus, unchanged from when _messageBus was captured by
             // the staging closure at call time -- the staging closure also read the
             // field, not a snapshot).
-            public abstract MessageHandler.HandlerDeregistration Register();
+            public MessageHandler.HandlerDeregistration Register()
+            {
+                Validate();
+                return RegisterValidated();
+            }
+
+            internal abstract MessageHandler.HandlerDeregistration RegisterValidated();
+
+            // Rejects invalid staged state without mutating the token or bus. Register()
+            // repeats this validation because disabled-token replay and retargeting do
+            // not pass through InternalRegister.
+            public abstract void Validate();
 
             public abstract MessageRegistrationMetadata Metadata { get; }
 
@@ -2570,6 +2591,14 @@ namespace DxMessaging.Core
                 IMessageBus messageBus = Token._messageBus;
                 _registeredMessageBus = messageBus ?? Token._messageHandler?.DefaultMessageBus;
                 return messageBus;
+            }
+
+            protected static void ThrowIfNullHandler(object handler, string parameterName)
+            {
+                if (handler == null)
+                {
+                    throw new ArgumentNullException(parameterName);
+                }
             }
 
             protected void RecordDiagnosticEmission(IMessage message, InstanceId? context = null)
@@ -2662,7 +2691,7 @@ namespace DxMessaging.Core
                     _priority
                 );
 
-            public override MessageHandler.HandlerDeregistration Register()
+            internal override MessageHandler.HandlerDeregistration RegisterValidated()
             {
                 MessageHandler messageHandler = Token._messageHandler;
                 IMessageBus messageBus = ResolveRegistrationMessageBus();
@@ -2759,6 +2788,31 @@ namespace DxMessaging.Core
                 }
             }
 
+            public override void Validate()
+            {
+                string parameterName;
+                switch (_kind)
+                {
+                    case RegistrationKind.TargetedHandlerAction:
+                    case RegistrationKind.TargetedHandlerFast:
+                        parameterName = "targetedHandler";
+                        break;
+                    case RegistrationKind.TargetedPostProcessorAction:
+                    case RegistrationKind.TargetedPostProcessorFast:
+                        parameterName = "targetedPostProcessor";
+                        break;
+                    case RegistrationKind.TargetedWithoutTargetingAction:
+                    case RegistrationKind.TargetedWithoutTargetingFast:
+                        parameterName = "messageHandler";
+                        break;
+                    default:
+                        parameterName = "postProcessor";
+                        break;
+                }
+
+                ThrowIfNullHandler(_userHandler, parameterName);
+            }
+
             // Scalar invokers (targeted handler / post-processor). The user's handler is
             // the identity/dedup key; this flat invoker runs for the default slot. Calls
             // the typed field directly (no castclass) then records the (message, _context)
@@ -2837,7 +2891,7 @@ namespace DxMessaging.Core
                     _priority
                 );
 
-            public override MessageHandler.HandlerDeregistration Register()
+            internal override MessageHandler.HandlerDeregistration RegisterValidated()
             {
                 MessageHandler messageHandler = Token._messageHandler;
                 IMessageBus messageBus = ResolveRegistrationMessageBus();
@@ -2878,6 +2932,15 @@ namespace DxMessaging.Core
                             $"Unexpected registration kind {_kind} for UntargetedRegistration<{typeof(T)}>."
                         );
                 }
+            }
+
+            public override void Validate()
+            {
+                string parameterName =
+                    _kind == RegistrationKind.UntargetedPostProcessorFast
+                        ? "untargetedPostProcessor"
+                        : "untargetedHandler";
+                ThrowIfNullHandler(_userHandler, parameterName);
             }
 
             // Untargeted scalar invokers. No context: emission data carries the message
@@ -2945,7 +3008,7 @@ namespace DxMessaging.Core
                     _priority
                 );
 
-            public override MessageHandler.HandlerDeregistration Register()
+            internal override MessageHandler.HandlerDeregistration RegisterValidated()
             {
                 MessageHandler messageHandler = Token._messageHandler;
                 IMessageBus messageBus = ResolveRegistrationMessageBus();
@@ -3040,6 +3103,23 @@ namespace DxMessaging.Core
                             $"Unexpected registration kind {_kind} for BroadcastRegistration<{typeof(T)}>."
                         );
                 }
+            }
+
+            public override void Validate()
+            {
+                string parameterName;
+                switch (_kind)
+                {
+                    case RegistrationKind.BroadcastPostProcessorAction:
+                    case RegistrationKind.BroadcastPostProcessorFast:
+                        parameterName = "broadcastPostProcessor";
+                        break;
+                    default:
+                        parameterName = "broadcastHandler";
+                        break;
+                }
+
+                ThrowIfNullHandler(_userHandler, parameterName);
             }
 
             // Broadcast scalar invokers. Emission data carries the stored source
@@ -3146,7 +3226,7 @@ namespace DxMessaging.Core
                     Priority
                 );
 
-            public override MessageHandler.HandlerDeregistration Register()
+            internal override MessageHandler.HandlerDeregistration RegisterValidated()
             {
                 return StoreDeregistration(
                     Token._messageHandler.RegisterUntargetedInterceptor(
@@ -3155,6 +3235,11 @@ namespace DxMessaging.Core
                         ResolveRegistrationMessageBus()
                     )
                 );
+            }
+
+            public override void Validate()
+            {
+                ThrowIfNullHandler(_interceptor, "interceptor");
             }
         }
 
@@ -3181,7 +3266,7 @@ namespace DxMessaging.Core
                     Priority
                 );
 
-            public override MessageHandler.HandlerDeregistration Register()
+            internal override MessageHandler.HandlerDeregistration RegisterValidated()
             {
                 return StoreDeregistration(
                     Token._messageHandler.RegisterTargetedInterceptor(
@@ -3190,6 +3275,11 @@ namespace DxMessaging.Core
                         ResolveRegistrationMessageBus()
                     )
                 );
+            }
+
+            public override void Validate()
+            {
+                ThrowIfNullHandler(_interceptor, "interceptor");
             }
         }
 
@@ -3216,7 +3306,7 @@ namespace DxMessaging.Core
                     Priority
                 );
 
-            public override MessageHandler.HandlerDeregistration Register()
+            internal override MessageHandler.HandlerDeregistration RegisterValidated()
             {
                 return StoreDeregistration(
                     Token._messageHandler.RegisterBroadcastInterceptor(
@@ -3225,6 +3315,11 @@ namespace DxMessaging.Core
                         ResolveRegistrationMessageBus()
                     )
                 );
+            }
+
+            public override void Validate()
+            {
+                ThrowIfNullHandler(_interceptor, "interceptor");
             }
         }
 
@@ -3286,7 +3381,7 @@ namespace DxMessaging.Core
                 _broadcastFast = broadcast;
             }
 
-            public override MessageHandler.HandlerDeregistration Register()
+            internal override MessageHandler.HandlerDeregistration RegisterValidated()
             {
                 MessageHandler messageHandler = Token._messageHandler;
                 IMessageBus messageBus = ResolveRegistrationMessageBus();
@@ -3316,6 +3411,22 @@ namespace DxMessaging.Core
                         messageBus
                     )
                 );
+            }
+
+            public override void Validate()
+            {
+                if (_kind == RegistrationKind.GlobalAcceptAllAction)
+                {
+                    ThrowIfNullHandler(_untargetedAction, "acceptAllUntargeted");
+                    ThrowIfNullHandler(_targetedAction, "acceptAllTargeted");
+                    ThrowIfNullHandler(_broadcastAction, "acceptAllBroadcast");
+                }
+                else
+                {
+                    ThrowIfNullHandler(_untargetedFast, "acceptAllUntargeted");
+                    ThrowIfNullHandler(_targetedFast, "acceptAllTargeted");
+                    ThrowIfNullHandler(_broadcastFast, "acceptAllBroadcast");
+                }
             }
 
             internal override void Deregister()

--- a/Tests/Runtime/Core/NullAndInvalidInputTests.cs
+++ b/Tests/Runtime/Core/NullAndInvalidInputTests.cs
@@ -7,6 +7,8 @@ namespace DxMessaging.Tests.Runtime.Core
     using DxMessaging.Core;
     using DxMessaging.Core.Extensions;
     using DxMessaging.Core.MessageBus;
+    using DxMessaging.Core.Messages;
+    using DxMessaging.Tests.Runtime;
     using DxMessaging.Tests.Runtime.Scripts.Messages;
     using NUnit.Framework;
     using BusType = DxMessaging.Core.MessageBus.MessageBus;
@@ -51,8 +53,7 @@ namespace DxMessaging.Tests.Runtime.Core
         /// <summary>
         /// Parameterized verification that the registration surface rejects null
         /// handler delegates with <see cref="ArgumentNullException"/>. Covers
-        /// FastHandler, Action&lt;T&gt;, and interceptor variants for all three
-        /// dispatch kinds.
+        /// every handler, post-processor, interceptor, and global callback shape.
         /// </summary>
         [Test]
         public void RegisterMethodThrowsOnNullHandler(
@@ -60,10 +61,97 @@ namespace DxMessaging.Tests.Runtime.Core
         )
         {
             using TokenScope scope = TokenScope.Create();
+            using LeakWatcher watcher = new(
+                scope.Bus,
+                label: testCase.Description,
+                watchSlots: true
+            );
+            int initialMetadataCount = scope.Token._metadata.Count;
             ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() =>
                 testCase.Action(scope.Token)
             );
             Assert.IsNotNull(ex, $"Expected ArgumentNullException for case '{testCase}'.");
+            Assert.AreEqual(
+                testCase.ParameterName,
+                ex.ParamName,
+                $"Case '{testCase}' must identify its public delegate parameter."
+            );
+            Assert.AreEqual(
+                initialMetadataCount,
+                scope.Token._metadata.Count,
+                $"Case '{testCase}' must not retain inaccessible token metadata."
+            );
+            Assert.IsTrue(scope.Token.Enabled, $"Case '{testCase}' must leave the token enabled.");
+
+            scope.Token.Disable();
+            Assert.IsFalse(scope.Token.Enabled, $"Case '{testCase}' must still disable cleanly.");
+            Assert.DoesNotThrow(
+                scope.Token.Enable,
+                $"Case '{testCase}' must not poison a later enable."
+            );
+            Assert.IsTrue(scope.Token.Enabled, $"Case '{testCase}' must re-enable cleanly.");
+        }
+
+        [Test]
+        public void DisabledTokenDefersNullHandlerRejectionUntilEnableWithoutLeaking()
+        {
+            BusType bus = new BusType();
+            MessageHandler handler = new MessageHandler(new InstanceId(OwnerInstanceId), bus)
+            {
+                active = true,
+            };
+            using MessageRegistrationToken token = MessageRegistrationToken.Create(handler, bus);
+            using (
+                LeakWatcher watcher = new(
+                    bus,
+                    label: "disabled token null handler",
+                    watchSlots: true
+                )
+            )
+            {
+                MessageRegistrationHandle handle =
+                    token.RegisterBroadcastWithoutSource<SimpleBroadcastMessage>(
+                        (MessageHandler.FastHandlerWithContext<SimpleBroadcastMessage>)null
+                    );
+
+                Assert.AreNotEqual(
+                    default(MessageRegistrationHandle),
+                    handle,
+                    "A disabled token must preserve the existing deferred-registration behavior."
+                );
+                Assert.AreEqual(
+                    1,
+                    token._metadata.Count,
+                    "The disabled token must stage one entry."
+                );
+                Assert.IsFalse(token.Enabled, "Staging must not enable the token.");
+
+                ArgumentNullException first = Assert.Throws<ArgumentNullException>(token.Enable);
+                Assert.AreEqual("broadcastHandler", first.ParamName);
+                Assert.IsFalse(token.Enabled, "A failed enable must leave the token disabled.");
+                Assert.AreEqual(
+                    1,
+                    token._metadata.Count,
+                    "A failed enable must preserve the staged entry for removal or retry."
+                );
+
+                ArgumentNullException retry = Assert.Throws<ArgumentNullException>(token.Enable);
+                Assert.AreEqual("broadcastHandler", retry.ParamName);
+                Assert.IsFalse(token.Enabled, "A failed retry must leave the token disabled.");
+                Assert.AreEqual(
+                    1,
+                    token._metadata.Count,
+                    "A failed retry must preserve one entry."
+                );
+
+                token.RemoveRegistration(handle);
+                Assert.AreEqual(0, token._metadata.Count, "Removing the bad entry must clear it.");
+                Assert.DoesNotThrow(token.Enable);
+                Assert.IsTrue(
+                    token.Enabled,
+                    "The token must be usable after removing the bad entry."
+                );
+            }
         }
 
         /// <summary>
@@ -407,6 +495,7 @@ namespace DxMessaging.Tests.Runtime.Core
             {
                 yield return new NullHandlerCase(
                     "RegisterUntargeted FastHandler null",
+                    "untargetedHandler",
                     token =>
                         token.RegisterUntargeted<SimpleUntargetedMessage>(
                             (MessageHandler.FastHandler<SimpleUntargetedMessage>)null
@@ -414,6 +503,7 @@ namespace DxMessaging.Tests.Runtime.Core
                 );
                 yield return new NullHandlerCase(
                     "RegisterUntargeted Action null",
+                    "untargetedHandler",
                     token =>
                         token.RegisterUntargeted<SimpleUntargetedMessage>(
                             (Action<SimpleUntargetedMessage>)null
@@ -421,6 +511,7 @@ namespace DxMessaging.Tests.Runtime.Core
                 );
                 yield return new NullHandlerCase(
                     "RegisterTargeted FastHandler null",
+                    "targetedHandler",
                     token =>
                         token.RegisterTargeted<SimpleTargetedMessage>(
                             new InstanceId(TargetInstanceId),
@@ -429,6 +520,7 @@ namespace DxMessaging.Tests.Runtime.Core
                 );
                 yield return new NullHandlerCase(
                     "RegisterTargeted Action null",
+                    "targetedHandler",
                     token =>
                         token.RegisterTargeted<SimpleTargetedMessage>(
                             new InstanceId(TargetInstanceId),
@@ -437,6 +529,7 @@ namespace DxMessaging.Tests.Runtime.Core
                 );
                 yield return new NullHandlerCase(
                     "RegisterBroadcast FastHandler null",
+                    "broadcastHandler",
                     token =>
                         token.RegisterBroadcast<SimpleBroadcastMessage>(
                             new InstanceId(SourceInstanceId),
@@ -445,6 +538,7 @@ namespace DxMessaging.Tests.Runtime.Core
                 );
                 yield return new NullHandlerCase(
                     "RegisterBroadcast Action null",
+                    "broadcastHandler",
                     token =>
                         token.RegisterBroadcast<SimpleBroadcastMessage>(
                             new InstanceId(SourceInstanceId),
@@ -452,15 +546,186 @@ namespace DxMessaging.Tests.Runtime.Core
                         )
                 );
                 yield return new NullHandlerCase(
+                    "RegisterTargetedPostProcessor FastHandler null",
+                    "targetedPostProcessor",
+                    token =>
+                        token.RegisterTargetedPostProcessor<SimpleTargetedMessage>(
+                            new InstanceId(TargetInstanceId),
+                            (MessageHandler.FastHandler<SimpleTargetedMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterTargetedPostProcessor Action null",
+                    "targetedPostProcessor",
+                    token =>
+                        token.RegisterTargetedPostProcessor<SimpleTargetedMessage>(
+                            new InstanceId(TargetInstanceId),
+                            (Action<SimpleTargetedMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterTargetedWithoutTargeting FastHandler null",
+                    "messageHandler",
+                    token =>
+                        token.RegisterTargetedWithoutTargeting<SimpleTargetedMessage>(
+                            (MessageHandler.FastHandlerWithContext<SimpleTargetedMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterTargetedWithoutTargeting Action null",
+                    "messageHandler",
+                    token =>
+                        token.RegisterTargetedWithoutTargeting<SimpleTargetedMessage>(
+                            (Action<InstanceId, SimpleTargetedMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterTargetedWithoutTargetingPostProcessor FastHandler null",
+                    "postProcessor",
+                    token =>
+                        token.RegisterTargetedWithoutTargetingPostProcessor<SimpleTargetedMessage>(
+                            (MessageHandler.FastHandlerWithContext<SimpleTargetedMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterTargetedWithoutTargetingPostProcessor Action null",
+                    "postProcessor",
+                    token =>
+                        token.RegisterTargetedWithoutTargetingPostProcessor<SimpleTargetedMessage>(
+                            (Action<InstanceId, SimpleTargetedMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterUntargetedPostProcessor FastHandler null",
+                    "untargetedPostProcessor",
+                    token =>
+                        token.RegisterUntargetedPostProcessor<SimpleUntargetedMessage>(
+                            (MessageHandler.FastHandler<SimpleUntargetedMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterBroadcastPostProcessor FastHandler null",
+                    "broadcastPostProcessor",
+                    token =>
+                        token.RegisterBroadcastPostProcessor<SimpleBroadcastMessage>(
+                            new InstanceId(SourceInstanceId),
+                            (MessageHandler.FastHandler<SimpleBroadcastMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterBroadcastPostProcessor Action null",
+                    "broadcastPostProcessor",
+                    token =>
+                        token.RegisterBroadcastPostProcessor<SimpleBroadcastMessage>(
+                            new InstanceId(SourceInstanceId),
+                            (Action<SimpleBroadcastMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterBroadcastWithoutSource FastHandler null",
+                    "broadcastHandler",
+                    token =>
+                        token.RegisterBroadcastWithoutSource<SimpleBroadcastMessage>(
+                            (MessageHandler.FastHandlerWithContext<SimpleBroadcastMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterBroadcastWithoutSource Action null",
+                    "broadcastHandler",
+                    token =>
+                        token.RegisterBroadcastWithoutSource<SimpleBroadcastMessage>(
+                            (Action<InstanceId, SimpleBroadcastMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterBroadcastWithoutSourcePostProcessor FastHandler null",
+                    "broadcastHandler",
+                    token =>
+                        token.RegisterBroadcastWithoutSourcePostProcessor<SimpleBroadcastMessage>(
+                            (MessageHandler.FastHandlerWithContext<SimpleBroadcastMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterBroadcastWithoutSourcePostProcessor Action null",
+                    "broadcastHandler",
+                    token =>
+                        token.RegisterBroadcastWithoutSourcePostProcessor<SimpleBroadcastMessage>(
+                            (Action<InstanceId, SimpleBroadcastMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterGlobalAcceptAll Action untargeted null",
+                    "acceptAllUntargeted",
+                    token =>
+                        token.RegisterGlobalAcceptAll(
+                            (Action<IUntargetedMessage>)null,
+                            static (_, _) => { },
+                            static (_, _) => { }
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterGlobalAcceptAll Action targeted null",
+                    "acceptAllTargeted",
+                    token =>
+                        token.RegisterGlobalAcceptAll(
+                            static _ => { },
+                            (Action<InstanceId, ITargetedMessage>)null,
+                            static (_, _) => { }
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterGlobalAcceptAll Action broadcast null",
+                    "acceptAllBroadcast",
+                    token =>
+                        token.RegisterGlobalAcceptAll(
+                            static _ => { },
+                            static (_, _) => { },
+                            (Action<InstanceId, IBroadcastMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterGlobalAcceptAll FastHandler untargeted null",
+                    "acceptAllUntargeted",
+                    token =>
+                        token.RegisterGlobalAcceptAll(
+                            (MessageHandler.FastHandler<IUntargetedMessage>)null,
+                            static (ref InstanceId _, ref ITargetedMessage _) => { },
+                            static (ref InstanceId _, ref IBroadcastMessage _) => { }
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterGlobalAcceptAll FastHandler targeted null",
+                    "acceptAllTargeted",
+                    token =>
+                        token.RegisterGlobalAcceptAll(
+                            static (ref IUntargetedMessage _) => { },
+                            (MessageHandler.FastHandlerWithContext<ITargetedMessage>)null,
+                            static (ref InstanceId _, ref IBroadcastMessage _) => { }
+                        )
+                );
+                yield return new NullHandlerCase(
+                    "RegisterGlobalAcceptAll FastHandler broadcast null",
+                    "acceptAllBroadcast",
+                    token =>
+                        token.RegisterGlobalAcceptAll(
+                            static (ref IUntargetedMessage _) => { },
+                            static (ref InstanceId _, ref ITargetedMessage _) => { },
+                            (MessageHandler.FastHandlerWithContext<IBroadcastMessage>)null
+                        )
+                );
+                yield return new NullHandlerCase(
                     "RegisterUntargetedInterceptor null",
+                    "interceptor",
                     token => token.RegisterUntargetedInterceptor<SimpleUntargetedMessage>(null)
                 );
                 yield return new NullHandlerCase(
                     "RegisterTargetedInterceptor null",
+                    "interceptor",
                     token => token.RegisterTargetedInterceptor<SimpleTargetedMessage>(null)
                 );
                 yield return new NullHandlerCase(
                     "RegisterBroadcastInterceptor null",
+                    "interceptor",
                     token => token.RegisterBroadcastInterceptor<SimpleBroadcastMessage>(null)
                 );
             }
@@ -521,11 +786,18 @@ namespace DxMessaging.Tests.Runtime.Core
         {
             public string Description { get; }
 
+            public string ParameterName { get; }
+
             public Action<MessageRegistrationToken> Action { get; }
 
-            public NullHandlerCase(string description, Action<MessageRegistrationToken> action)
+            public NullHandlerCase(
+                string description,
+                string parameterName,
+                Action<MessageRegistrationToken> action
+            )
             {
                 Description = description;
+                ParameterName = parameterName;
                 Action = action;
             }
 


### PR DESCRIPTION
## Summary

- validate enabled registrations before allocating token metadata
- validate disabled-token replay and retargeting before touching the message bus
- cover handlers, post-processors, interceptors, and every global accept-all delegate position
- preserve disabled-token staging and deterministic retry/removal recovery
- document the consumer-visible fix under `[Unreleased]`

## Root cause

Active token registration previously allocated an internal token slot before downstream handler storage rejected a null delegate. Interceptor registration could also create occupied bus slots before its dictionary rejected a null key. The call threw without returning a handle, leaving inaccessible token metadata or partial bus structure until reset.

Validation now occurs before token-slot allocation for enabled calls. The replay wrapper validates before any bus mutation for disabled-token enable, retry, retarget, and recovery paths. Successful enabled registrations still perform one cold validation and emission remains unchanged.

## Coverage

The data-driven null matrix covers every shared registration kind and delegate shape. It asserts the public `ArgumentNullException.ParamName`, unchanged token metadata, all six registration counters, occupied type/target slots, clean disable/re-enable, and disabled-token failed-enable retry/removal recovery. Unity GameObject/Component facades reuse these shared registration families.

## Performance investigation

This branch began as an experiment for #414. IL2CPP null-check elision on the token-owned callback wrappers was rejected and removed: the candidate reached 32.281M emits/sec, only 0.43% above the stronger same-code control and below the 3% keep threshold. Same-code controls repeatedly reversed the direct/token ordering, so the result did not support a stable performance claim.

## Validation

- earlier fresh Unity null-input/leak fixture: 46 passed
- diagnostics, lifecycle, and reentrancy fixtures: 84 passed
- focused allocation matrix: 11 passed
- superseded candidate Standalone IL2CPP Release suite: 169 passed
- exact final diff: two independent adversarial reviews, zero blocking findings
- `npm run format:check`
- `npm run lint:markdown`
- `npm run check:spelling`
- `npm run validate:all`

The Unity MCP endpoint is reachable, but the host editor discovery heartbeat is stale (#418), so the current-head Unity matrix supplies final compile/runtime proof.

Refs #414

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lifecycle fix in registration validation ordering with broad test coverage; behavior change is stricter failure before mutation, not dispatch hot-path logic.
> 
> **Overview**
> Fixes **#414** by making null callback registration failures atomic on **enabled** `MessageRegistrationToken`s: each registration path now runs **`Validate()` before allocating a slot or touching the bus**, so a thrown `ArgumentNullException` no longer leaves orphaned token metadata or partial bus state.
> 
> Registration is split into **`Validate()`** plus **`RegisterValidated()`** across handlers, post-processors, interceptors, and global accept-all shapes. **Disabled tokens** keep staging a handle without immediate validation; **`Enable()`** still validates via **`Register()`** on replay (retarget paths included), with parameter names matching the public API.
> 
> Tests expand null-input coverage (every delegate shape, expected **`ParamName`**, **`LeakWatcher`** / metadata counts) and add a scenario for deferred rejection on enable without leaking staged entries. **CHANGELOG** documents the fix under **Unreleased → Fixed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07f82b5180ed8a38a5b6cbdaa0b1330ca92857d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->