### PR TITLE
test(perf): preserve deregistration trial pairing

### DIFF
--- a/.llm/skills/benchmark-methodology/references/runtime-performance-campaign-decisions.md
+++ b/.llm/skills/benchmark-methodology/references/runtime-performance-campaign-decisions.md
@@ -2,10 +2,11 @@
 
 <!-- cspell:ignore gshared -->
 
-> **One-line summary**: Keep the measured physical-two handler-entry map and
-> holder-local flat-dispatch count read; the targeted post-phase state bundle
-> and other small-container, dispatch-switch, and private-pool candidates failed
-> explicit timing or storage gates and were reverted.
+> **One-line summary**: Keep the measured physical-two handler-entry map,
+> holder-local flat-dispatch count read, and same-trial deregistration
+> diagnostic; the targeted post-phase state bundle and other small-container,
+> dispatch-switch, and private-pool candidates failed explicit timing or storage
+> gates and were reverted.
 
 ## Decision rule
 
@@ -35,6 +36,31 @@ separately.
   representative DxMessaging dispatch rows cleared the regression gate. Keep
   `DispatchSnapshot.entryCount` as lifecycle/topology telemetry, but do not route
   the hot loop through the extra owner.
+
+## Accepted measurement method
+
+- Keep the joint deregistration palindrome. Its predecessor minimized four
+  independent seven-trial windows, so the reported H/B/B/H arms could come from
+  four different host phases. The corrected diagnostic prepares four fresh
+  populations per trial, measures them back-to-back, balances four forward and
+  four reverse preparation opportunities, and selects one complete trial. Its
+  marker retains every trial's direction and total so the floor is independently
+  auditable. The loaded Mono assembly passed 48
+  contract cases, including whole-sample selection and an enforced H/B/B/H
+  execution-order contract. Four
+  fresh-population invocations in one already-loaded Mono editor qualified only
+  two samples under the predeclared 3% gates; the two rejected samples measured
+  3.70% handler drift with 5.13% handler-excess spread and 3.03% bus drift. A
+  separate warmed raw distribution qualified all seven trials. The method stops
+  mixing arms from different host phases, but that intermittent invocation result
+  does not authorize the exact-`MessageBus` candidate. The final balanced
+  eight-trial marker independently rejected itself at 3.79% handler-excess spread.
+  Require repeated
+  interpretable Standalone IL2CPP Release brackets before making that runtime
+  edit. Four simultaneous populations deliberately increase diagnostic-only peak
+  memory: the existing 131072 cardinality keeps the shortest direct-bus arm near
+  10 ms, and preparing all arms first avoids allocation-heavy setup between their
+  timestamps.
 
 ## Rejected runtime candidates
 

--- a/Tests/Runtime/Benchmarks/DispatchThroughputBenchmarks.cs
+++ b/Tests/Runtime/Benchmarks/DispatchThroughputBenchmarks.cs
@@ -218,29 +218,40 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
         [Test, Performance, Category("PerfBench"), Order(DeregistrationAttributionDiagnosticOrder)]
         public void DirectHandlerAndBusDeregistrationPalindromeDiagnostic()
         {
-            DispatchBenchmarkResult handlerA = DeregistrationAttributionBenchmarks.RunScenario(
-                DeregistrationAttributionOperation.DirectHandler
-            );
-            DispatchBenchmarkResult busA = DeregistrationAttributionBenchmarks.RunScenario(
-                DeregistrationAttributionOperation.DirectBus
-            );
-            DispatchBenchmarkResult busB = DeregistrationAttributionBenchmarks.RunScenario(
-                DeregistrationAttributionOperation.DirectBus
-            );
-            DispatchBenchmarkResult handlerB = DeregistrationAttributionBenchmarks.RunScenario(
-                DeregistrationAttributionOperation.DirectHandler
-            );
-
-            // Each arm independently selects its minimum from seven fresh populations. That
-            // rejects interruptions but loses cross-path covariance: interpretable=true is
-            // necessary for a later candidate bracket, never sufficient acceptance evidence.
             DeregistrationAttributionPalindromeDiagnostic diagnostic =
-                DeregistrationAttributionBenchmarks.AnalyzePalindrome(
-                    handlerA.WallClockMs,
-                    busA.WallClockMs,
-                    busB.WallClockMs,
-                    handlerB.WallClockMs
+                DeregistrationAttributionBenchmarks.RunPairedDiagnostic();
+            Assert.IsTrue(
+                diagnostic.JointTrialSelection,
+                "The measured diagnostic must select one complete trial."
+            );
+            Assert.IsTrue(
+                diagnostic.SameTrialArms,
+                "The measured diagnostic must retain all four arms from one trial."
+            );
+            Assert.IsTrue(
+                diagnostic.PreparationDirectionAlternated,
+                "The measured diagnostic must alternate preparation direction across trials."
+            );
+            Assert.AreEqual(
+                DeregistrationAttributionBenchmarks.PalindromeTimingTrials,
+                diagnostic.TimingTrials,
+                "The measured diagnostic must report its actual trial count."
+            );
+            string[] trialRecords = diagnostic.TrialSequence.Split(',');
+            Assert.AreEqual(
+                DeregistrationAttributionBenchmarks.PalindromeTimingTrials,
+                trialRecords.Length,
+                "The measured diagnostic must retain every trial record."
+            );
+            for (int trial = 0; trial < trialRecords.Length; trial++)
+            {
+                string expectedPrefix = $"{trial}:{((trial & 1) == 0 ? 'F' : 'R')}:";
+                StringAssert.StartsWith(
+                    expectedPrefix,
+                    trialRecords[trial],
+                    $"trial={trial}, expectedPrefix={expectedPrefix}: trial provenance changed."
                 );
+            }
             string evidence = diagnostic.ToStructuredLog();
             Debug.Log(evidence);
             TestContext.Out.WriteLine(evidence);

--- a/Tests/Runtime/Benchmarks/RegistrationLifecycleBenchmarkContractTests.cs
+++ b/Tests/Runtime/Benchmarks/RegistrationLifecycleBenchmarkContractTests.cs
@@ -284,13 +284,12 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
             int expectedClassification
         )
         {
-            DeregistrationAttributionPalindromeDiagnostic diagnostic =
-                DeregistrationAttributionBenchmarks.AnalyzePalindrome(
-                    handlerA,
-                    busA,
-                    busB,
-                    handlerB
-                );
+            DeregistrationAttributionPalindromeDiagnostic diagnostic = AnalyzePalindrome(
+                handlerA,
+                busA,
+                busB,
+                handlerB
+            );
             int actualClassification =
                 (diagnostic.HandlerDriftWithinThreshold ? 1 : 0)
                 | (diagnostic.BusDriftWithinThreshold ? 2 : 0)
@@ -312,10 +311,18 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
         [Category("PerfBench")]
         public void DeregistrationPalindromeIsArmSwapInvariant()
         {
-            DeregistrationAttributionPalindromeDiagnostic first =
-                DeregistrationAttributionBenchmarks.AnalyzePalindrome(198.5d, 100d, 101d, 200.5d);
-            DeregistrationAttributionPalindromeDiagnostic swapped =
-                DeregistrationAttributionBenchmarks.AnalyzePalindrome(200.5d, 101d, 100d, 198.5d);
+            DeregistrationAttributionPalindromeDiagnostic first = AnalyzePalindrome(
+                198.5d,
+                100d,
+                101d,
+                200.5d
+            );
+            DeregistrationAttributionPalindromeDiagnostic swapped = AnalyzePalindrome(
+                200.5d,
+                101d,
+                100d,
+                198.5d
+            );
 
             Assert.AreEqual(
                 first.HandlerDriftPercent,
@@ -343,8 +350,12 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
         [Category("PerfBench")]
         public void DeregistrationPalindromeLogRejectsAcceptanceMeaning()
         {
-            DeregistrationAttributionPalindromeDiagnostic diagnostic =
-                DeregistrationAttributionBenchmarks.AnalyzePalindrome(130d, 100d, 101d, 131d);
+            DeregistrationAttributionPalindromeDiagnostic diagnostic = AnalyzePalindrome(
+                130d,
+                100d,
+                101d,
+                131d
+            );
             string evidence = diagnostic.ToStructuredLog();
 
             Assert.AreEqual(
@@ -373,9 +384,9 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
                 "The log must retain each threshold decision."
             );
             StringAssert.Contains(
-                "independentMinima=true diagnosticOnly=true acceptanceEvidence=false candidateCompared=false interpretable=true",
+                "handlerFirstPairTotal_ms=230 busFirstPairTotal_ms=232 palindromeTotal_ms=462 selectedTrial=-1 prepareForward=false jointTrialSelection=false sameTrialArms=false preparationDirectionAlternated=false timingTrials=0 trialSequence=none diagnosticOnly=true acceptanceEvidence=false candidateCompared=false interpretable=true",
                 evidence,
-                "The log must reject acceptance meaning for independently selected minima."
+                "Arithmetic-only diagnostics must not claim measured selection provenance."
             );
             StringAssert.DoesNotContain(
                 " valid=",
@@ -388,11 +399,8 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
         [Category("PerfBench")]
         public void DeregistrationPalindromeLogDistinguishesExactAndJustOverThreshold()
         {
-            string exact = DeregistrationAttributionBenchmarks
-                .AnalyzePalindrome(1100d, 100d, 103d, 1103d)
-                .ToStructuredLog();
-            string justOver = DeregistrationAttributionBenchmarks
-                .AnalyzePalindrome(1100d, 100d, 103.000001d, 1103.000001d)
+            string exact = AnalyzePalindrome(1100d, 100d, 103d, 1103d).ToStructuredLog();
+            string justOver = AnalyzePalindrome(1100d, 100d, 103.000001d, 1103.000001d)
                 .ToStructuredLog();
 
             Assert.AreNotEqual(
@@ -419,6 +427,88 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
                 "interpretable=false",
                 justOver,
                 "The just-over threshold sample must remain uninterpretable."
+            );
+        }
+
+        [Test]
+        [Category("PerfBench")]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void DeregistrationPalindromeFloorKeepsAllArmsFromOneTrial(bool prepareForward)
+        {
+            DeregistrationAttributionPalindromeSample current = PalindromeSample(
+                120d,
+                10d,
+                9d,
+                121d,
+                trial: 2,
+                prepareForward
+            );
+            DeregistrationAttributionPalindromeSample mixedArmTrap = PalindromeSample(
+                100d,
+                40d,
+                50d,
+                90d,
+                trial: 3,
+                !prepareForward
+            );
+            DeregistrationAttributionPalindromeSample faster = PalindromeSample(
+                121d,
+                8d,
+                8d,
+                120d,
+                trial: 4,
+                !prepareForward
+            );
+
+            DeregistrationAttributionPalindromeSample kept =
+                DeregistrationAttributionBenchmarks.SelectPalindromeFloor(current, mixedArmTrap);
+            AssertPalindromeSample(
+                current,
+                kept,
+                $"prepareForward={prepareForward}: retained sample"
+            );
+
+            DeregistrationAttributionPalindromeSample replaced =
+                DeregistrationAttributionBenchmarks.SelectPalindromeFloor(current, faster);
+            AssertPalindromeSample(
+                faster,
+                replaced,
+                $"prepareForward={prepareForward}: replacement sample"
+            );
+        }
+
+        [Test]
+        [Category("PerfBench")]
+        [TestCase(0, DeregistrationAttributionOperation.DirectHandler)]
+        [TestCase(1, DeregistrationAttributionOperation.DirectBus)]
+        [TestCase(2, DeregistrationAttributionOperation.DirectBus)]
+        [TestCase(3, DeregistrationAttributionOperation.DirectHandler)]
+        public void DeregistrationPalindromeExecutionOrderIsSymmetric(
+            int armIndex,
+            DeregistrationAttributionOperation expectedOperation
+        )
+        {
+            Assert.AreEqual(
+                expectedOperation,
+                DeregistrationAttributionBenchmarks.PalindromeOperationAt(armIndex),
+                $"armIndex={armIndex}, expectedOperation={expectedOperation}: the timed execution sequence must remain H/B/B/H."
+            );
+        }
+
+        [Test]
+        [Category("PerfBench")]
+        [TestCase(-1)]
+        [TestCase(4)]
+        public void DeregistrationPalindromeRejectsUnknownArmIndex(int armIndex)
+        {
+            ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                DeregistrationAttributionBenchmarks.PalindromeOperationAt(armIndex)
+            );
+            Assert.AreEqual(
+                nameof(armIndex),
+                exception.ParamName,
+                $"armIndex={armIndex}: the diagnostic must reject an arm outside H/B/B/H."
             );
         }
 
@@ -595,6 +685,59 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
                 double.MaxValue,
                 15
             );
+        }
+
+        private static DeregistrationAttributionPalindromeDiagnostic AnalyzePalindrome(
+            double handlerA,
+            double busA,
+            double busB,
+            double handlerB
+        )
+        {
+            return DeregistrationAttributionBenchmarks.AnalyzePalindrome(
+                handlerA,
+                busA,
+                busB,
+                handlerB
+            );
+        }
+
+        private static DeregistrationAttributionPalindromeSample PalindromeSample(
+            double handlerA,
+            double busA,
+            double busB,
+            double handlerB,
+            int trial,
+            bool prepareForward
+        )
+        {
+            return new DeregistrationAttributionPalindromeSample(
+                handlerA,
+                busA,
+                busB,
+                handlerB,
+                trial,
+                prepareForward
+            );
+        }
+
+        private static void AssertPalindromeSample(
+            DeregistrationAttributionPalindromeSample expected,
+            DeregistrationAttributionPalindromeSample actual,
+            string context
+        )
+        {
+            Assert.AreEqual(expected.HandlerA, actual.HandlerA, $"{context}: handler A changed.");
+            Assert.AreEqual(expected.BusA, actual.BusA, $"{context}: bus A changed.");
+            Assert.AreEqual(expected.BusB, actual.BusB, $"{context}: bus B changed.");
+            Assert.AreEqual(expected.HandlerB, actual.HandlerB, $"{context}: handler B changed.");
+            Assert.AreEqual(expected.Trial, actual.Trial, $"{context}: trial changed.");
+            Assert.AreEqual(
+                expected.PrepareForward,
+                actual.PrepareForward,
+                $"{context}: preparation direction changed."
+            );
+            Assert.AreEqual(expected.TotalMs, actual.TotalMs, $"{context}: total changed.");
         }
 
         private static TestCaseData PalindromeCase(

--- a/Tests/Runtime/Benchmarks/RegistrationLifecycleBenchmarks.cs
+++ b/Tests/Runtime/Benchmarks/RegistrationLifecycleBenchmarks.cs
@@ -6,6 +6,7 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
     using System.Diagnostics;
     using System.Globalization;
     using System.Runtime.CompilerServices;
+    using System.Text;
     using DxMessaging.Core;
     using DxMessaging.Core.Internal;
     using DxMessaging.Core.MessageBus;
@@ -949,6 +950,7 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
         internal const double MaxSamePathDriftPercent = 3d;
         internal const double MaxHandlerExcessSpreadPercent = 3d;
         private const int TimingTrials = 7;
+        internal const int PalindromeTimingTrials = 8;
 
         internal static DeregistrationAttributionObservation ExecuteOnceForContract(
             DeregistrationAttributionOperation operation,
@@ -956,7 +958,7 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
         )
         {
             ValidateCardinality(cardinality);
-            using DeregistrationAttributionState state = new(operation, cardinality);
+            using DeregistrationAttributionState state = CreateState(operation, cardinality);
             state.VerifyPrepared();
             state.Execute();
             return state.Verify();
@@ -975,7 +977,7 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
             double minElapsedSeconds = double.MaxValue;
             for (int trial = 0; trial < TimingTrials; trial++)
             {
-                using DeregistrationAttributionState state = new(operation, Cardinality);
+                using DeregistrationAttributionState state = CreateState(operation, Cardinality);
                 state.VerifyPrepared();
                 long startTimestamp = Stopwatch.GetTimestamp();
                 state.Execute();
@@ -1022,12 +1024,257 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
             double handlerB
         )
         {
-            return new DeregistrationAttributionPalindromeDiagnostic(
-                handlerA,
-                busA,
-                busB,
-                handlerB
+            return AnalyzePalindrome(
+                new DeregistrationAttributionPalindromeSample(
+                    handlerA,
+                    busA,
+                    busB,
+                    handlerB,
+                    trial: -1,
+                    prepareForward: false
+                ),
+                timingTrials: 0,
+                jointTrialSelection: false,
+                sameTrialArms: false,
+                preparationDirectionAlternated: false,
+                trialSequence: "none"
             );
+        }
+
+        private static DeregistrationAttributionPalindromeDiagnostic AnalyzePalindrome(
+            DeregistrationAttributionPalindromeSample sample,
+            int timingTrials,
+            bool jointTrialSelection,
+            bool sameTrialArms,
+            bool preparationDirectionAlternated,
+            string trialSequence
+        )
+        {
+            return new DeregistrationAttributionPalindromeDiagnostic(
+                sample,
+                timingTrials,
+                jointTrialSelection,
+                sameTrialArms,
+                preparationDirectionAlternated,
+                trialSequence
+            );
+        }
+
+        internal static DeregistrationAttributionPalindromeDiagnostic RunPairedDiagnostic()
+        {
+            _ = ExecuteOnceForContract(
+                DeregistrationAttributionOperation.DirectHandler,
+                cardinality: 16
+            );
+            _ = ExecuteOnceForContract(
+                DeregistrationAttributionOperation.DirectBus,
+                cardinality: 16
+            );
+
+            // Select one joint H/B/B/H floor. All four fresh states in a trial are prepared
+            // before the first stopwatch sample and timed back-to-back. Minimizing the complete
+            // palindrome rejects interrupted trials without combining an arm from another host
+            // phase. Alternate preparation direction so one endpoint is not always hottest.
+            AllocationProbe.SettleHeapForMeasurement();
+            DeregistrationAttributionPalindromeSample sample = MeasurePalindromeFloor(
+                out string trialSequence
+            );
+            return AnalyzePalindrome(
+                sample,
+                PalindromeTimingTrials,
+                jointTrialSelection: true,
+                sameTrialArms: true,
+                preparationDirectionAlternated: true,
+                trialSequence: trialSequence
+            );
+        }
+
+        internal static DeregistrationAttributionPalindromeSample SelectPalindromeFloor(
+            DeregistrationAttributionPalindromeSample current,
+            DeregistrationAttributionPalindromeSample candidate
+        )
+        {
+            return candidate.TotalMs < current.TotalMs ? candidate : current;
+        }
+
+        internal static DeregistrationAttributionOperation PalindromeOperationAt(int armIndex)
+        {
+            return armIndex switch
+            {
+                0 => DeregistrationAttributionOperation.DirectHandler,
+                1 => DeregistrationAttributionOperation.DirectBus,
+                2 => DeregistrationAttributionOperation.DirectBus,
+                3 => DeregistrationAttributionOperation.DirectHandler,
+                _ => throw new ArgumentOutOfRangeException(nameof(armIndex), armIndex, null),
+            };
+        }
+
+        private static DeregistrationAttributionPalindromeSample MeasurePalindromeFloor(
+            out string trialSequence
+        )
+        {
+            DeregistrationAttributionPalindromeSample best = default;
+            bool hasBest = false;
+            StringBuilder sequence = new();
+            for (int trial = 0; trial < PalindromeTimingTrials; trial++)
+            {
+                bool prepareForward = (trial & 1) == 0;
+                DeregistrationAttributionPalindromeSample candidate = MeasurePalindromeTrial(
+                    trial,
+                    prepareForward
+                );
+                if (trial > 0)
+                {
+                    sequence.Append(',');
+                }
+                sequence
+                    .Append(trial)
+                    .Append(':')
+                    .Append(prepareForward ? 'F' : 'R')
+                    .Append(':')
+                    .Append(candidate.TotalMs.ToString("R", CultureInfo.InvariantCulture));
+                best = hasBest ? SelectPalindromeFloor(best, candidate) : candidate;
+                hasBest = true;
+            }
+
+            trialSequence = sequence.ToString();
+            return best;
+        }
+
+        private static DeregistrationAttributionPalindromeSample MeasurePalindromeTrial(
+            int trial,
+            bool prepareForward
+        )
+        {
+            if (prepareForward)
+            {
+                using DeregistrationAttributionState handlerA = NewState(
+                    DeregistrationAttributionOperation.DirectHandler
+                );
+                using DeregistrationAttributionState busA = NewState(
+                    DeregistrationAttributionOperation.DirectBus
+                );
+                using DeregistrationAttributionState busB = NewState(
+                    DeregistrationAttributionOperation.DirectBus
+                );
+                using DeregistrationAttributionState handlerB = NewState(
+                    DeregistrationAttributionOperation.DirectHandler
+                );
+                return MeasurePreparedPalindrome(
+                    handlerA,
+                    busA,
+                    busB,
+                    handlerB,
+                    trial,
+                    prepareForward
+                );
+            }
+
+            using DeregistrationAttributionState reverseHandlerB = NewState(
+                DeregistrationAttributionOperation.DirectHandler
+            );
+            using DeregistrationAttributionState reverseBusB = NewState(
+                DeregistrationAttributionOperation.DirectBus
+            );
+            using DeregistrationAttributionState reverseBusA = NewState(
+                DeregistrationAttributionOperation.DirectBus
+            );
+            using DeregistrationAttributionState reverseHandlerA = NewState(
+                DeregistrationAttributionOperation.DirectHandler
+            );
+            return MeasurePreparedPalindrome(
+                reverseHandlerA,
+                reverseBusA,
+                reverseBusB,
+                reverseHandlerB,
+                trial,
+                prepareForward
+            );
+        }
+
+        private static DeregistrationAttributionState NewState(
+            DeregistrationAttributionOperation operation
+        )
+        {
+            return CreateState(operation, Cardinality);
+        }
+
+        private static DeregistrationAttributionState CreateState(
+            DeregistrationAttributionOperation operation,
+            int cardinality
+        )
+        {
+            IDisposable registryScope = MessageBus.IsolateIdleSweepRegistryForBenchmark();
+            try
+            {
+                return new DeregistrationAttributionState(operation, cardinality, registryScope);
+            }
+            catch
+            {
+                registryScope.Dispose();
+                throw;
+            }
+        }
+
+        private static DeregistrationAttributionPalindromeSample MeasurePreparedPalindrome(
+            DeregistrationAttributionState handlerA,
+            DeregistrationAttributionState busA,
+            DeregistrationAttributionState busB,
+            DeregistrationAttributionState handlerB,
+            int trial,
+            bool prepareForward
+        )
+        {
+            handlerA.VerifyPrepared();
+            busA.VerifyPrepared();
+            busB.VerifyPrepared();
+            handlerB.VerifyPrepared();
+
+            int nextArm = 0;
+            long startTimestamp = Stopwatch.GetTimestamp();
+            ExecutePalindromeArm(ref nextArm, handlerA);
+            long handlerABoundary = Stopwatch.GetTimestamp();
+            ExecutePalindromeArm(ref nextArm, busA);
+            long busABoundary = Stopwatch.GetTimestamp();
+            ExecutePalindromeArm(ref nextArm, busB);
+            long busBBoundary = Stopwatch.GetTimestamp();
+            ExecutePalindromeArm(ref nextArm, handlerB);
+            long endTimestamp = Stopwatch.GetTimestamp();
+
+            _ = handlerA.Verify();
+            _ = busA.Verify();
+            _ = busB.Verify();
+            _ = handlerB.Verify();
+            return new DeregistrationAttributionPalindromeSample(
+                TimestampDeltaToMilliseconds(startTimestamp, handlerABoundary),
+                TimestampDeltaToMilliseconds(handlerABoundary, busABoundary),
+                TimestampDeltaToMilliseconds(busABoundary, busBBoundary),
+                TimestampDeltaToMilliseconds(busBBoundary, endTimestamp),
+                trial,
+                prepareForward
+            );
+        }
+
+        private static void ExecutePalindromeArm(
+            ref int nextArm,
+            DeregistrationAttributionState state
+        )
+        {
+            DeregistrationAttributionOperation expected = PalindromeOperationAt(nextArm);
+            if (state.Operation != expected)
+            {
+                throw new InvalidOperationException(
+                    $"Deregistration palindrome arm {nextArm} must be {expected}, not {state.Operation}."
+                );
+            }
+
+            state.Execute();
+            nextArm++;
+        }
+
+        private static double TimestampDeltaToMilliseconds(long start, long end)
+        {
+            return (end - start) / (double)Stopwatch.Frequency * 1000d;
         }
 
         private static void ValidateCardinality(int cardinality)
@@ -1074,12 +1321,13 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
 
             public DeregistrationAttributionState(
                 DeregistrationAttributionOperation operation,
-                int cardinality
+                int cardinality,
+                IDisposable registryScope
             )
             {
                 _operation = operation;
                 _cardinality = cardinality;
-                _registryScope = MessageBus.IsolateIdleSweepRegistryForBenchmark();
+                _registryScope = registryScope;
                 _bus = new MessageBus { DiagnosticsMode = false };
                 _handler = new MessageHandler(new InstanceId(42001), _bus) { active = true };
                 _counter = new AttributionCounter();
@@ -1137,6 +1385,8 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
                     }
                 }
             }
+
+            public DeregistrationAttributionOperation Operation => _operation;
 
             public void VerifyPrepared()
             {
@@ -1289,19 +1539,23 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
         }
     }
 
-    internal readonly struct DeregistrationAttributionPalindromeDiagnostic
+    internal readonly struct DeregistrationAttributionPalindromeSample
     {
-        public DeregistrationAttributionPalindromeDiagnostic(
+        public DeregistrationAttributionPalindromeSample(
             double handlerA,
             double busA,
             double busB,
-            double handlerB
+            double handlerB,
+            int trial,
+            bool prepareForward
         )
         {
             HandlerA = handlerA;
             BusA = busA;
             BusB = busB;
             HandlerB = handlerB;
+            Trial = trial;
+            PrepareForward = prepareForward;
         }
 
         public double HandlerA { get; }
@@ -1311,6 +1565,52 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
         public double BusB { get; }
 
         public double HandlerB { get; }
+
+        public int Trial { get; }
+
+        public bool PrepareForward { get; }
+
+        public double TotalMs => HandlerA + BusA + BusB + HandlerB;
+    }
+
+    internal readonly struct DeregistrationAttributionPalindromeDiagnostic
+    {
+        public DeregistrationAttributionPalindromeDiagnostic(
+            DeregistrationAttributionPalindromeSample sample,
+            int timingTrials,
+            bool jointTrialSelection,
+            bool sameTrialArms,
+            bool preparationDirectionAlternated,
+            string trialSequence
+        )
+        {
+            Sample = sample;
+            TimingTrials = timingTrials;
+            JointTrialSelection = jointTrialSelection;
+            SameTrialArms = sameTrialArms;
+            PreparationDirectionAlternated = preparationDirectionAlternated;
+            TrialSequence = trialSequence;
+        }
+
+        public DeregistrationAttributionPalindromeSample Sample { get; }
+
+        public int TimingTrials { get; }
+
+        public bool JointTrialSelection { get; }
+
+        public bool SameTrialArms { get; }
+
+        public bool PreparationDirectionAlternated { get; }
+
+        public string TrialSequence { get; }
+
+        public double HandlerA => Sample.HandlerA;
+
+        public double BusA => Sample.BusA;
+
+        public double BusB => Sample.BusB;
+
+        public double HandlerB => Sample.HandlerB;
 
         public double HandlerExcessA => HandlerA - BusA;
 
@@ -1386,7 +1686,16 @@ namespace DxMessaging.Tests.Runtime.Benchmarks
                 + $"maxHandlerExcessSpreadPercent={Format(DeregistrationAttributionBenchmarks.MaxHandlerExcessSpreadPercent)} "
                 + $"finitePositiveDurations={Format(HasFinitePositiveDurations)} "
                 + $"finitePositiveExcesses={Format(HasFinitePositiveExcesses)} "
-                + $"independentMinima=true diagnosticOnly=true acceptanceEvidence=false "
+                + $"handlerFirstPairTotal_ms={Format(HandlerA + BusA)} "
+                + $"busFirstPairTotal_ms={Format(BusB + HandlerB)} "
+                + $"palindromeTotal_ms={Format(Sample.TotalMs)} "
+                + $"selectedTrial={Sample.Trial} prepareForward={Format(Sample.PrepareForward)} "
+                + $"jointTrialSelection={Format(JointTrialSelection)} "
+                + $"sameTrialArms={Format(SameTrialArms)} "
+                + $"preparationDirectionAlternated={Format(PreparationDirectionAlternated)} "
+                + $"timingTrials={TimingTrials} "
+                + $"trialSequence={TrialSequence} "
+                + $"diagnosticOnly=true acceptanceEvidence=false "
                 + $"candidateCompared=false interpretable={Format(Interpretable)}";
         }
 

--- a/docs/runbooks/perf-benchmark-methodology.md
+++ b/docs/runbooks/perf-benchmark-methodology.md
@@ -173,16 +173,29 @@ they are report-only -- rendered as wall clock, never gated.
   diagnostic wall-clock rows are not hard regression gates. Do not compare them
   with the 1000-type flood rows because their registration topology differs.
 - **Deregistration attribution palindrome.** The non-published
-  `DirectHandlerAndBusDeregistrationPalindromeDiagnostic` runs direct handler A,
-  direct bus A, direct bus B, then direct handler B after the published
-  attribution rows. It reports
+  `DirectHandlerAndBusDeregistrationPalindromeDiagnostic` measures a
+  handler-then-bus pair followed by a bus-then-handler pair after the published
+  attribution rows. Each trial prepares all four fresh populations before timing,
+  measures the H/B/B/H arms back-to-back, and selects the lowest complete
+  palindrome duration across eight trials. Preparation direction alternates with
+  four forward and four reverse opportunities, so the same endpoint is not always
+  the most recently built state. The diagnostic
+  never combines an arm from one trial with an arm from another. Keeping four
+  populations live increases diagnostic peak memory, but it is required to avoid
+  allocation-heavy setup between timed arms. The 131072 cardinality stays aligned
+  with the published attribution rows and keeps the direct-bus arm near 10 ms on
+  the measured Mono host. This diagnostic runs after the published rows and does
+  not add player/runtime storage. It reports
   `DXM_DEREGISTRATION_ATTRIBUTION_PALINDROME` with both additive handler-minus-bus
   excesses and their arithmetic center. Interpret the sample only when both
   excesses are positive, handler and bus same-path drift are each at most 3%, and
-  the two additive excesses differ by at most 3% of their center. The four arms
-  independently select the minimum of seven fresh populations, so they do not
-  preserve cross-path covariance. `interpretable=true` is a noise-rejection
-  prerequisite, not candidate acceptance. The marker always records
+  the two additive excesses differ by at most 3% of their center. Joint trial
+  selection retains all four arms from one observation and records
+  `jointTrialSelection=true` plus `sameTrialArms=true` in the marker. Its compact
+  `trialSequence` records each trial index, preparation direction, and complete
+  duration so an artifact consumer can verify alternation and the selected floor.
+  `interpretable=true` is still a noise-rejection prerequisite, not candidate
+  acceptance. The marker always records
   `diagnosticOnly=true`, `acceptanceEvidence=false`, and
   `candidateCompared=false`; require a separate repeated control/candidate
   bracket before claiming a 3% improvement.


### PR DESCRIPTION
## Summary

- replace four independently minimized deregistration arms with one complete H/B/B/H trial selection
- balance eight preparation trials (four forward, four reverse) and emit every trial total/direction for artifact-level auditability
- distinguish synthetic arithmetic from measured provenance, enforce the timed H/B/B/H order, and restore nested idle-sweep scopes if state construction fails
- document the diagnostic-only memory tradeoff and retain the no-candidate verdict for #414

## Science

The old diagnostic could combine four different host phases. The new marker retains all arms from one trial and reports `jointTrialSelection=true`, `sameTrialArms=true`, the selected trial, and the full `trialSequence`.

Four fresh-population invocations in one loaded Mono editor qualified only 2/4 samples. The final balanced eight-trial sample also rejected itself at 3.79% handler-excess spread. This PR therefore improves evidence quality but does **not** implement or claim acceptance for the exact-`MessageBus` specialization.

## Validation

- fresh Unity assembly timestamp newer than edited source
- Unity MCP focused contracts: 48/48
- Unity MCP real diagnostic: 1/1
- Node tests: 421/421
- `npm run validate:all`
- CSharpier, Prettier, Markdownlint, spelling, ASCII prose, and `git diff --check`
- final Unity postflight: idle editor, clean scene, main stage, no prefab stage
- two adversarial review rounds; final verdict: zero findings

The only Unity console errors are pre-existing malformed `Assets/Plugins/Zenject/package.json.meta` host-project errors outside this package.

Refs #414.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to perf benchmarks, contract tests, and documentation; no production dispatch or registration behavior is modified.
> 
> **Overview**
> Replaces the deregistration **H/B/B/H** palindrome diagnostic that minimized four arms in separate seven-trial windows with **`RunPairedDiagnostic`**, which runs **eight** trials, prepares all four fresh populations before timing, executes the arms back-to-back, and keeps the **lowest complete palindrome** so arms never come from different host phases. Preparation alternates forward/reverse; the structured log and tests record **`jointTrialSelection`**, **`sameTrialArms`**, **`trialSequence`**, and fixed **H/B/B/H** execution order, while arithmetic-only **`AnalyzePalindrome`** paths no longer claim measured provenance.
> 
> Adds **`DeregistrationAttributionPalindromeSample`**, injects benchmark registry isolation via **`CreateState`** (dispose on failed construction), and extends contract coverage for floor selection and arm indexing. **Perf methodology** and **campaign decisions** document the accepted joint method, diagnostic peak-memory tradeoff, and that this still does **not** authorize the exact-`MessageBus` candidate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00a360c1eae522084f739189405a8d9fa6074220. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->